### PR TITLE
feat(storage): Add artifact and working area contracts

### DIFF
--- a/src/core/storage/__init__.py
+++ b/src/core/storage/__init__.py
@@ -1,0 +1,25 @@
+from .filesystem import FileSystemArtifactStore, FileSystemWorkingAreaStore
+from .interfaces import ArtifactReader, ArtifactStore, ArtifactWriter, WorkingAreaStore
+from .models import (
+    Artifact,
+    ArtifactKey,
+    ArtifactWrite,
+    ContentDigest,
+    WorkingArea,
+    WorkingAreaRequest,
+)
+
+__all__ = [
+    "Artifact",
+    "ArtifactKey",
+    "ArtifactReader",
+    "ArtifactStore",
+    "ArtifactWrite",
+    "ArtifactWriter",
+    "ContentDigest",
+    "FileSystemArtifactStore",
+    "FileSystemWorkingAreaStore",
+    "WorkingArea",
+    "WorkingAreaRequest",
+    "WorkingAreaStore",
+]

--- a/src/core/storage/filesystem.py
+++ b/src/core/storage/filesystem.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import BinaryIO
+
+from src.core.scope import Scope
+
+from .models import (
+    Artifact,
+    ArtifactKey,
+    ArtifactWrite,
+    ContentDigest,
+    WorkingArea,
+    WorkingAreaRequest,
+)
+
+
+def _component(value: str) -> str:
+    if value in {".", ".."} or not value or any(char in value for char in "/\\\0"):
+        raise ValueError("storage identifiers must be single path components")
+    return value
+
+
+def _scope_id(scope: Scope) -> str:
+    encoded = json.dumps(scope.values, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class FileSystemArtifactStore:
+    def __init__(self, root: Path):
+        self._root = root.resolve()
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    def get(self, key: ArtifactKey) -> Artifact | None:
+        metadata = self._metadata_path(key)
+        if not metadata.is_file():
+            return None
+        payload = json.loads(metadata.read_text(encoding="utf-8"))
+        return Artifact(
+            key=key,
+            digest=ContentDigest(payload["digest_algorithm"], payload["digest"]),
+            size=payload["size"],
+            media_type=payload["media_type"],
+            created_at=datetime.fromisoformat(payload["created_at"]),
+            properties=payload["properties"],
+        )
+
+    def open(self, key: ArtifactKey) -> BinaryIO:
+        return self._content_path(key).open("rb")
+
+    def list(
+        self, scope: Scope, namespace: str, name: str | None = None
+    ) -> tuple[Artifact, ...]:
+        base = self._root / _scope_id(scope) / _component(namespace)
+        if name is not None:
+            base /= _component(name)
+        if not base.exists():
+            return ()
+        artifacts = []
+        for metadata in sorted(base.rglob("metadata.json")):
+            relative = metadata.relative_to(self._root / _scope_id(scope))
+            parts = relative.parts
+            key = ArtifactKey(scope, parts[0], parts[1], parts[2])
+            artifact = self.get(key)
+            if artifact is not None:
+                artifacts.append(artifact)
+        return tuple(artifacts)
+
+    def put(self, request: ArtifactWrite, content: BinaryIO) -> Artifact:
+        target = self._content_path(request.key)
+        if target.exists():
+            raise FileExistsError(f"artifact already exists: {request.key.version}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        digest = hashlib.new(request.digest_algorithm)
+        size = 0
+        temporary = tempfile.NamedTemporaryFile(dir=target.parent, delete=False)
+        temporary_path = Path(temporary.name)
+        try:
+            with temporary:
+                while chunk := content.read(1024 * 1024):
+                    temporary.write(chunk)
+                    digest.update(chunk)
+                    size += len(chunk)
+            value = digest.hexdigest()
+            actual = ContentDigest(request.digest_algorithm, value)
+            if request.expected_digest is not None and request.expected_digest != actual:
+                raise ValueError("artifact content does not match expected digest")
+            os.replace(temporary_path, target)
+            artifact = Artifact(
+                key=request.key,
+                digest=actual,
+                size=size,
+                media_type=request.media_type,
+                created_at=datetime.now(timezone.utc),
+                properties=dict(request.properties),
+            )
+            self._write_metadata(artifact)
+            return artifact
+        finally:
+            temporary_path.unlink(missing_ok=True)
+
+    def delete(self, key: ArtifactKey) -> bool:
+        directory = self._directory(key)
+        if not directory.exists():
+            return False
+        shutil.rmtree(directory)
+        return True
+
+    def _directory(self, key: ArtifactKey) -> Path:
+        return (
+            self._root
+            / _scope_id(key.scope)
+            / _component(key.namespace)
+            / _component(key.name)
+            / _component(key.version)
+        )
+
+    def _content_path(self, key: ArtifactKey) -> Path:
+        return self._directory(key) / "content"
+
+    def _metadata_path(self, key: ArtifactKey) -> Path:
+        return self._directory(key) / "metadata.json"
+
+    def _write_metadata(self, artifact: Artifact) -> None:
+        payload = {
+            "created_at": artifact.created_at.isoformat(),
+            "digest": artifact.digest.value,
+            "digest_algorithm": artifact.digest.algorithm,
+            "media_type": artifact.media_type,
+            "properties": dict(artifact.properties),
+            "size": artifact.size,
+        }
+        path = self._metadata_path(artifact.key)
+        temporary = path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+        os.replace(temporary, path)
+
+
+class FileSystemWorkingAreaStore:
+    def __init__(self, root: Path):
+        self._root = root.resolve()
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    def provision(self, request: WorkingAreaRequest) -> WorkingArea:
+        area = self._area(request)
+        area.path.mkdir(parents=True, exist_ok=True)
+        return area
+
+    def get(self, request: WorkingAreaRequest) -> WorkingArea | None:
+        area = self._area(request)
+        return area if area.path.is_dir() else None
+
+    def remove(self, request: WorkingAreaRequest) -> bool:
+        area = self.get(request)
+        if area is None:
+            return False
+        shutil.rmtree(area.path)
+        return True
+
+    def list(self, scope: Scope, purpose: str | None = None) -> tuple[WorkingArea, ...]:
+        scope_root = self._root / _scope_id(scope)
+        purposes = [scope_root / _component(purpose)] if purpose else scope_root.glob("*")
+        areas = []
+        for purpose_path in purposes:
+            if not purpose_path.is_dir():
+                continue
+            for path in sorted(purpose_path.iterdir()):
+                if path.is_dir():
+                    request = WorkingAreaRequest(scope, purpose_path.name, path.name)
+                    areas.append(WorkingArea(request, path))
+        return tuple(areas)
+
+    def _area(self, request: WorkingAreaRequest) -> WorkingArea:
+        path = (
+            self._root
+            / _scope_id(request.scope)
+            / _component(request.purpose)
+            / _component(request.name)
+        )
+        return WorkingArea(request, path)

--- a/src/core/storage/filesystem.py
+++ b/src/core/storage/filesystem.py
@@ -89,7 +89,10 @@ class FileSystemArtifactStore:
                     size += len(chunk)
             value = digest.hexdigest()
             actual = ContentDigest(request.digest_algorithm, value)
-            if request.expected_digest is not None and request.expected_digest != actual:
+            if (
+                request.expected_digest is not None
+                and request.expected_digest != actual
+            ):
                 raise ValueError("artifact content does not match expected digest")
             os.replace(temporary_path, target)
             artifact = Artifact(
@@ -165,7 +168,9 @@ class FileSystemWorkingAreaStore:
 
     def list(self, scope: Scope, purpose: str | None = None) -> tuple[WorkingArea, ...]:
         scope_root = self._root / _scope_id(scope)
-        purposes = [scope_root / _component(purpose)] if purpose else scope_root.glob("*")
+        purposes = (
+            [scope_root / _component(purpose)] if purpose else scope_root.glob("*")
+        )
         areas = []
         for purpose_path in purposes:
             if not purpose_path.is_dir():

--- a/src/core/storage/filesystem.py
+++ b/src/core/storage/filesystem.py
@@ -74,7 +74,7 @@ class FileSystemArtifactStore:
 
     def put(self, request: ArtifactWrite, content: BinaryIO) -> Artifact:
         target = self._content_path(request.key)
-        if target.exists():
+        if self._metadata_path(request.key).exists():
             raise FileExistsError(f"artifact already exists: {request.key.version}")
         target.parent.mkdir(parents=True, exist_ok=True)
         digest = hashlib.new(request.digest_algorithm)

--- a/src/core/storage/interfaces.py
+++ b/src/core/storage/interfaces.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import BinaryIO, Protocol, runtime_checkable
+
+from src.core.scope import Scope
+
+from .models import Artifact, ArtifactKey, ArtifactWrite, WorkingArea, WorkingAreaRequest
+
+
+@runtime_checkable
+class ArtifactReader(Protocol):
+    def get(self, key: ArtifactKey) -> Artifact | None: ...
+
+    def open(self, key: ArtifactKey) -> BinaryIO: ...
+
+    def list(
+        self, scope: Scope, namespace: str, name: str | None = None
+    ) -> tuple[Artifact, ...]: ...
+
+
+@runtime_checkable
+class ArtifactWriter(Protocol):
+    def put(self, request: ArtifactWrite, content: BinaryIO) -> Artifact: ...
+
+    def delete(self, key: ArtifactKey) -> bool: ...
+
+
+@runtime_checkable
+class ArtifactStore(ArtifactReader, ArtifactWriter, Protocol):
+    pass
+
+
+@runtime_checkable
+class WorkingAreaStore(Protocol):
+    def provision(self, request: WorkingAreaRequest) -> WorkingArea: ...
+
+    def get(self, request: WorkingAreaRequest) -> WorkingArea | None: ...
+
+    def remove(self, request: WorkingAreaRequest) -> bool: ...
+
+    def list(self, scope: Scope, purpose: str | None = None) -> Iterable[WorkingArea]: ...

--- a/src/core/storage/interfaces.py
+++ b/src/core/storage/interfaces.py
@@ -5,7 +5,13 @@ from typing import BinaryIO, Protocol, runtime_checkable
 
 from src.core.scope import Scope
 
-from .models import Artifact, ArtifactKey, ArtifactWrite, WorkingArea, WorkingAreaRequest
+from .models import (
+    Artifact,
+    ArtifactKey,
+    ArtifactWrite,
+    WorkingArea,
+    WorkingAreaRequest,
+)
 
 
 @runtime_checkable
@@ -39,4 +45,6 @@ class WorkingAreaStore(Protocol):
 
     def remove(self, request: WorkingAreaRequest) -> bool: ...
 
-    def list(self, scope: Scope, purpose: str | None = None) -> Iterable[WorkingArea]: ...
+    def list(
+        self, scope: Scope, purpose: str | None = None
+    ) -> Iterable[WorkingArea]: ...

--- a/src/core/storage/models.py
+++ b/src/core/storage/models.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Mapping
+
+from src.core.scope import Scope
+
+
+@dataclass(frozen=True)
+class ArtifactKey:
+    scope: Scope
+    namespace: str
+    name: str
+    version: str
+
+    def __post_init__(self) -> None:
+        if any(not value for value in (self.namespace, self.name, self.version)):
+            raise ValueError("artifact namespace, name, and version must not be empty")
+
+
+@dataclass(frozen=True)
+class ContentDigest:
+    algorithm: str
+    value: str
+
+    def __post_init__(self) -> None:
+        if not self.algorithm or not self.value:
+            raise ValueError("digest algorithm and value must not be empty")
+
+
+@dataclass(frozen=True)
+class Artifact:
+    key: ArtifactKey
+    digest: ContentDigest
+    size: int
+    media_type: str
+    created_at: datetime
+    properties: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.size < 0:
+            raise ValueError("artifact size must not be negative")
+        if not self.media_type:
+            raise ValueError("artifact media_type must not be empty")
+
+
+@dataclass(frozen=True)
+class ArtifactWrite:
+    key: ArtifactKey
+    media_type: str = "application/octet-stream"
+    digest_algorithm: str = "sha256"
+    expected_digest: ContentDigest | None = None
+    properties: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class WorkingAreaRequest:
+    scope: Scope
+    purpose: str
+    name: str
+
+    def __post_init__(self) -> None:
+        if not self.purpose or not self.name:
+            raise ValueError("working area purpose and name must not be empty")
+
+
+@dataclass(frozen=True)
+class WorkingArea:
+    request: WorkingAreaRequest
+    path: Path

--- a/src/tests/unit/test_core_storage.py
+++ b/src/tests/unit/test_core_storage.py
@@ -44,6 +44,21 @@ def test_filesystem_artifact_checks_expected_digest_before_publish(tmp_path):
     assert store.get(key) is None
 
 
+def test_filesystem_artifact_recovers_content_without_metadata(tmp_path):
+    store = FileSystemArtifactStore(tmp_path)
+    key = ArtifactKey(PROJECT, "code-index", "repository", "abc123")
+    invalid = ArtifactWrite(key, expected_digest=ContentDigest("sha256", "incorrect"))
+    with pytest.raises(ValueError, match="expected digest"):
+        store.put(invalid, BytesIO(b"partial"))
+    orphan = next(tmp_path.rglob("abc123")) / "content"
+    orphan.write_bytes(b"partial")
+
+    artifact = store.put(ArtifactWrite(key), BytesIO(b"graph"))
+
+    assert artifact.size == 5
+    assert store.open(key).read() == b"graph"
+
+
 def test_filesystem_working_areas_are_stable_and_scope_isolated(tmp_path):
     store = FileSystemWorkingAreaStore(tmp_path)
     request = WorkingAreaRequest(PROJECT, "repository", "source")

--- a/src/tests/unit/test_core_storage.py
+++ b/src/tests/unit/test_core_storage.py
@@ -1,0 +1,77 @@
+from io import BytesIO
+
+import pytest
+
+from src.core.scope import Scope
+from src.core.storage import (
+    ArtifactKey,
+    ArtifactStore,
+    ArtifactWrite,
+    ContentDigest,
+    FileSystemArtifactStore,
+    FileSystemWorkingAreaStore,
+    WorkingAreaRequest,
+    WorkingAreaStore,
+)
+
+PROJECT = Scope.from_mapping({"project": "one", "tenant": "alpha"})
+OTHER_PROJECT = Scope.from_mapping({"project": "one", "tenant": "beta"})
+
+
+def test_filesystem_artifacts_are_immutable_and_scope_isolated(tmp_path):
+    store = FileSystemArtifactStore(tmp_path)
+    key = ArtifactKey(PROJECT, "code-index", "repository", "abc123")
+    other_key = ArtifactKey(OTHER_PROJECT, "code-index", "repository", "abc123")
+
+    artifact = store.put(ArtifactWrite(key), BytesIO(b"graph"))
+    store.put(ArtifactWrite(other_key), BytesIO(b"other"))
+
+    assert artifact.size == 5
+    assert store.open(key).read() == b"graph"
+    assert [item.key for item in store.list(PROJECT, "code-index")] == [key]
+    with pytest.raises(FileExistsError):
+        store.put(ArtifactWrite(key), BytesIO(b"replacement"))
+
+
+def test_filesystem_artifact_checks_expected_digest_before_publish(tmp_path):
+    store = FileSystemArtifactStore(tmp_path)
+    key = ArtifactKey(PROJECT, "code-index", "repository", "abc123")
+    request = ArtifactWrite(key, expected_digest=ContentDigest("sha256", "incorrect"))
+
+    with pytest.raises(ValueError, match="expected digest"):
+        store.put(request, BytesIO(b"graph"))
+
+    assert store.get(key) is None
+
+
+def test_filesystem_working_areas_are_stable_and_scope_isolated(tmp_path):
+    store = FileSystemWorkingAreaStore(tmp_path)
+    request = WorkingAreaRequest(PROJECT, "repository", "source")
+    other_request = WorkingAreaRequest(OTHER_PROJECT, "repository", "source")
+
+    area = store.provision(request)
+    other_area = store.provision(other_request)
+
+    assert area == store.provision(request)
+    assert area.path != other_area.path
+    assert tuple(store.list(PROJECT, "repository")) == (area,)
+    assert store.remove(request) is True
+    assert store.remove(request) is False
+
+
+def test_storage_identifiers_cannot_escape_the_storage_root(tmp_path):
+    artifacts = FileSystemArtifactStore(tmp_path / "artifacts")
+    areas = FileSystemWorkingAreaStore(tmp_path / "areas")
+
+    with pytest.raises(ValueError, match="single path components"):
+        artifacts.put(
+            ArtifactWrite(ArtifactKey(PROJECT, "code-index", "repository", "../bad")),
+            BytesIO(b"graph"),
+        )
+    with pytest.raises(ValueError, match="single path components"):
+        areas.provision(WorkingAreaRequest(PROJECT, "repository", "../bad"))
+
+
+def test_filesystem_implementations_satisfy_storage_protocols(tmp_path):
+    assert isinstance(FileSystemArtifactStore(tmp_path / "artifacts"), ArtifactStore)
+    assert isinstance(FileSystemWorkingAreaStore(tmp_path / "areas"), WorkingAreaStore)


### PR DESCRIPTION
Establishes the provider-neutral boundary needed to keep active indexes on local storage while publishing immutable snapshots to object storage. Scope remains opaque to storage providers and filesystem paths are derived from its complete canonical value.