### PR TITLE
feat(review): Do semantic PR summary comparison

### DIFF
--- a/src/llms/gemini.py
+++ b/src/llms/gemini.py
@@ -119,3 +119,23 @@ class Gemini(LLMInterface):
             model=f"models/{self.model_name}", contents=[text]
         )
         return response.total_tokens
+
+    def is_summary_different(self, summary_a: str, summary_b: str) -> bool:
+        """Compares two summaries to see if they are semantically different."""
+        prompt = Prompts.COMPARE_SUMMARIES_PROMPT.format(
+            summary_a=summary_a, summary_b=summary_b
+        )
+        try:
+            logger.info("Comparing summaries for semantic differences...")
+            response = self.client.models.generate_content(
+                model=f"models/{self.model_name}", contents=[prompt]
+            )
+
+            verdict = response.text.strip().upper()
+            logger.info(f"Summary comparison verdict: {verdict}")
+
+            return verdict == "DIFFERENT"
+        except Exception as e:
+            logger.error(f"An error occurred during summary comparison: {e}")
+            # Default to assuming they are different to be safe and force an update.
+            return True

--- a/src/llms/llm_interface.py
+++ b/src/llms/llm_interface.py
@@ -18,3 +18,8 @@ class LLMInterface(ABC):
     def generate_code_review(self, diff: str, context: str = "None") -> CodeReview:
         """Generates a code review based on the given diff."""
         pass
+
+    @abstractmethod
+    def is_summary_different(self, summary_a: str, summary_b: str) -> bool:
+        """Compares two summaries to see if they are semantically different."""
+        pass

--- a/src/prompts/prompts.py
+++ b/src/prompts/prompts.py
@@ -140,3 +140,34 @@ class Prompts:
 
     Please provide clear and concise documentation that explains the purpose and functionality of the code changes.
     """
+
+    COMPARE_SUMMARIES_PROMPT = """
+    # Task: Compare two pull request summaries for semantic equivalence.
+
+    You will be given two summaries of a pull request, an "Old Summary" and a "New Summary".
+    Your task is to determine if the **meaning and core information** of the New Summary are substantively different from the Old Summary.
+
+    ## Criteria for "DIFFERENT":
+    - The New Summary introduces new information, suggestions, or warnings not present in the old one.
+    - The New Summary removes critical information that was in the old one.
+    - The tone or conclusion of the review has significantly changed (e.g., from approval to requesting changes).
+
+    ## Criteria for "SAME":
+    - The New Summary is just a rephrasing of the Old Summary without changing the core message.
+    - Minor stylistic or formatting changes.
+    - The order of points is different, but the substance is identical.
+
+    ## Input:
+    ### Old Summary:
+    ```markdown
+    {summary_a}
+    ```
+
+    ### New Summary:
+    ```markdown
+    {summary_b}
+    ```
+
+    ## Output:
+    Respond with a single word: **SAME** or **DIFFERENT**. Do not provide any other text or explanation.
+    """

--- a/src/tests/unit/test_github_adapter.py
+++ b/src/tests/unit/test_github_adapter.py
@@ -189,13 +189,13 @@ def test_find_overview_comment_found(
         mock_response.raise_for_status.return_value = None
         mock_get.return_value = mock_response
 
-        comment_id = github_instance._find_overview_comment(
+        comment = github_instance._find_overview_comment(
             repository_instance.owner,
             repository_instance.name,
             pull_request_instance.number,
             {},
         )
-        assert comment_id == 456
+        assert comment["id"] == 456
         mock_get.assert_called_once()
 
 
@@ -247,7 +247,8 @@ def test_create_or_update_overview_comment_update(
     github_instance, repository_instance, pull_request_instance
 ):
     with patch(
-        "src.integrations.github.github.GitHub._find_overview_comment", return_value=123
+        "src.integrations.github.github.GitHub._find_overview_comment",
+        return_value={"id": 123, "body": "old summary"},
     ), patch("requests.patch") as mock_patch:
 
         mock_response = MagicMock()


### PR DESCRIPTION
This change prevents redundant updates to PR summary comments.

Previously, the summary comment was updated on every event change, even if the meaning was the same.
Now, an LLM-powered semantic comparison is used to check if a new summary is meaningfully different from the old one before posting an update.

This reduces comment noise and focuses on substantial changes.