### PR TITLE
feat(core): Add bounded knowledge traversal

### DIFF
--- a/src/core/knowledge/__init__.py
+++ b/src/core/knowledge/__init__.py
@@ -5,6 +5,8 @@ from .models import (
     KnowledgeQuery,
     KnowledgeRelationship,
     KnowledgeResult,
+    KnowledgeSubgraph,
+    KnowledgeTraversal,
 )
 
 __all__ = [
@@ -14,6 +16,8 @@ __all__ = [
     "KnowledgeReader",
     "KnowledgeRelationship",
     "KnowledgeResult",
+    "KnowledgeSubgraph",
+    "KnowledgeTraversal",
     "KnowledgeRepository",
     "KnowledgeWriter",
 ]

--- a/src/core/knowledge/interfaces.py
+++ b/src/core/knowledge/interfaces.py
@@ -4,7 +4,14 @@ from typing import Protocol, runtime_checkable
 
 from src.core.scope import Scope
 
-from .models import Knowledge, KnowledgeQuery, KnowledgeRelationship, KnowledgeResult
+from .models import (
+    Knowledge,
+    KnowledgeQuery,
+    KnowledgeRelationship,
+    KnowledgeResult,
+    KnowledgeSubgraph,
+    KnowledgeTraversal,
+)
 
 
 @runtime_checkable
@@ -17,6 +24,8 @@ class KnowledgeReader(Protocol):
         knowledge_ids: frozenset[str],
         statuses: frozenset[str] = frozenset(),
     ) -> tuple[KnowledgeRelationship, ...]: ...
+
+    def traverse(self, traversal: KnowledgeTraversal) -> KnowledgeSubgraph: ...
 
 
 @runtime_checkable

--- a/src/core/knowledge/memory.py
+++ b/src/core/knowledge/memory.py
@@ -139,12 +139,10 @@ class InMemoryKnowledgeRepository:
         packed_relationships = tuple(
             relationship
             for relationship in relationships.values()
-            if relationship.source_id in included
-            and relationship.target_id in included
+            if relationship.source_id in included and relationship.target_id in included
         )
         return KnowledgeSubgraph(
             items=tuple(items),
             relationships=packed_relationships,
-            truncated=truncated
-            or len(packed_relationships) != len(relationships),
+            truncated=truncated or len(packed_relationships) != len(relationships),
         )

--- a/src/core/knowledge/memory.py
+++ b/src/core/knowledge/memory.py
@@ -80,6 +80,7 @@ class InMemoryKnowledgeRepository:
             for knowledge_id in traversal.knowledge_ids
             if (item := self._knowledge.get((scope, knowledge_id)))
         )
+        queued = {item.id for item, _ in queue}
         visited: set[str] = set()
         items: list[Knowledge] = []
         relationships: dict[str, KnowledgeRelationship] = {}
@@ -97,7 +98,7 @@ class InMemoryKnowledgeRepository:
             if distance == traversal.depth:
                 continue
 
-            for relationship_id in sorted(self._adjacency[(scope, item.id)]):
+            for relationship_id in sorted(self._adjacency.get((scope, item.id), ())):
                 relationship = self._relationships[(scope, relationship_id)]
                 if (
                     traversal.relationship_types
@@ -132,14 +133,14 @@ class InMemoryKnowledgeRepository:
                     else relationship.source_id
                 )
                 target = self._knowledge.get((scope, other_id))
-                if target:
+                if target and target.id not in queued:
+                    queued.add(target.id)
                     queue.append((target, distance + 1))
 
-        included = {item.id for item in items}
         packed_relationships = tuple(
             relationship
             for relationship in relationships.values()
-            if relationship.source_id in included and relationship.target_id in included
+            if relationship.source_id in visited and relationship.target_id in visited
         )
         return KnowledgeSubgraph(
             items=tuple(items),

--- a/src/core/knowledge/memory.py
+++ b/src/core/knowledge/memory.py
@@ -1,12 +1,22 @@
+from collections import defaultdict, deque
+
 from src.core.scope import Scope
 
-from .models import Knowledge, KnowledgeQuery, KnowledgeRelationship, KnowledgeResult
+from .models import (
+    Knowledge,
+    KnowledgeQuery,
+    KnowledgeRelationship,
+    KnowledgeResult,
+    KnowledgeSubgraph,
+    KnowledgeTraversal,
+)
 
 
 class InMemoryKnowledgeRepository:
     def __init__(self) -> None:
         self._knowledge: dict[tuple[Scope, str], Knowledge] = {}
         self._relationships: dict[tuple[Scope, str], KnowledgeRelationship] = {}
+        self._adjacency: dict[tuple[Scope, str], set[str]] = defaultdict(set)
 
     def put(self, scope: Scope, knowledge: Knowledge) -> None:
         self._knowledge[(scope, knowledge.id)] = knowledge
@@ -19,7 +29,14 @@ class InMemoryKnowledgeRepository:
             relationship.target_id,
         ) not in self._knowledge:
             raise ValueError("relationship endpoints must exist in the same scope")
