### PR TITLE
fix: Add cryptography dep for pyjwt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 alembic
 click
+cryptography # Required by pyjwt
 fastapi
 google-genai
 httpx


### PR DESCRIPTION
Although things worked locally in the dev container (docker compose), errors like `Failed to generate JWT token: Algorithm 'RS256' could not be found. Do you have cryptography installed?` show in serverless environments. This indicates we need to install the cryptography package to include algorithms used in pyjwt.