### PR TITLE
feat(core): Add memory service interfaces

### DIFF
--- a/src/core/code_index/__init__.py
+++ b/src/core/code_index/__init__.py
@@ -1,0 +1,23 @@
+from .interfaces import CodeIndexReader, CodeIndexRepository, CodeIndexWriter
+from .memory import InMemoryCodeIndex
+from .models import (
+    CodeEdge,
+    CodeNode,
+    CodeSearch,
+    CodeSearchResult,
+    CodeTraversal,
+    CodeTraversalResult,
+)
+
+__all__ = [
+    "CodeEdge",
+    "CodeIndexReader",
+    "CodeIndexRepository",
+    "CodeIndexWriter",
+    "CodeNode",
+    "CodeSearch",
+    "CodeSearchResult",
+    "CodeTraversal",
+    "CodeTraversalResult",
+    "InMemoryCodeIndex",
+]

--- a/src/core/code_index/interfaces.py
+++ b/src/core/code_index/interfaces.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from src.core.scope import Scope
+
+from .models import (
+    CodeEdge,
+    CodeNode,
+    CodeSearch,
+    CodeSearchResult,
+    CodeTraversal,
+    CodeTraversalResult,
+)
+
+
+@runtime_checkable
+class CodeIndexReader(Protocol):
+    def search(self, query: CodeSearch) -> CodeSearchResult: ...
+
+    def traverse(self, traversal: CodeTraversal) -> CodeTraversalResult: ...
+
+
+@runtime_checkable
+class CodeIndexWriter(Protocol):
+    def put_node(self, scope: Scope, node: CodeNode) -> None: ...
+
+    def put_edge(self, scope: Scope, edge: CodeEdge) -> None: ...
+
+    def clear(self, scope: Scope) -> None: ...
+
+
+@runtime_checkable
+class CodeIndexRepository(CodeIndexReader, CodeIndexWriter, Protocol):
+    pass

--- a/src/core/code_index/memory.py
+++ b/src/core/code_index/memory.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from collections import defaultdict, deque
+
+from src.core.scope import Scope
+
+from .models import (
+    CodeEdge,
+    CodeNode,
+    CodeSearch,
+    CodeSearchResult,
+    CodeTraversal,
+    CodeTraversalResult,
+)
+
+
+class InMemoryCodeIndex:
+    def __init__(self) -> None:
+        self._nodes: dict[tuple[Scope, str], CodeNode] = {}
+        self._edges: dict[tuple[Scope, str], CodeEdge] = {}
+        self._adjacency: dict[tuple[Scope, str], set[str]] = defaultdict(set)
+
+    def put_node(self, scope: Scope, node: CodeNode) -> None:
+        self._nodes[(scope, node.id)] = node
+
+    def put_edge(self, scope: Scope, edge: CodeEdge) -> None:
+        source = scope, edge.source_id
+        target = scope, edge.target_id
+        if source not in self._nodes or target not in self._nodes:
+            raise ValueError("edge endpoints must exist in the same scope")
+        edge_key = scope, edge.id
+        previous = self._edges.get(edge_key)
+        if previous:
+            self._adjacency[(scope, previous.source_id)].discard(previous.id)
+            self._adjacency[(scope, previous.target_id)].discard(previous.id)
+        self._edges[edge_key] = edge
+        self._adjacency[source].add(edge.id)
+        self._adjacency[target].add(edge.id)
+
+    def clear(self, scope: Scope) -> None:
+        for key in list(self._nodes):
+            if key[0] == scope:
+                del self._nodes[key]
+                self._adjacency.pop(key, None)
+        for key in list(self._edges):
+            if key[0] == scope:
+                del self._edges[key]
+
+    def search(self, query: CodeSearch) -> CodeSearchResult:
+        matches = [
+            node
+            for (scope, _), node in self._nodes.items()
+            if scope == query.scope
+            and query.labels.issubset(node.labels)
+            and all(
+                node.properties.get(key) == value
+                for key, value in query.properties.items()
+            )
+        ]
+        nodes = tuple(matches[query.offset : query.offset + query.limit])
+        return CodeSearchResult(
+            nodes=nodes,
+            total=len(matches),
+            has_more=query.offset + len(nodes) < len(matches),
+        )
+
+    def traverse(self, traversal: CodeTraversal) -> CodeTraversalResult:
+        scope = traversal.scope
+        queue = deque(
+            (node, 0)
+            for node_id in traversal.node_ids
+            if (node := self._nodes.get((scope, node_id)))
+        )
+        visited: set[str] = set()
+        nodes: list[CodeNode] = []
+        edges: dict[str, CodeEdge] = {}
+        truncated = False
+
+        while queue:
+            node, distance = queue.popleft()
+            if node.id in visited:
+                continue
+            if len(nodes) >= traversal.node_limit:
+                truncated = True
+                continue
+            visited.add(node.id)
+            nodes.append(node)
+            if distance == traversal.depth:
+                continue
+
+            for edge_id in sorted(self._adjacency[(scope, node.id)]):
+                edge = self._edges[(scope, edge_id)]
+                if traversal.edge_types and edge.type not in traversal.edge_types:
+                    continue
+                if traversal.direction == "outbound" and edge.source_id != node.id:
+                    continue
+                if traversal.direction == "inbound" and edge.target_id != node.id:
+                    continue
+                other_id = (
+                    edge.target_id if edge.source_id == node.id else edge.source_id
+                )
+                target = self._nodes.get((scope, other_id))
+                if target:
+                    queue.append((target, distance + 1))
+                edges[edge.id] = edge
+
+        included = {node.id for node in nodes}
+        packed_edges = tuple(
+            edge
+            for edge in edges.values()
+            if edge.source_id in included and edge.target_id in included
+        )
+        return CodeTraversalResult(
+            nodes=tuple(nodes),
+            edges=packed_edges,
+            truncated=truncated or len(packed_edges) != len(edges),
+        )

