### PR TITLE
feat(core): Add software topology interfaces

### DIFF
--- a/src/core/topology/__init__.py
+++ b/src/core/topology/__init__.py
@@ -1,0 +1,21 @@
+from .interfaces import TopologyReader, TopologyRepository, TopologyWriter
+from .memory import InMemoryTopologyRepository
+from .models import (
+    TopologyEntity,
+    TopologyEvidence,
+    TopologyRelationship,
+    TopologySubgraph,
+    TopologyTraversal,
+)
+
+__all__ = [
+    "InMemoryTopologyRepository",
+    "TopologyEntity",
+    "TopologyEvidence",
+    "TopologyReader",
+    "TopologyRelationship",
+    "TopologyRepository",
+    "TopologySubgraph",
+    "TopologyTraversal",
+    "TopologyWriter",
+]

--- a/src/core/topology/interfaces.py
+++ b/src/core/topology/interfaces.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from src.core.scope import Scope
+
+from .models import (
+    TopologyEntity,
+    TopologyRelationship,
+    TopologySubgraph,
+    TopologyTraversal,
+)
+
+
+@runtime_checkable
+class TopologyReader(Protocol):
+    def traverse(self, traversal: TopologyTraversal) -> TopologySubgraph: ...
+
+
+@runtime_checkable
+class TopologyWriter(Protocol):
+    def put_entity(self, scope: Scope, entity: TopologyEntity) -> None: ...
+
+    def put_relationship(
+        self, scope: Scope, relationship: TopologyRelationship
+    ) -> None: ...
+
+
+@runtime_checkable
+class TopologyRepository(TopologyReader, TopologyWriter, Protocol):
+    pass

--- a/src/core/topology/memory.py
+++ b/src/core/topology/memory.py
@@ -64,13 +64,9 @@ class InMemoryTopologyRepository:
             if distance == traversal.depth:
                 continue
 
-            for relationship_id in sorted(
-                self._adjacency.get((scope, entity.id), ())
-            ):
+            for relationship_id in sorted(self._adjacency.get((scope, entity.id), ())):
                 relationship = self._relationships[(scope, relationship_id)]
-                if not self._matches_relationship(
-                    relationship, entity.id, traversal
-                ):
+                if not self._matches_relationship(relationship, entity.id, traversal):
                     continue
                 other_id = (
                     relationship.target_id
@@ -103,9 +99,7 @@ class InMemoryTopologyRepository:
         )
 
     @staticmethod
