### PR TITLE
feat: Conditionally skip draft and merged PRs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ GITHUB_APP_PRIVATE_KEY_PATH=sourceant.2025-02-28.sample.private-key.pem
 GITHUB_APP_CLIENT_ID=Iv23liOAxxxxxM88Sqy97
 GITHUB_SECRET=secret
 
+# Review configuration
+REVIEW_DRAFT_PRS=false
+
 # Logging configuration
 LOG_DRIVER=console # console, file, syslog
 LOG_FILE=sourceant.log

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -23,6 +23,7 @@ LLM = os.getenv("LLM", "gemini")
 LOG_DRIVER: str = os.getenv("LOG_DRIVER", "console")
 LOG_FILE: str = os.getenv("LOG_FILE", "sourceant.log")
 GITHUB_SECRET = os.getenv("GITHUB_SECRET")
+REVIEW_DRAFT_PRS = os.getenv("REVIEW_DRAFT_PRS", "false").lower() == "true"
 
 
 if GITHUB_SECRET is None:

--- a/src/models/pull_request.py
+++ b/src/models/pull_request.py
@@ -10,6 +10,8 @@ class PullRequest(BaseModel, table=True):
     provider: str = Field(..., index=True)
     number: int
     title: str
+    draft: bool = False
+    merged: bool = False
     body: Optional[str] = None
     url: str = Field(..., unique=True)
     state: str

--- a/src/tests/unit/test_process_event.py
+++ b/src/tests/unit/test_process_event.py
@@ -1,0 +1,113 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.events.dispatcher import EventDispatcher
+from src.events.repository_event import RepositoryEvent
+from src.models.repository_event import (
+    RepositoryEvent as RepositoryEventModel,
+)
+
+
+class TestProcessEvent:
+    @pytest.fixture
+    def dispatcher(self):
+        """Fixture to create an EventDispatcher instance."""
+        return EventDispatcher()
+
+    @patch("src.events.dispatcher.logger")
+    @patch("src.events.dispatcher.GitHub")
+    def test_skips_merged_pr(self, mock_github, mock_logger, dispatcher):
+        """Test that merged pull requests are skipped."""
+        event_data = RepositoryEventModel(
+            provider="github",
+            type="pull_request",
+            action="opened",
+            repository_full_name="test/repo",
+            number=1,
+            title="Test PR",
+            payload={"pull_request": {"merged": True, "draft": False}},
+        )
+        event = RepositoryEvent(event_data)
+
+        dispatcher._process_event(event)
+
+        mock_logger.info.assert_any_call("Skipping review for merged PR #1")
+        mock_github.assert_not_called()
+
+    @patch("src.events.dispatcher.logger")
+    @patch("src.events.dispatcher.GitHub")
+    def test_skips_draft_pr_when_disabled(
+        self, mock_github, mock_logger, dispatcher, monkeypatch
+    ):
+        """Test that draft PRs are skipped when REVIEW_DRAFT_PRS is False."""
+        monkeypatch.setattr("src.events.dispatcher.REVIEW_DRAFT_PRS", False)
+        event_data = RepositoryEventModel(
+            provider="github",
+            type="pull_request",
+            action="opened",
+            repository_full_name="test/repo",
+            number=2,
+            title="Draft PR",
+            payload={"pull_request": {"merged": False, "draft": True}},
+        )
+        event = RepositoryEvent(event_data)
+
+        dispatcher._process_event(event)
+
+        mock_logger.info.assert_any_call("Skipping review for draft PR #2")
+        mock_github.assert_not_called()
+
+    @patch("src.events.dispatcher.logger")
+    @patch("src.events.dispatcher.GitHub")
+    def test_processes_draft_pr_when_enabled(
+        self, mock_github, mock_logger, dispatcher, monkeypatch
+    ):
+        """Test that draft PRs are processed when REVIEW_DRAFT_PRS is True."""
+        monkeypatch.setattr("src.events.dispatcher.REVIEW_DRAFT_PRS", True)
+        mock_github_instance = MagicMock()
+        mock_github.return_value = mock_github_instance
+
+        event_data = RepositoryEventModel(
+            provider="github",
+            type="pull_request",
+            action="opened",
+            repository_full_name="test/repo",
+            number=3,
+            title="Draft PR",
+            payload={"pull_request": {"merged": False, "draft": True}},
+        )
+        event = RepositoryEvent(event_data)
+
+        dispatcher._process_event(event)
+
+        assert not any(
+            "Skipping review" in call.args[0]
+            for call in mock_logger.info.call_args_list
+        )
+        mock_github_instance.get_diff.assert_called_once()
+
+    @patch("src.events.dispatcher.logger")
+    @patch("src.events.dispatcher.GitHub")
+    def test_processes_normal_pr(self, mock_github, mock_logger, dispatcher):
+        """Test that normal (non-draft, non-merged) PRs are processed."""
+        mock_github_instance = MagicMock()
+        mock_github.return_value = mock_github_instance
+
+        event_data = RepositoryEventModel(
+            provider="github",
+            type="pull_request",
+            action="opened",
+            repository_full_name="test/repo",
+            number=4,
+            title="Normal PR",
+            payload={"pull_request": {"merged": False, "draft": False}},
+        )
+        event = RepositoryEvent(event_data)
+
+        dispatcher._process_event(event)
+
+        assert not any(
+            "Skipping review" in call.args[0]
+            for call in mock_logger.info.call_args_list
+        )
+        mock_github_instance.get_diff.assert_called_once()


### PR DESCRIPTION
This commit introduces functionality to avoid processing pull requests that are in a draft state or have already been merged.

Merged pull requests are now always skipped to prevent redundant reviews.

Draft pull requests are skipped by default. This behavior can be overridden by setting the `REVIEW_DRAFT_PRS` environment variable to `true`, allowing for reviews of work-in-progress pull requests when needed.

Changes include:
- Added `REVIEW_DRAFT_PRS` setting to control draft PR reviews.
- Enhanced `PullRequest` model with `draft` and `merged` attributes.
- Updated `EventDispatcher` to check PR status before processing.
- Added comprehensive unit tests for the new logic.