--- a/src/core/code_index/models.py
+++ b/src/core/code_index/models.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from src.core.scope import Scope
+
+
+@dataclass(frozen=True)
+class CodeNode:
+    id: str
+    labels: frozenset[str] = field(default_factory=frozenset)
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CodeEdge:
+    id: str
+    source_id: str
+    target_id: str
+    type: str
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CodeTraversal:
+    scope: Scope
+    node_ids: tuple[str, ...]
+    depth: int = 2
+    edge_types: frozenset[str] = field(default_factory=frozenset)
+    direction: str = "both"
+    node_limit: int = 50
+
+    def __post_init__(self) -> None:
+        if not self.node_ids or len(self.node_ids) > 100:
+            raise ValueError("node_ids must contain between 1 and 100 values")
+        if len(self.node_ids) != len(set(self.node_ids)):
+            raise ValueError("node_ids must be unique")
+        if not 1 <= self.depth <= 5:
+            raise ValueError("depth must be between 1 and 5")
+        if not 1 <= self.node_limit <= 100:
+            raise ValueError("node_limit must be between 1 and 100")
+        if self.direction not in {"outbound", "inbound", "both"}:
+            raise ValueError("direction must be outbound, inbound, or both")
+
+
+@dataclass(frozen=True)
+class CodeSearch:
+    scope: Scope
+    labels: frozenset[str] = field(default_factory=frozenset)
+    properties: Mapping[str, Any] = field(default_factory=dict)
+    limit: int = 50
+    offset: int = 0
+
+    def __post_init__(self) -> None:
+        if not 1 <= self.limit <= 100:
+            raise ValueError("limit must be between 1 and 100")
+        if self.offset < 0:
+            raise ValueError("offset must not be negative")
+
+
+@dataclass(frozen=True)
+class CodeTraversalResult:
+    nodes: tuple[CodeNode, ...]
+    edges: tuple[CodeEdge, ...]
+    truncated: bool
+
+
+@dataclass(frozen=True)
+class CodeSearchResult:
+    nodes: tuple[CodeNode, ...]
+    total: int
+    has_more: bool

--- a/src/core/knowledge/__init__.py
+++ b/src/core/knowledge/__init__.py
@@ -1,0 +1,19 @@
+from .interfaces import KnowledgeReader, KnowledgeRepository, KnowledgeWriter
+from .memory import InMemoryKnowledgeRepository
+from .models import (
+    Knowledge,
+    KnowledgeQuery,
+    KnowledgeRelationship,
+    KnowledgeResult,
+)
+
+__all__ = [
+    "InMemoryKnowledgeRepository",
+    "Knowledge",
+    "KnowledgeQuery",
+    "KnowledgeReader",
+    "KnowledgeRelationship",
+    "KnowledgeResult",
+    "KnowledgeRepository",
+    "KnowledgeWriter",
+]

