### PR TITLE
feat: Add a seperate docker image for production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,29 @@
-FROM python:3.9-slim
+FROM python:3.9-slim AS builder
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y \
-    libpq-dev gcc python3-dev sqlite3 && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends gcc libpq-dev python3-dev && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt .
+RUN pip wheel --no-cache-dir --wheel-dir /app/wheels -r requirements.txt
 
-COPY . /app/
-RUN python -m pip install --upgrade pip
-RUN pip install --no-cache-dir -r requirements.txt
+FROM python:3.9-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+RUN useradd --create-home appuser
+USER appuser
+
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+
+COPY --from=builder /app/wheels /wheels
+RUN pip install --no-cache /wheels/*
+
+COPY . .
+
+USER root
 RUN ln -s /app/sourceant /usr/local/bin/sourceant
+USER appuser
 
-EXPOSE 8000
-
-CMD ["/app/start.sh"]
+ENTRYPOINT ["/app/start.prod.sh"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,17 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    libpq-dev gcc python3-dev sqlite3 && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . /app/
+RUN python -m pip install --upgrade pip
+RUN pip install --no-cache-dir -r requirements.txt
+
+RUN ln -s /app/sourceant /usr/local/bin/sourceant
+
+EXPOSE 8000
+
+CMD ["/app/start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
-version: "3.9"
 services:
   app:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
     container_name: sourceant
     ports:
       - "8000:8000"

--- a/start.prod.sh
+++ b/start.prod.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+sourceant db upgrade head
+uvicorn src.api.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
We the .env file in dev and can be used in prod too but in severless environments the .env file needs to provisioned meanwhile it's possible to just pass env vars to most serverless runners.

Also for obvious reasons the prod setup does not need everything in the dev env.