### PR TITLE
feat(core): Filter knowledge traversal by status

### DIFF
--- a/src/core/knowledge/memory.py
+++ b/src/core/knowledge/memory.py
@@ -79,6 +79,10 @@ class InMemoryKnowledgeRepository:
             (item, 0)
             for knowledge_id in traversal.knowledge_ids
             if (item := self._knowledge.get((scope, knowledge_id)))
+            and (
+                not traversal.knowledge_statuses
+                or item.status in traversal.knowledge_statuses
+            )
         )
         queued = {item.id for item, _ in queue}
         visited: set[str] = set()
@@ -120,6 +124,17 @@ class InMemoryKnowledgeRepository:
                     and relationship.target_id != item.id
                 ):
                     continue
+                other_id = (
+                    relationship.target_id
+                    if relationship.source_id == item.id
+                    else relationship.source_id
+                )
+                target = self._knowledge.get((scope, other_id))
+                if not target or (
+                    traversal.knowledge_statuses
+                    and target.status not in traversal.knowledge_statuses
+                ):
+                    continue
                 if (
                     relationship.id not in relationships
                     and len(relationships) >= traversal.relationship_limit
@@ -127,13 +142,7 @@ class InMemoryKnowledgeRepository:
                     truncated = True
                     continue
                 relationships[relationship.id] = relationship
-                other_id = (
-                    relationship.target_id
-                    if relationship.source_id == item.id
-                    else relationship.source_id
-                )
-                target = self._knowledge.get((scope, other_id))
-                if target and target.id not in queued:
+                if target.id not in queued:
                     queued.add(target.id)
                     queue.append((target, distance + 1))
 

--- a/src/core/knowledge/models.py
+++ b/src/core/knowledge/models.py
@@ -52,6 +52,7 @@ class KnowledgeTraversal:
     scope: Scope
     knowledge_ids: tuple[str, ...]
     depth: int = 2
+    knowledge_statuses: frozenset[str] = field(default_factory=frozenset)
     relationship_types: frozenset[str] = field(default_factory=frozenset)
     relationship_statuses: frozenset[str] = field(default_factory=frozenset)
     direction: Literal["outbound", "inbound", "both"] = "both"

--- a/src/tests/unit/test_core_memory_services.py
+++ b/src/tests/unit/test_core_memory_services.py
@@ -204,6 +204,33 @@ def test_knowledge_traversal_handles_cycles_directions_and_limits():
     assert limited.truncated is True
 
 
+def test_knowledge_traversal_filters_seed_and_connected_node_statuses():
+    knowledge = InMemoryKnowledgeRepository()
+    knowledge.put(PROJECT, Knowledge("active", "decision", "active", "Active"))
+    knowledge.put(
+        PROJECT,
+        Knowledge("superseded", "decision", "superseded", "Superseded"),
+    )
+    knowledge.put_relationship(
+        PROJECT,
+        KnowledgeRelationship(
+            "replacement", "active", "superseded", "supersedes", "approved"
+        ),
+    )
+
+    result = knowledge.traverse(
+        KnowledgeTraversal(
+            PROJECT,
+            ("active", "superseded"),
+            knowledge_statuses=frozenset({"active"}),
+        )
+    )
+
+    assert [item.id for item in result.items] == ["active"]
+    assert result.relationships == ()
+    assert result.truncated is False
+
+
 @pytest.mark.parametrize(
     ("field", "value", "message"),
     [


### PR DESCRIPTION
Prevents graph traversal from returning superseded, pending, or otherwise ineligible knowledge when callers request approved lifecycle states. This is required before MCP get_context can safely return graph subgraphs.