--- a/src/core/knowledge/interfaces.py
+++ b/src/core/knowledge/interfaces.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from src.core.scope import Scope
+
+from .models import Knowledge, KnowledgeQuery, KnowledgeRelationship, KnowledgeResult
+
+
+@runtime_checkable
+class KnowledgeReader(Protocol):
+    def search(self, query: KnowledgeQuery) -> KnowledgeResult: ...
+
+    def get_relationships(
+        self,
+        scope: Scope,
+        knowledge_ids: frozenset[str],
+        statuses: frozenset[str] = frozenset(),
+    ) -> tuple[KnowledgeRelationship, ...]: ...
+
+
+@runtime_checkable
+class KnowledgeWriter(Protocol):
+    def put(self, scope: Scope, knowledge: Knowledge) -> None: ...
+
+    def put_relationship(
+        self, scope: Scope, relationship: KnowledgeRelationship
+    ) -> None: ...
+
+
+@runtime_checkable
+class KnowledgeRepository(KnowledgeReader, KnowledgeWriter, Protocol):
+    pass

--- a/src/core/knowledge/memory.py
+++ b/src/core/knowledge/memory.py
@@ -1,0 +1,57 @@
+from src.core.scope import Scope
+
+from .models import Knowledge, KnowledgeQuery, KnowledgeRelationship, KnowledgeResult
+
+
+class InMemoryKnowledgeRepository:
+    def __init__(self) -> None:
+        self._knowledge: dict[tuple[Scope, str], Knowledge] = {}
+        self._relationships: dict[tuple[Scope, str], KnowledgeRelationship] = {}
+
+    def put(self, scope: Scope, knowledge: Knowledge) -> None:
+        self._knowledge[(scope, knowledge.id)] = knowledge
+
+    def put_relationship(
+        self, scope: Scope, relationship: KnowledgeRelationship
+    ) -> None:
+        if (scope, relationship.source_id) not in self._knowledge or (
+            scope,
+            relationship.target_id,
+        ) not in self._knowledge:
+            raise ValueError("relationship endpoints must exist in the same scope")
+        self._relationships[(scope, relationship.id)] = relationship
+
+    def search(self, query: KnowledgeQuery) -> KnowledgeResult:
+        matches = [
+            knowledge
+            for (scope, _), knowledge in self._knowledge.items()
+            if scope == query.scope
+            and (not query.ids or knowledge.id in query.ids)
+            and (not query.kinds or knowledge.kind in query.kinds)
+            and (not query.statuses or knowledge.status in query.statuses)
+            and all(
+                knowledge.properties.get(key) == value
+                for key, value in query.properties.items()
+            )
+        ]
+        items = tuple(matches[query.offset : query.offset + query.limit])
+        return KnowledgeResult(
+            items=items,
+            total=len(matches),
+            has_more=query.offset + len(items) < len(matches),
+        )
+
+    def get_relationships(
+        self,
+        scope: Scope,
+        knowledge_ids: frozenset[str],
+        statuses: frozenset[str] = frozenset(),
+    ) -> tuple[KnowledgeRelationship, ...]:
+        return tuple(
+            relationship
+            for (relationship_scope, _), relationship in self._relationships.items()
+            if relationship_scope == scope
+            and (not statuses or relationship.status in statuses)
+            and relationship.source_id in knowledge_ids
+            and relationship.target_id in knowledge_ids
+        )

--- a/src/core/knowledge/models.py
+++ b/src/core/knowledge/models.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from src.core.scope import Scope
+
+
+@dataclass(frozen=True)
+class Knowledge:
+    id: str
+    kind: str
+    status: str
+    summary: str
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class KnowledgeRelationship:
+    id: str
+    source_id: str
+    target_id: str
+    type: str
+    status: str = ""
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class KnowledgeQuery:
+    scope: Scope
+    ids: frozenset[str] = field(default_factory=frozenset)
+    kinds: frozenset[str] = field(default_factory=frozenset)
+    statuses: frozenset[str] = field(default_factory=frozenset)
+    properties: Mapping[str, Any] = field(default_factory=dict)
+    limit: int = 50
+    offset: int = 0
+
+    def __post_init__(self) -> None:
+        if not 1 <= self.limit <= 100:
+            raise ValueError("limit must be between 1 and 100")
+        if self.offset < 0:
+            raise ValueError("offset must not be negative")
+
+
+@dataclass(frozen=True)
+class KnowledgeResult:
+    items: tuple[Knowledge, ...]
+    total: int
+    has_more: bool

