### PR TITLE
feat(config): Adapt db config for stateless mode, harden prod docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 APP_ENV=dev
+# sqlitedb: sqlite:///sourceant.db
+# sqlite is accepted for local development and quick testing
 DATABASE_URL=postgresql://admin:admin@db:5432/sourceant
 STATELESS_MODE=false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim AS builder
+FROM python:3.9-slim-bookworm AS builder
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends gcc libpq-dev p
 COPY requirements.txt .
 RUN pip wheel --no-cache-dir --wheel-dir /app/wheels -r requirements.txt
 
-FROM python:3.9-slim
+FROM python:3.9-slim-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends libpq5 && rm -rf /var/lib/apt/lists/*
 
@@ -16,14 +16,14 @@ RUN useradd --create-home appuser
 USER appuser
 
 ENV PATH="/home/appuser/.local/bin:${PATH}"
+ENV PYTHONPATH=/app
 
 COPY --from=builder /app/wheels /wheels
 RUN pip install --no-cache /wheels/*
 
 COPY . .
 
-USER root
-RUN ln -s /app/sourceant /usr/local/bin/sourceant
-USER appuser
+COPY --chown=appuser:appuser sourceant /home/appuser/.local/bin/sourceant
+RUN chmod +x /home/appuser/.local/bin/sourceant
 
 ENTRYPOINT ["/app/start.prod.sh"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9-slim-bookworm
 
 WORKDIR /app
 
@@ -10,7 +10,15 @@ COPY . /app/
 RUN python -m pip install --upgrade pip
 RUN pip install --no-cache-dir -r requirements.txt
 
-RUN ln -s /app/sourceant /usr/local/bin/sourceant
+RUN useradd --create-home appuser
+
+COPY --chown=appuser:appuser sourceant /home/appuser/.local/bin/sourceant
+RUN chmod +x /home/appuser/.local/bin/sourceant
+
+USER appuser
+
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+ENV PYTHONPATH=/app
 
 EXPOSE 8000
 

--- a/sourceant
+++ b/sourceant
@@ -3,6 +3,8 @@
 import click
 import sys
 import subprocess
+from src.config.settings import DATABASE_URL, STATELESS_MODE
+from src.utils.logger import logger
 from alembic.config import CommandLine
 
 
@@ -15,6 +17,15 @@ def cli():
                context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 @click.pass_context
 def db_command(ctx):
+    if STATELESS_MODE:
+        print("Application is in STATELESS_MODE. Skipping database command.")
+        logger.warning("Application is in STATELESS_MODE. Skipping database command.")
+        sys.exit(0)
+    if not DATABASE_URL:
+        print("DATABASE_URL not set, skipping database command.")
+        logger.warning("DATABASE_URL not set, skipping database command.")
+        sys.exit(0)
+
     sys.argv = ["alembic"] + ctx.args
     sys.exit(CommandLine().main())
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -11,6 +11,12 @@ if QUEUE_MODE not in VALID_QUEUE_MODES:
         f"Invalid QUEUE_MODE: {QUEUE_MODE}. Must be one of {VALID_QUEUE_MODES}"
     )
 
+DATABASE_URL = os.getenv("DATABASE_URL")
+if not STATELESS_MODE and DATABASE_URL is None:
+    raise ValueError(
+        "DATABASE_URL environment variable must be set when not in STATELESS_MODE."
+    )
+
 REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
 REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
 LLM = os.getenv("LLM", "gemini")

--- a/src/migrations/env.py
+++ b/src/migrations/env.py
@@ -1,35 +1,20 @@
-import os
 from logging.config import fileConfig
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 from alembic import context
 
-from dotenv import load_dotenv
+from src.config.settings import DATABASE_URL
 
-load_dotenv()
-
-# this is the Alembic Config object, which provides
-# access to the values within the .ini file in use.
 config = context.config
 
-config.set_section_option("alembic", "sqlalchemy.url", os.getenv("DATABASE_URL"))
+if DATABASE_URL:
+    config.set_section_option("alembic", "sqlalchemy.url", DATABASE_URL)
 
 
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
 target_metadata = None
-
-# other values from the config, defined by the needs of env.py,
-# can be acquired:
-# my_important_option = config.get_main_option("my_important_option")
-# ... etc.
 
 
 def run_migrations_offline() -> None:
@@ -76,7 +61,8 @@ def run_migrations_online() -> None:
             context.run_migrations()
 
 
-if context.is_offline_mode():
-    run_migrations_offline()
-else:
-    run_migrations_online()
+if DATABASE_URL:
+    if context.is_offline_mode():
+        run_migrations_offline()
+    else:
+        run_migrations_online()


### PR DESCRIPTION
This commit introduces several major improvements to the application's containerization, configuration handling, and overall robustness.

Key changes include:

- **Docker Security Hardening**:
  - Both production and development Dockerfiles now run the application as a non-root `appuser` to enhance security by adhering to the principle of least privilege.
  - The base images have been updated to `python:3.9-slim-bookworm` to mitigate known vulnerabilities.
  - The executable is now copied directly to the user's PATH, avoiding the need for root access to create symlinks.

- **Configuration and Stateless Mode**:
  - The `DATABASE_URL` is now centralized in `config.settings`, making it the single source of truth.
  - The application now supports a stateless mode. If the `DATABASE_URL` environment variable is not set, all database operations, including migrations, are gracefully skipped.