-    def _matches_entity(
-        entity: TopologyEntity, traversal: TopologyTraversal
-    ) -> bool:
+    def _matches_entity(entity: TopologyEntity, traversal: TopologyTraversal) -> bool:
         return (
             (not traversal.entity_kinds or entity.kind in traversal.entity_kinds)
             and (

--- a/src/core/topology/memory.py
+++ b/src/core/topology/memory.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from collections import defaultdict, deque
+
+from src.core.scope import Scope
+
+from .models import (
+    TopologyEntity,
+    TopologyRelationship,
+    TopologySubgraph,
+    TopologyTraversal,
+)
+
+
+class InMemoryTopologyRepository:
+    def __init__(self) -> None:
+        self._entities: dict[tuple[Scope, str], TopologyEntity] = {}
+        self._relationships: dict[tuple[Scope, str], TopologyRelationship] = {}
+        self._adjacency: dict[tuple[Scope, str], set[str]] = defaultdict(set)
+
+    def put_entity(self, scope: Scope, entity: TopologyEntity) -> None:
+        self._entities[(scope, entity.id)] = entity
+
+    def put_relationship(
+        self, scope: Scope, relationship: TopologyRelationship
+    ) -> None:
+        if (scope, relationship.source_id) not in self._entities or (
+            scope,
+            relationship.target_id,
+        ) not in self._entities:
+            raise ValueError("relationship endpoints must exist in the same scope")
+        key = scope, relationship.id
+        previous = self._relationships.get(key)
+        if previous:
+            self._adjacency[(scope, previous.source_id)].discard(previous.id)
+            self._adjacency[(scope, previous.target_id)].discard(previous.id)
+        self._relationships[key] = relationship
+        self._adjacency[(scope, relationship.source_id)].add(relationship.id)
+        self._adjacency[(scope, relationship.target_id)].add(relationship.id)
+
+    def traverse(self, traversal: TopologyTraversal) -> TopologySubgraph:
+        scope = traversal.scope
+        queue = deque(
+            (entity, 0)
+            for entity_id in traversal.entity_ids
+            if (entity := self._entities.get((scope, entity_id)))
+            and self._matches_entity(entity, traversal)
+        )
+        queued = {entity.id for entity, _ in queue}
+        visited: set[str] = set()
+        entities: list[TopologyEntity] = []
+        relationships: dict[str, TopologyRelationship] = {}
+        truncated = False
+
+        while queue:
+            entity, distance = queue.popleft()
+            if entity.id in visited:
+                continue
+            if len(entities) >= traversal.entity_limit:
+                truncated = True
+                continue
+            visited.add(entity.id)
+            entities.append(entity)
+            if distance == traversal.depth:
+                continue
+
+            for relationship_id in sorted(
+                self._adjacency.get((scope, entity.id), ())
+            ):
+                relationship = self._relationships[(scope, relationship_id)]
+                if not self._matches_relationship(
+                    relationship, entity.id, traversal
+                ):
+                    continue
+                other_id = (
+                    relationship.target_id
+                    if relationship.source_id == entity.id
+                    else relationship.source_id
+                )
+                target = self._entities.get((scope, other_id))
+                if not target or not self._matches_entity(target, traversal):
+                    continue
+                if (
+                    relationship.id not in relationships
+                    and len(relationships) >= traversal.relationship_limit
+                ):
+                    truncated = True
+                    continue
+                relationships[relationship.id] = relationship
+                if target.id not in queued:
+                    queued.add(target.id)
+                    queue.append((target, distance + 1))
+
+        packed_relationships = tuple(
+            relationship
+            for relationship in relationships.values()
+            if relationship.source_id in visited and relationship.target_id in visited
+        )
+        return TopologySubgraph(
+            entities=tuple(entities),
+            relationships=packed_relationships,
+            truncated=truncated or len(packed_relationships) != len(relationships),
+        )
+
+    @staticmethod
+    def _matches_entity(
+        entity: TopologyEntity, traversal: TopologyTraversal
+    ) -> bool:
+        return (
+            (not traversal.entity_kinds or entity.kind in traversal.entity_kinds)
+            and (
+                not traversal.entity_statuses
+                or entity.status in traversal.entity_statuses
+            )
+            and entity.confidence >= traversal.minimum_confidence
+            and (traversal.include_stale or not entity.stale)
+        )
+
+    @staticmethod
+    def _matches_relationship(
+        relationship: TopologyRelationship,
+        entity_id: str,
+        traversal: TopologyTraversal,
+    ) -> bool:
+        return (
+            (
+                not traversal.relationship_types
+                or relationship.type in traversal.relationship_types
+            )
+            and (
+                not traversal.relationship_statuses
+                or relationship.status in traversal.relationship_statuses
+            )
+            and relationship.confidence >= traversal.minimum_confidence
+            and (traversal.include_stale or not relationship.stale)
+            and (
+                traversal.direction == "both"
+                or (
+                    traversal.direction == "outbound"
+                    and relationship.source_id == entity_id
+                )
+                or (
+                    traversal.direction == "inbound"
+                    and relationship.target_id == entity_id
+                )
+            )
+        )

--- a/src/core/topology/memory.py
+++ b/src/core/topology/memory.py
@@ -58,7 +58,7 @@ class InMemoryTopologyRepository:
                 continue
             if len(entities) >= traversal.entity_limit:
                 truncated = True
-                continue
+                break
             visited.add(entity.id)
             entities.append(entity)
             if distance == traversal.depth:

--- a/src/core/topology/memory.py
+++ b/src/core/topology/memory.py
@@ -24,11 +24,14 @@ class InMemoryTopologyRepository:
     def put_relationship(
         self, scope: Scope, relationship: TopologyRelationship
     ) -> None:
-        if (scope, relationship.source_id) not in self._entities or (
-            scope,
-            relationship.target_id,
-        ) not in self._entities:
-            raise ValueError("relationship endpoints must exist in the same scope")
+        if (scope, relationship.source_id) not in self._entities:
+            raise ValueError(
+                f"source entity {relationship.source_id!r} does not exist in scope"
+            )
+        if (scope, relationship.target_id) not in self._entities:
+            raise ValueError(
+                f"target entity {relationship.target_id!r} does not exist in scope"
+            )
         key = scope, relationship.id
         previous = self._relationships.get(key)
         if previous:

--- a/src/core/topology/models.py
+++ b/src/core/topology/models.py
@@ -14,6 +14,10 @@ class TopologyEvidence:
     revision: str = ""
     properties: Mapping[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("evidence id cannot be empty")
+
 
 @dataclass(frozen=True)
 class TopologyEntity:
@@ -26,6 +30,8 @@ class TopologyEntity:
     evidence: tuple[TopologyEvidence, ...] = ()
 
     def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("entity id cannot be empty")
         if not 0.0 <= self.confidence <= 1.0:
             raise ValueError("confidence must be between 0 and 1")
 
@@ -43,6 +49,12 @@ class TopologyRelationship:
     evidence: tuple[TopologyEvidence, ...] = ()
 
     def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("relationship id cannot be empty")
+        if not self.source_id:
+            raise ValueError("relationship source_id cannot be empty")
+        if not self.target_id:
+            raise ValueError("relationship target_id cannot be empty")
         if not 0.0 <= self.confidence <= 1.0:
             raise ValueError("confidence must be between 0 and 1")
 
@@ -67,6 +79,8 @@ class TopologyTraversal:
             raise ValueError("entity_ids must contain between 1 and 50 values")
         if len(self.entity_ids) != len(set(self.entity_ids)):
             raise ValueError("entity_ids must be unique")
+        if any(not entity_id for entity_id in self.entity_ids):
+            raise ValueError("entity_ids cannot contain empty values")
         if not 1 <= self.depth <= 3:
             raise ValueError("depth must be between 1 and 3")
         if not 0.0 <= self.minimum_confidence <= 1.0:

--- a/src/core/topology/models.py
+++ b/src/core/topology/models.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Mapping
+
+from src.core.scope import Scope
+
+
+@dataclass(frozen=True)
+class TopologyEvidence:
+    id: str
+    kind: str
+    source: str
+    revision: str = ""
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TopologyEntity:
+    id: str
+    kind: str
+    status: str
+    confidence: float = 1.0
+    stale: bool = False
+    properties: Mapping[str, Any] = field(default_factory=dict)
+    evidence: tuple[TopologyEvidence, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be between 0 and 1")
+
+
+@dataclass(frozen=True)
+class TopologyRelationship:
+    id: str
+    source_id: str
+    target_id: str
+    type: str
+    status: str
+    confidence: float = 1.0
+    stale: bool = False
+    properties: Mapping[str, Any] = field(default_factory=dict)
+    evidence: tuple[TopologyEvidence, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be between 0 and 1")
+
+
+@dataclass(frozen=True)
+class TopologyTraversal:
+    scope: Scope
+    entity_ids: tuple[str, ...]
+    depth: int = 2
+    entity_kinds: frozenset[str] = field(default_factory=frozenset)
+    entity_statuses: frozenset[str] = field(default_factory=frozenset)
+    relationship_types: frozenset[str] = field(default_factory=frozenset)
+    relationship_statuses: frozenset[str] = field(default_factory=frozenset)
+    direction: Literal["outbound", "inbound", "both"] = "both"
+    minimum_confidence: float = 0.0
+    include_stale: bool = False
+    entity_limit: int = 50
+    relationship_limit: int = 100
+
+    def __post_init__(self) -> None:
+        if not self.entity_ids or len(self.entity_ids) > 50:
+            raise ValueError("entity_ids must contain between 1 and 50 values")
+        if len(self.entity_ids) != len(set(self.entity_ids)):
+            raise ValueError("entity_ids must be unique")
+        if not 1 <= self.depth <= 3:
+            raise ValueError("depth must be between 1 and 3")
+        if not 0.0 <= self.minimum_confidence <= 1.0:
+            raise ValueError("minimum_confidence must be between 0 and 1")
+        if not 1 <= self.entity_limit <= 50:
+            raise ValueError("entity_limit must be between 1 and 50")
+        if not 1 <= self.relationship_limit <= 500:
+            raise ValueError("relationship_limit must be between 1 and 500")
+        if self.direction not in {"outbound", "inbound", "both"}:
+            raise ValueError("direction must be outbound, inbound, or both")
+
+
+@dataclass(frozen=True)
+class TopologySubgraph:
+    entities: tuple[TopologyEntity, ...]
+    relationships: tuple[TopologyRelationship, ...]
+    truncated: bool

--- a/src/tests/unit/test_core_topology.py
+++ b/src/tests/unit/test_core_topology.py
@@ -1,0 +1,198 @@
+import pytest
+
+from src.core.scope import Scope
+from src.core.topology import (
+    InMemoryTopologyRepository,
+    TopologyEntity,
+    TopologyEvidence,
+    TopologyRelationship,
+    TopologyTraversal,
+)
+
+PRODUCT = Scope.from_mapping({"boundary": "product"})
+OTHER_PRODUCT = Scope.from_mapping({"boundary": "other"})
+
+
+def entity(identifier: str, kind: str = "component", **values) -> TopologyEntity:
+    return TopologyEntity(identifier, kind, "active", **values)
+
+
+def test_topology_traversal_is_bounded_filtered_and_scope_isolated():
+    topology = InMemoryTopologyRepository()
+    for scope in (PRODUCT, OTHER_PRODUCT):
+        for item in (
+            entity("frontend"),
+            entity("api"),
+            entity("contract", "interface"),
+            entity("release", "release"),
+        ):
+            topology.put_entity(scope, item)
+    topology.put_relationship(
+        PRODUCT,
+        TopologyRelationship(
+            "frontend-contract",
+            "frontend",
+            "contract",
+            "consumes",
+            "approved",
+        ),
+    )
+    topology.put_relationship(
+        PRODUCT,
+        TopologyRelationship(
+            "api-contract", "api", "contract", "provides", "approved"
+        ),
+    )
+    topology.put_relationship(
+        PRODUCT,
+        TopologyRelationship(
+            "api-release", "api", "release", "released_as", "pending"
+        ),
+    )
+
+    result = topology.traverse(
+        TopologyTraversal(
+            PRODUCT,
+            ("frontend",),
+            depth=2,
+            relationship_types=frozenset({"consumes", "provides"}),
+            relationship_statuses=frozenset({"approved"}),
+        )
+    )
+
+    assert [item.id for item in result.entities] == [
+        "frontend",
+        "contract",
+        "api",
+    ]
+    assert [relationship.id for relationship in result.relationships] == [
+        "frontend-contract",
+        "api-contract",
+    ]
+    assert result.truncated is False
+
+
+def test_topology_traversal_handles_cycles_directions_and_limits():
+    topology = InMemoryTopologyRepository()
+    for identifier in ("a", "b", "c"):
+        topology.put_entity(PRODUCT, entity(identifier))
+    for source, target in (("a", "b"), ("b", "c"), ("c", "a")):
+        topology.put_relationship(
+            PRODUCT,
+            TopologyRelationship(
+                f"{source}-{target}", source, target, "relates_to", "approved"
+            ),
+        )
+
+    outbound = topology.traverse(
+        TopologyTraversal(PRODUCT, ("a",), depth=3, direction="outbound")
+    )
+    inbound = topology.traverse(
+        TopologyTraversal(PRODUCT, ("a",), depth=1, direction="inbound")
+    )
+    limited = topology.traverse(
+        TopologyTraversal(PRODUCT, ("a",), depth=3, entity_limit=2)
+    )
+    relationship_limited = topology.traverse(
+        TopologyTraversal(PRODUCT, ("a",), depth=3, relationship_limit=1)
+    )
+
+    assert [item.id for item in outbound.entities] == ["a", "b", "c"]
+    assert len(outbound.relationships) == 3
+    assert [item.id for item in inbound.entities] == ["a", "c"]
+    assert [relationship.id for relationship in inbound.relationships] == ["c-a"]
+    assert len(limited.entities) == 2
+    assert limited.truncated is True
+    assert len(relationship_limited.relationships) == 1
+    assert relationship_limited.truncated is True
+
+
+def test_topology_filters_confidence_lifecycle_and_stale_evidence():
+    topology = InMemoryTopologyRepository()
+    evidence = TopologyEvidence(
+        "verification", "contract_test", "build", "abc123"
+    )
+    topology.put_entity(PRODUCT, entity("source", evidence=(evidence,)))
+    topology.put_entity(PRODUCT, entity("trusted", confidence=0.9))
+    topology.put_entity(PRODUCT, entity("uncertain", confidence=0.4))
+    topology.put_entity(PRODUCT, entity("stale", stale=True))
+    for target in ("trusted", "uncertain", "stale"):
+        topology.put_relationship(
+            PRODUCT,
+            TopologyRelationship(
+                f"source-{target}",
+                "source",
+                target,
+                "depends_on",
+                "approved",
+                evidence=(evidence,),
+            ),
+        )
+
+    result = topology.traverse(
+        TopologyTraversal(PRODUCT, ("source",), minimum_confidence=0.8)
+    )
+
+    assert [item.id for item in result.entities] == ["source", "trusted"]
+    assert [relationship.id for relationship in result.relationships] == [
+        "source-trusted"
+    ]
+    assert result.entities[0].evidence == (evidence,)
+
+
+def test_topology_updates_preserve_identity_and_replace_duplicate_edges():
+    topology = InMemoryTopologyRepository()
+    for identifier in ("a", "b", "c"):
+        topology.put_entity(PRODUCT, entity(identifier))
+    topology.put_relationship(
+        PRODUCT,
+        TopologyRelationship("edge", "a", "b", "depends_on", "approved"),
+    )
+    topology.put_entity(
+        PRODUCT, entity("a", properties={"qualified_name": "moved.a"})
+    )
+    topology.put_relationship(
+        PRODUCT,
+        TopologyRelationship("edge", "a", "c", "depends_on", "approved"),
+    )
+
+    result = topology.traverse(TopologyTraversal(PRODUCT, ("a",), depth=1))
+
+    assert [item.id for item in result.entities] == ["a", "c"]
+    assert result.entities[0].properties == {"qualified_name": "moved.a"}
+    assert [relationship.target_id for relationship in result.relationships] == [
+        "c"
+    ]
+
+
+def test_topology_rejects_cross_scope_relationships():
+    topology = InMemoryTopologyRepository()
+    topology.put_entity(PRODUCT, entity("a"))
+    topology.put_entity(OTHER_PRODUCT, entity("b"))
+
+    with pytest.raises(ValueError, match="same scope"):
+        topology.put_relationship(
+            PRODUCT,
+            TopologyRelationship("edge", "a", "b", "depends_on", "approved"),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("depth", 4, "depth must be between 1 and 3"),
+        ("minimum_confidence", 1.1, "minimum_confidence must be between 0 and 1"),
+        ("entity_limit", 51, "entity_limit must be between 1 and 50"),
+        (
+            "relationship_limit",
+            501,
+            "relationship_limit must be between 1 and 500",
+        ),
+        ("direction", "sideways", "direction must be outbound, inbound, or both"),
+    ],
+)
+def test_topology_traversal_rejects_unbounded_inputs(field, value, message):
+    arguments = {"scope": PRODUCT, "entity_ids": ("a",), field: value}
+
+    with pytest.raises(ValueError, match=message):
+        TopologyTraversal(**arguments)

--- a/src/tests/unit/test_core_topology.py
+++ b/src/tests/unit/test_core_topology.py
@@ -155,16 +155,31 @@ def test_topology_updates_preserve_identity_and_replace_duplicate_edges():
     assert [relationship.target_id for relationship in result.relationships] == ["c"]
 
 
-def test_topology_rejects_cross_scope_relationships():
+def test_topology_identifies_missing_relationship_endpoint():
     topology = InMemoryTopologyRepository()
     topology.put_entity(PRODUCT, entity("a"))
     topology.put_entity(OTHER_PRODUCT, entity("b"))
 
-    with pytest.raises(ValueError, match="same scope"):
+    with pytest.raises(ValueError, match="target entity 'b' does not exist in scope"):
         topology.put_relationship(
             PRODUCT,
             TopologyRelationship("edge", "a", "b", "depends_on", "approved"),
         )
+
+
+def test_topology_rejects_empty_identifiers():
+    with pytest.raises(ValueError, match="evidence id cannot be empty"):
+        TopologyEvidence("", "contract_test", "build")
+    with pytest.raises(ValueError, match="entity id cannot be empty"):
+        entity("")
+    with pytest.raises(ValueError, match="relationship id cannot be empty"):
+        TopologyRelationship("", "a", "b", "depends_on", "approved")
+    with pytest.raises(ValueError, match="relationship source_id cannot be empty"):
+        TopologyRelationship("edge", "", "b", "depends_on", "approved")
+    with pytest.raises(ValueError, match="relationship target_id cannot be empty"):
+        TopologyRelationship("edge", "a", "", "depends_on", "approved")
+    with pytest.raises(ValueError, match="entity_ids cannot contain empty values"):
+        TopologyTraversal(PRODUCT, ("",))
 
 
 @pytest.mark.parametrize(

--- a/src/tests/unit/test_core_topology.py
+++ b/src/tests/unit/test_core_topology.py
@@ -39,15 +39,11 @@ def test_topology_traversal_is_bounded_filtered_and_scope_isolated():
     )
     topology.put_relationship(
         PRODUCT,
-        TopologyRelationship(
-            "api-contract", "api", "contract", "provides", "approved"
-        ),
+        TopologyRelationship("api-contract", "api", "contract", "provides", "approved"),
     )
     topology.put_relationship(
         PRODUCT,
-        TopologyRelationship(
-            "api-release", "api", "release", "released_as", "pending"
-        ),
+        TopologyRelationship("api-release", "api", "release", "released_as", "pending"),
     )
 
     result = topology.traverse(
@@ -109,9 +105,7 @@ def test_topology_traversal_handles_cycles_directions_and_limits():
 
 def test_topology_filters_confidence_lifecycle_and_stale_evidence():
     topology = InMemoryTopologyRepository()
-    evidence = TopologyEvidence(
-        "verification", "contract_test", "build", "abc123"
-    )
+    evidence = TopologyEvidence("verification", "contract_test", "build", "abc123")
     topology.put_entity(PRODUCT, entity("source", evidence=(evidence,)))
     topology.put_entity(PRODUCT, entity("trusted", confidence=0.9))
     topology.put_entity(PRODUCT, entity("uncertain", confidence=0.4))
@@ -148,9 +142,7 @@ def test_topology_updates_preserve_identity_and_replace_duplicate_edges():
         PRODUCT,
         TopologyRelationship("edge", "a", "b", "depends_on", "approved"),
     )
-    topology.put_entity(
-        PRODUCT, entity("a", properties={"qualified_name": "moved.a"})
-    )
+    topology.put_entity(PRODUCT, entity("a", properties={"qualified_name": "moved.a"}))
     topology.put_relationship(
         PRODUCT,
         TopologyRelationship("edge", "a", "c", "depends_on", "approved"),
@@ -160,9 +152,7 @@ def test_topology_updates_preserve_identity_and_replace_duplicate_edges():
 
     assert [item.id for item in result.entities] == ["a", "c"]
     assert result.entities[0].properties == {"qualified_name": "moved.a"}
-    assert [relationship.target_id for relationship in result.relationships] == [
-        "c"
-    ]
+    assert [relationship.target_id for relationship in result.relationships] == ["c"]
 
 
 def test_topology_rejects_cross_scope_relationships():


### PR DESCRIPTION
Adds the generic topology contract needed by adapters and review preparation without introducing product authorization, provider payloads, parser choices, or persistence concerns into core. Closes #72.