--- a/src/core/plugins/__init__.py
+++ b/src/core/plugins/__init__.py
@@ -8,6 +8,7 @@ from .plugin_manager import PluginManager, plugin_manager
 from .base_plugin import BasePlugin, PluginMetadata, PluginType
 from .plugin_registry import PluginRegistry, PluginStatus, plugin_registry
 from .event_hooks import EventHooks, HookPriority, event_hooks
+from src.core.services import ServiceRegistry, service_registry
 
 __all__ = [
     "PluginManager",
@@ -21,4 +22,6 @@ __all__ = [
     "EventHooks",
     "HookPriority",
     "event_hooks",
+    "ServiceRegistry",
+    "service_registry",
 ]

--- a/src/core/plugins/base_plugin.py
+++ b/src/core/plugins/base_plugin.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from typing import Dict, Any, List, Optional
 from enum import Enum
 
+from src.core.services import ServiceRegistry, service_registry
+
 
 class PluginType(Enum):
     """Plugin type enumeration."""
@@ -52,6 +54,12 @@ class BasePlugin(ABC):
         self.config = config or {}
         self._initialized = False
         self._started = False
+        self.services = service_registry
+
+    def bind_services(self, services: ServiceRegistry) -> None:
+        if self._initialized:
+            raise RuntimeError("Cannot replace services after plugin initialization")
+        self.services = services
 
     @property
     @abstractmethod
@@ -85,8 +93,13 @@ class BasePlugin(ABC):
         if self._initialized:
             return
 
-        await self._initialize()
-        self._initialized = True
+        try:
+            await self._register_services()
+            await self._initialize()
+            self._initialized = True
+        except Exception:
+            self.services.unregister_provider(self.metadata.name)
+            raise
 
     async def start(self) -> None:
         """
@@ -125,12 +138,18 @@ class BasePlugin(ABC):
 
         Called after stop() for final cleanup. Plugin will be unloaded after this.
         """
-        await self._cleanup()
-        self._initialized = False
+        try:
+            await self._cleanup()
+        finally:
+            self.services.unregister_provider(self.metadata.name)
+            self._initialized = False
 
     # Override these methods in your plugin implementation
     async def _initialize(self) -> None:
         """Plugin-specific initialization logic."""
+        pass
+
+    async def _register_services(self) -> None:
         pass
 
     async def _start(self) -> None:

--- a/src/core/plugins/plugin_manager.py
+++ b/src/core/plugins/plugin_manager.py
@@ -14,6 +14,7 @@ from .base_plugin import BasePlugin, PluginType
 from .plugin_registry import PluginRegistry, PluginStatus, plugin_registry
 from .event_hooks import EventHooks, event_hooks
 from src.utils.logger import logger
+from src.core.services import ServiceRegistry, service_registry
 
 
 class PluginManager:
@@ -29,6 +30,7 @@ class PluginManager:
         self,
         registry: Optional[PluginRegistry] = None,
         hooks: Optional[EventHooks] = None,
+        services: Optional[ServiceRegistry] = None,
     ):
         """
         Initialize the plugin manager.
@@ -39,6 +41,7 @@ class PluginManager:
         """
         self.registry = registry or plugin_registry
         self.hooks = hooks or event_hooks
+        self.services = services or service_registry
         self._plugin_configs: Dict[str, Dict[str, Any]] = {}
         self._plugin_directories: List[Path] = []
 
@@ -268,6 +271,7 @@ class PluginManager:
 
             # Create plugin instance
             plugin_instance = plugin_class(config=plugin_config)
+            plugin_instance.bind_services(self.services)
 
             # Validate configuration if plugin has schema and is enabled
             metadata = plugin_instance.metadata
@@ -319,6 +323,7 @@ class PluginManager:
             plugin_class = ep.load()
             plugin_config = self._plugin_configs.get(name, {})
             plugin_instance = plugin_class(config=plugin_config)