-        self._relationships[(scope, relationship.id)] = relationship
+        key = scope, relationship.id
+        previous = self._relationships.get(key)
+        if previous:
+            self._adjacency[(scope, previous.source_id)].discard(previous.id)
+            self._adjacency[(scope, previous.target_id)].discard(previous.id)
+        self._relationships[key] = relationship
+        self._adjacency[(scope, relationship.source_id)].add(relationship.id)
+        self._adjacency[(scope, relationship.target_id)].add(relationship.id)
 
     def search(self, query: KnowledgeQuery) -> KnowledgeResult:
         matches = [
@@ -54,4 +71,80 @@ class InMemoryKnowledgeRepository:
             and (not statuses or relationship.status in statuses)
             and relationship.source_id in knowledge_ids
             and relationship.target_id in knowledge_ids
+        )
+
+    def traverse(self, traversal: KnowledgeTraversal) -> KnowledgeSubgraph:
+        scope = traversal.scope
+        queue = deque(
+            (item, 0)
+            for knowledge_id in traversal.knowledge_ids
+            if (item := self._knowledge.get((scope, knowledge_id)))
+        )
+        visited: set[str] = set()
+        items: list[Knowledge] = []
+        relationships: dict[str, KnowledgeRelationship] = {}
+        truncated = False
+
+        while queue:
+            item, distance = queue.popleft()
+            if item.id in visited:
+                continue
+            if len(items) >= traversal.knowledge_limit:
+                truncated = True
+                continue
+            visited.add(item.id)
+            items.append(item)
+            if distance == traversal.depth:
+                continue
+
+            for relationship_id in sorted(self._adjacency[(scope, item.id)]):
+                relationship = self._relationships[(scope, relationship_id)]
+                if (
+                    traversal.relationship_types
+                    and relationship.type not in traversal.relationship_types
+                ):
+                    continue
+                if (
+                    traversal.relationship_statuses
+                    and relationship.status not in traversal.relationship_statuses
+                ):
+                    continue
+                if (
+                    traversal.direction == "outbound"
+                    and relationship.source_id != item.id
+                ):
+                    continue
+                if (
+                    traversal.direction == "inbound"
+                    and relationship.target_id != item.id
+                ):
+                    continue
+                if (
+                    relationship.id not in relationships
+                    and len(relationships) >= traversal.relationship_limit
+                ):
+                    truncated = True
+                    continue
+                relationships[relationship.id] = relationship
+                other_id = (
+                    relationship.target_id
+                    if relationship.source_id == item.id
+                    else relationship.source_id
+                )
+                target = self._knowledge.get((scope, other_id))
+                if target:
+                    queue.append((target, distance + 1))
+
+        included = {item.id for item in items}
+        packed_relationships = tuple(
+            relationship
+            for relationship in relationships.values()
+            if relationship.source_id in included
+            and relationship.target_id in included
+        )
+        return KnowledgeSubgraph(
+            items=tuple(items),
+            relationships=packed_relationships,
+            truncated=truncated
+            or len(packed_relationships) != len(relationships),
         )

--- a/src/core/knowledge/models.py
+++ b/src/core/knowledge/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Mapping
+from typing import Any, Literal, Mapping
 
 from src.core.scope import Scope
 
@@ -54,7 +54,7 @@ class KnowledgeTraversal:
     depth: int = 2
     relationship_types: frozenset[str] = field(default_factory=frozenset)
     relationship_statuses: frozenset[str] = field(default_factory=frozenset)
-    direction: str = "both"
+    direction: Literal["outbound", "inbound", "both"] = "both"
     knowledge_limit: int = 50
     relationship_limit: int = 100
 

--- a/src/core/knowledge/models.py
+++ b/src/core/knowledge/models.py
@@ -45,3 +45,36 @@ class KnowledgeResult:
     items: tuple[Knowledge, ...]
     total: int
     has_more: bool
+
+
+@dataclass(frozen=True)
+class KnowledgeTraversal:
+    scope: Scope
+    knowledge_ids: tuple[str, ...]
+    depth: int = 2
+    relationship_types: frozenset[str] = field(default_factory=frozenset)
+    relationship_statuses: frozenset[str] = field(default_factory=frozenset)
+    direction: str = "both"
+    knowledge_limit: int = 50
+    relationship_limit: int = 100
+
+    def __post_init__(self) -> None:
+        if not self.knowledge_ids or len(self.knowledge_ids) > 50:
+            raise ValueError("knowledge_ids must contain between 1 and 50 values")
+        if len(self.knowledge_ids) != len(set(self.knowledge_ids)):
+            raise ValueError("knowledge_ids must be unique")
+        if not 1 <= self.depth <= 3:
+            raise ValueError("depth must be between 1 and 3")
+        if not 1 <= self.knowledge_limit <= 50:
+            raise ValueError("knowledge_limit must be between 1 and 50")
+        if not 1 <= self.relationship_limit <= 500:
+            raise ValueError("relationship_limit must be between 1 and 500")
+        if self.direction not in {"outbound", "inbound", "both"}:
+            raise ValueError("direction must be outbound, inbound, or both")
+
+
+@dataclass(frozen=True)
+class KnowledgeSubgraph:
+    items: tuple[Knowledge, ...]
+    relationships: tuple[KnowledgeRelationship, ...]
+    truncated: bool