+            plugin_instance.bind_services(self.services)
 
             metadata = plugin_instance.metadata
             if metadata.enabled and metadata.config_schema:

--- a/src/core/review_state/__init__.py
+++ b/src/core/review_state/__init__.py
@@ -1,0 +1,13 @@
+from .interfaces import ReviewStateReader, ReviewStateRepository, ReviewStateWriter
+from .memory import InMemoryReviewStateRepository
+from .models import FindingQuery, FindingResult, ReviewFinding
+
+__all__ = [
+    "FindingQuery",
+    "FindingResult",
+    "InMemoryReviewStateRepository",
+    "ReviewFinding",
+    "ReviewStateReader",
+    "ReviewStateRepository",
+    "ReviewStateWriter",
+]

--- a/src/core/review_state/interfaces.py
+++ b/src/core/review_state/interfaces.py
@@ -1,0 +1,20 @@
+from typing import Protocol, runtime_checkable
+
+from src.core.scope import Scope
+
+from .models import FindingQuery, FindingResult, ReviewFinding
+
+
+@runtime_checkable
+class ReviewStateReader(Protocol):
+    def search(self, query: FindingQuery) -> FindingResult: ...
+
+
+@runtime_checkable
+class ReviewStateWriter(Protocol):
+    def put_finding(self, scope: Scope, finding: ReviewFinding) -> None: ...
+
+
+@runtime_checkable
+class ReviewStateRepository(ReviewStateReader, ReviewStateWriter, Protocol):
+    pass

--- a/src/core/review_state/memory.py
+++ b/src/core/review_state/memory.py
@@ -1,0 +1,29 @@
+from src.core.scope import Scope
+
+from .models import FindingQuery, FindingResult, ReviewFinding
+
+
+class InMemoryReviewStateRepository:
+    def __init__(self) -> None:
+        self._findings: dict[tuple[Scope, str], ReviewFinding] = {}
+
+    def put_finding(self, scope: Scope, finding: ReviewFinding) -> None:
+        self._findings[(scope, finding.id)] = finding
+
+    def search(self, query: FindingQuery) -> FindingResult:
+        matches = [
+            finding
+            for (scope, _), finding in self._findings.items()
+            if scope == query.scope
+            and (not query.states or finding.state in query.states)
+            and all(
+                finding.properties.get(key) == value
+                for key, value in query.properties.items()
+            )
+        ]
+        findings = tuple(matches[query.offset : query.offset + query.limit])
+        return FindingResult(
+            findings=findings,
+            total=len(matches),
+            has_more=query.offset + len(findings) < len(matches),
+        )

--- a/src/core/review_state/models.py
+++ b/src/core/review_state/models.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from src.core.scope import Scope
+
+
+@dataclass(frozen=True)
+class ReviewFinding:
+    id: str
+    state: str
+    summary: str
+    code_anchor: str | None = None
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class FindingQuery:
+    scope: Scope
+    states: frozenset[str] = field(default_factory=frozenset)
+    properties: Mapping[str, Any] = field(default_factory=dict)
+    limit: int = 100
+    offset: int = 0
+
+    def __post_init__(self) -> None:
+        if not 1 <= self.limit <= 500:
+            raise ValueError("limit must be between 1 and 500")
+        if self.offset < 0:
+            raise ValueError("offset must not be negative")
+
+
+@dataclass(frozen=True)
+class FindingResult:
+    findings: tuple[ReviewFinding, ...]
+    total: int
+    has_more: bool

--- a/src/core/scope.py
+++ b/src/core/scope.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class Scope:
+    values: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        keys = [key for key, _ in self.values]
+        if len(keys) != len(set(keys)):
+            raise ValueError("scope keys must be unique")
+        if any(not key or not value for key, value in self.values):
+            raise ValueError("scope keys and values must not be empty")
+        object.__setattr__(self, "values", tuple(sorted(self.values)))
+
+    @classmethod
+    def from_mapping(cls, values: Mapping[str, str]) -> "Scope":
+        return cls(tuple(sorted(values.items())))
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return dict(self.values).get(key, default)
+
+    def extend(self, values: Mapping[str, str]) -> "Scope":
+        combined = dict(self.values)
+        combined.update(values)
+        return self.from_mapping(combined)