--- a/src/tests/unit/test_core_memory_services.py
+++ b/src/tests/unit/test_core_memory_services.py
@@ -15,6 +15,7 @@ from src.core.knowledge import (
     Knowledge,
     KnowledgeQuery,
     KnowledgeRelationship,
+    KnowledgeTraversal,
 )
 from src.core.plugins import (
     BasePlugin,
@@ -143,6 +144,86 @@ def test_knowledge_relationships_remain_inside_scope():
     )
 
     assert [relationship.id for relationship in relationships] == ["edge"]
+
+
+def test_knowledge_traversal_is_bounded_filtered_and_scope_isolated():
+    knowledge = InMemoryKnowledgeRepository()
+    for scope in (PROJECT, OTHER_PROJECT):
+        for identifier in ("a", "b", "c"):
+            knowledge.put(
+                scope,
+                Knowledge(identifier, "decision", "approved", identifier),
+            )
+    knowledge.put_relationship(
+        PROJECT,
+        KnowledgeRelationship("a-b", "a", "b", "depends_on", "approved"),
+    )
+    knowledge.put_relationship(
+        PROJECT,
+        KnowledgeRelationship("b-c", "b", "c", "relates_to", "pending"),
+    )
+
+    result = knowledge.traverse(
+        KnowledgeTraversal(
+            PROJECT,
+            ("a",),
+            depth=3,
+            relationship_types=frozenset({"depends_on"}),
+            relationship_statuses=frozenset({"approved"}),
+        )
+    )
+
+    assert [item.id for item in result.items] == ["a", "b"]
+    assert [relationship.id for relationship in result.relationships] == ["a-b"]
+    assert result.truncated is False
+
+
+def test_knowledge_traversal_handles_cycles_directions_and_limits():
+    knowledge = InMemoryKnowledgeRepository()
+    for identifier in ("a", "b", "c"):
+        knowledge.put(
+            PROJECT,
+            Knowledge(identifier, "decision", "approved", identifier),
+        )
+    for source, target in (("a", "b"), ("b", "c"), ("c", "a")):
+        knowledge.put_relationship(
+            PROJECT,
+            KnowledgeRelationship(
+                f"{source}-{target}", source, target, "relates_to"
+            ),
+        )
+
+    outbound = knowledge.traverse(
+        KnowledgeTraversal(PROJECT, ("a",), depth=3, direction="outbound")
+    )
+    limited = knowledge.traverse(
+        KnowledgeTraversal(PROJECT, ("a",), depth=3, knowledge_limit=2)
+    )
+
+    assert [item.id for item in outbound.items] == ["a", "b", "c"]
+    assert len(outbound.relationships) == 3
+    assert len(limited.items) == 2
+    assert limited.truncated is True
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("depth", 4, "depth must be between 1 and 3"),
+        ("knowledge_limit", 51, "knowledge_limit must be between 1 and 50"),
+        (
+            "relationship_limit",
+            501,
+            "relationship_limit must be between 1 and 500",
+        ),
+        ("direction", "sideways", "direction must be outbound, inbound, or both"),
+    ],
+)
+def test_knowledge_traversal_rejects_unbounded_inputs(field, value, message):
+    arguments = {"scope": PROJECT, "knowledge_ids": ("a",), field: value}
+
+    with pytest.raises(ValueError, match=message):
+        KnowledgeTraversal(**arguments)
 
 
 def test_review_state_uses_scope_and_extensible_state():

--- a/src/tests/unit/test_core_memory_services.py
+++ b/src/tests/unit/test_core_memory_services.py
@@ -188,9 +188,7 @@ def test_knowledge_traversal_handles_cycles_directions_and_limits():
     for source, target in (("a", "b"), ("b", "c"), ("c", "a")):
         knowledge.put_relationship(
             PROJECT,
-            KnowledgeRelationship(
-                f"{source}-{target}", source, target, "relates_to"
-            ),
+            KnowledgeRelationship(f"{source}-{target}", source, target, "relates_to"),
         )
 
     outbound = knowledge.traverse(


### PR DESCRIPTION
Gives graph providers a shared traversal contract with strict depth, node, relationship, direction, status, and type boundaries. This is the core prerequisite for Memory's context subgraph retrieval.