--- a/src/core/services.py
+++ b/src/core/services.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar, cast
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class ServiceRegistration(Generic[T]):
+    service: T
+    provider: str
+
+
+class ServiceRegistry:
+    def __init__(self) -> None:
+        self._registrations: dict[type[object], ServiceRegistration[object]] = {}
+
+    def register(self, interface: type[T], service: T, provider: str) -> None:
+        if interface in self._registrations:
+            current = self._registrations[interface]
+            raise ValueError(
+                f"{interface.__name__} is already provided by {current.provider}"
+            )
+        self._registrations[interface] = ServiceRegistration(service, provider)
+
+    def resolve(self, interface: type[T]) -> T:
+        try:
+            registration = self._registrations[interface]
+        except KeyError as error:
+            message = f"No provider registered for {interface.__name__}"
+            raise LookupError(message) from error
+        return cast(T, registration.service)
+
+    def unregister_provider(self, provider: str) -> None:
+        interfaces = [
+            interface
+            for interface, registration in self._registrations.items()
+            if registration.provider == provider
+        ]
+        for interface in interfaces:
+            del self._registrations[interface]
+
+
+service_registry = ServiceRegistry()

--- a/src/tests/unit/test_core_memory_services.py
+++ b/src/tests/unit/test_core_memory_services.py
@@ -1,0 +1,195 @@
+import asyncio
+
+import pytest
+
+from src.core.code_index import (
+    CodeEdge,
+    CodeIndexReader,
+    CodeNode,
+    CodeSearch,
+    CodeTraversal,
+    InMemoryCodeIndex,
+)
+from src.core.knowledge import (
+    InMemoryKnowledgeRepository,
+    Knowledge,
+    KnowledgeQuery,
+    KnowledgeRelationship,
+)
+from src.core.plugins import (
+    BasePlugin,
+    EventHooks,
+    PluginManager,
+    PluginMetadata,
+    PluginRegistry,
+    PluginType,
+)
+from src.core.review_state import (
+    FindingQuery,
+    InMemoryReviewStateRepository,
+    ReviewFinding,
+)
+from src.core.scope import Scope
+from src.core.services import ServiceRegistry
+
+PROJECT = Scope.from_mapping({"project": "one"})
+OTHER_PROJECT = Scope.from_mapping({"project": "two"})
+
+
+def code_node(identifier: str, **properties) -> CodeNode:
+    return CodeNode(identifier, frozenset({"Function"}), properties)
+
+
+def test_scope_is_immutable_extensible_and_order_independent():
+    first = Scope.from_mapping({"repository": "one", "tenant": "two"})
+    second = Scope((("tenant", "two"), ("repository", "one")))
+
+    assert first == second
+    assert first.get("tenant") == "two"
+    assert first.extend({"revision": "abc"}).get("revision") == "abc"
+
+
+def test_code_index_isolates_arbitrary_scopes():
+    index = InMemoryCodeIndex()
+    index.put_node(PROJECT, code_node("shared"))
+    index.put_node(OTHER_PROJECT, code_node("shared"))
+
+    result = index.traverse(CodeTraversal(PROJECT, ("shared",)))
+
+    assert [node.id for node in result.nodes] == ["shared"]
+
+
+def test_code_index_searches_open_labels_properties_and_pages():
+    index = InMemoryCodeIndex()
+    index.put_node(PROJECT, code_node("one", language="python"))
+    index.put_node(PROJECT, code_node("two", language="python"))
+    index.put_node(PROJECT, code_node("three", language="php"))
+
+    result = index.search(
+        CodeSearch(
+            PROJECT,
+            labels=frozenset({"Function"}),
+            properties={"language": "python"},
+            limit=1,
+        )
+    )
+
+    assert [node.id for node in result.nodes] == ["one"]
+    assert result.total == 2
+    assert result.has_more is True
+
+
+def test_code_index_traverses_cycles_with_limits():
+    index = InMemoryCodeIndex()
+    for identifier in ("a", "b", "c"):
+        index.put_node(PROJECT, code_node(identifier))
+    for source, target in (("a", "b"), ("b", "c"), ("c", "a")):
+        index.put_edge(PROJECT, CodeEdge(f"{source}-{target}", source, target, "CALLS"))
+
+    result = index.traverse(CodeTraversal(PROJECT, ("a",), depth=2, node_limit=2))
+
+    assert len(result.nodes) == 2
+    assert result.truncated is True
+
+
+def test_code_index_replaces_edge_endpoints_and_obeys_direction():
+    index = InMemoryCodeIndex()
+    for identifier in ("a", "b", "c"):
+        index.put_node(PROJECT, code_node(identifier))
+    index.put_edge(PROJECT, CodeEdge("edge", "a", "b", "CALLS"))
+    index.put_edge(PROJECT, CodeEdge("edge", "b", "c", "CUSTOM_RELATIONSHIP"))
+
+    stale = index.traverse(CodeTraversal(PROJECT, ("a",)))
+    inbound = index.traverse(CodeTraversal(PROJECT, ("c",), direction="inbound"))
+
+    assert [node.id for node in stale.nodes] == ["a"]
+    assert [node.id for node in inbound.nodes] == ["c", "b"]
+
+
+def test_knowledge_queries_open_kinds_statuses_properties_and_pages():
+    knowledge = InMemoryKnowledgeRepository()
+    knowledge.put(PROJECT, Knowledge("one", "decision", "approved", "One"))
+    knowledge.put(
+        PROJECT,
+        Knowledge("two", "custom-kind", "accepted", "Two", {"language": "python"}),
+    )
+
+    result = knowledge.search(
+        KnowledgeQuery(
+            PROJECT,
+            kinds=frozenset({"custom-kind"}),
+            statuses=frozenset({"accepted"}),
+            properties={"language": "python"},
+        )
+    )
+
+    assert [item.id for item in result.items] == ["two"]
+    assert result.total == 1
+
+
+def test_knowledge_relationships_remain_inside_scope():
+    knowledge = InMemoryKnowledgeRepository()
+    knowledge.put(PROJECT, Knowledge("one", "rule", "approved", "One"))
+    knowledge.put(PROJECT, Knowledge("two", "rule", "approved", "Two"))
+    knowledge.put_relationship(
+        PROJECT,
+        KnowledgeRelationship("edge", "one", "two", "CUSTOM", "accepted"),
+    )
+
+    relationships = knowledge.get_relationships(
+        PROJECT,
+        frozenset({"one", "two"}),
+        frozenset({"accepted"}),
+    )
+
+    assert [relationship.id for relationship in relationships] == ["edge"]
+
+
+def test_review_state_uses_scope_and_extensible_state():
+    reviews = InMemoryReviewStateRepository()
+    reviews.put_finding(PROJECT, ReviewFinding("one", "needs-review", "One"))
+    reviews.put_finding(PROJECT, ReviewFinding("two", "resolved", "Two"))
+
+    result = reviews.search(FindingQuery(PROJECT, frozenset({"needs-review"})))
+
+    assert [finding.id for finding in result.findings] == ["one"]
+
+
+class CodeIndexPlugin(BasePlugin):
+    @property
+    def metadata(self):
+        return PluginMetadata(
+            name="code-index",
+            version="1",
+            description="",
+            author="",
+            plugin_type=PluginType.UTILITY,
+        )
+
+    async def _register_services(self):
+        self.services.register(CodeIndexReader, InMemoryCodeIndex(), self.metadata.name)
+
+
+def test_plugin_manager_binds_runtime_services(tmp_path):
+    services = ServiceRegistry()
+    manager = PluginManager(
+        registry=PluginRegistry(),
+        hooks=EventHooks(),
+        services=services,
+    )
+    package = tmp_path / "code_index_plugin"
+    package.mkdir()
+    (package / "__init__.py").write_text("")
+    plugin_path = package / "plugin.py"
+    plugin_path.write_text(
+        "from src.tests.unit.test_core_memory_services import CodeIndexPlugin\n"
+    )
+
+    plugin = asyncio.run(manager.load_plugin(plugin_path, "code_index_plugin"))
+    assert plugin is not None
+    asyncio.run(plugin.initialize())
+    assert isinstance(services.resolve(CodeIndexReader), InMemoryCodeIndex)
+
+    asyncio.run(plugin.cleanup())
+    with pytest.raises(LookupError, match="CodeIndexReader"):
+        services.resolve(CodeIndexReader)


### PR DESCRIPTION
Separates code intelligence, durable knowledge, and review findings behind core-owned service contracts. Plugins can provide Codebase Memory, Memgraph, or other implementations without making review workers import plugin packages; in-memory providers keep isolation and lifecycle behavior testable before production adapters land.