### PR TITLE
feat(core): Add contract analysis interfaces

### DIFF
--- a/src/core/contracts/__init__.py
+++ b/src/core/contracts/__init__.py
@@ -1,0 +1,39 @@
+from .interfaces import (
+    ContractAdapter,
+    ContractComparator,
+    ContractExtractor,
+    ContractReader,
+    ContractRepository,
+    ContractWriter,
+)
+from .memory import InMemoryContractRepository
+from .models import (
+    ContractChange,
+    ContractComparison,
+    ContractDocument,
+    ContractElement,
+    ContractEvidence,
+    ContractPayload,
+    ContractQuery,
+    ContractResult,
+    ContractSnapshot,
+)
+
+__all__ = [
+    "ContractAdapter",
+    "ContractChange",
+    "ContractComparator",
+    "ContractComparison",
+    "ContractDocument",
+    "ContractElement",
+    "ContractEvidence",
+    "ContractExtractor",
+    "ContractPayload",
+    "ContractQuery",
+    "ContractReader",
+    "ContractRepository",
+    "ContractResult",
+    "ContractSnapshot",
+    "ContractWriter",
+    "InMemoryContractRepository",
+]

--- a/src/core/contracts/interfaces.py
+++ b/src/core/contracts/interfaces.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from src.core.scope import Scope
+
+from .models import (
+    ContractComparison,
+    ContractDocument,
+    ContractPayload,
+    ContractQuery,
+    ContractResult,
+    ContractSnapshot,
+)
+
+
+@runtime_checkable
+class ContractExtractor(Protocol):
+    def supports(self, document: ContractDocument) -> bool: ...
+
+    def extract(self, payload: ContractPayload) -> ContractSnapshot: ...
+
+
+@runtime_checkable
+class ContractComparator(Protocol):
+    def compare(
+        self, before: ContractSnapshot, after: ContractSnapshot
+    ) -> ContractComparison: ...
+
+
+@runtime_checkable
+class ContractAdapter(ContractExtractor, ContractComparator, Protocol):
+    pass
+
+
+@runtime_checkable
+class ContractReader(Protocol):
+    def search(self, query: ContractQuery) -> ContractResult: ...
+
+    def get_snapshot(
+        self, scope: Scope, snapshot_id: str
+    ) -> ContractSnapshot | None: ...
+
+    def get_comparison(
+        self, scope: Scope, comparison_id: str
+    ) -> ContractComparison | None: ...
+
+
+@runtime_checkable
+class ContractWriter(Protocol):
+    def put_snapshot(self, scope: Scope, snapshot: ContractSnapshot) -> None: ...
+
+    def put_comparison(self, scope: Scope, comparison: ContractComparison) -> None: ...
+
+
+@runtime_checkable
+class ContractRepository(ContractReader, ContractWriter, Protocol):
+    pass

--- a/src/core/contracts/memory.py
+++ b/src/core/contracts/memory.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from src.core.scope import Scope
+
+from .models import (
+    ContractComparison,
+    ContractQuery,
+    ContractResult,
+    ContractSnapshot,
+)
+
+
+class InMemoryContractRepository:
+    def __init__(self) -> None:
+        self._snapshots: dict[tuple[Scope, str], ContractSnapshot] = {}
+        self._comparisons: dict[tuple[Scope, str], ContractComparison] = {}
+
+    def put_snapshot(self, scope: Scope, snapshot: ContractSnapshot) -> None:
+        self._snapshots[(scope, snapshot.id)] = snapshot
+
+    def put_comparison(self, scope: Scope, comparison: ContractComparison) -> None:
+        if (scope, comparison.before_snapshot_id) not in self._snapshots:
+            raise ValueError("comparison before snapshot does not exist in scope")
+        if (scope, comparison.after_snapshot_id) not in self._snapshots:
+            raise ValueError("comparison after snapshot does not exist in scope")
+        self._comparisons[(scope, comparison.id)] = comparison
+
+    def search(self, query: ContractQuery) -> ContractResult:
+        matches = sorted(
+            (
+                snapshot
+                for (scope, _), snapshot in self._snapshots.items()
+                if scope == query.scope
+                and (
+                    not query.document_ids or snapshot.document.id in query.document_ids
+                )
+                and (not query.formats or snapshot.document.format in query.formats)
+            ),
+            key=lambda snapshot: snapshot.id,
+        )
+        items = tuple(matches[query.offset : query.offset + query.limit])
+        return ContractResult(
+            items=items,
+            total=len(matches),
+            has_more=query.offset + len(items) < len(matches),
+        )
+
+    def get_snapshot(self, scope: Scope, snapshot_id: str) -> ContractSnapshot | None:
+        return self._snapshots.get((scope, snapshot_id))
+
+    def get_comparison(
+        self, scope: Scope, comparison_id: str
+    ) -> ContractComparison | None:
+        return self._comparisons.get((scope, comparison_id))

--- a/src/core/contracts/models.py
+++ b/src/core/contracts/models.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from src.core.scope import Scope
+
+
+@dataclass(frozen=True)
+class ContractDocument:
+    id: str
+    format: str
+    media_type: str
+    digest: str
+    size: int
+    revision: str = ""
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("contract document id cannot be empty")
+        if not self.format:
+            raise ValueError("contract document format cannot be empty")
+        if not self.media_type:
+            raise ValueError("contract document media_type cannot be empty")
+        algorithm, separator, encoded = self.digest.partition(":")
+        if not separator or not algorithm or not encoded:
+            raise ValueError("contract document digest must be algorithm:value")
+        if self.size < 0:
+            raise ValueError("contract document size cannot be negative")
+
+
+@dataclass(frozen=True)
+class ContractPayload:
+    document: ContractDocument
+    content: bytes
+
+    def __post_init__(self) -> None:
+        if len(self.content) != self.document.size:
+            raise ValueError("contract payload size does not match its document")
+
+
+@dataclass(frozen=True)
+class ContractElement:
+    id: str
+    kind: str
+    name: str
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("contract element id cannot be empty")
+        if not self.kind:
+            raise ValueError("contract element kind cannot be empty")
+
+
+@dataclass(frozen=True)
+class ContractSnapshot:
+    id: str
+    document: ContractDocument
+    elements: tuple[ContractElement, ...]
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("contract snapshot id cannot be empty")
+        element_ids = [element.id for element in self.elements]
+        if len(element_ids) != len(set(element_ids)):
+            raise ValueError("contract snapshot element ids must be unique")
+
+
+@dataclass(frozen=True)
+class ContractEvidence:
+    id: str
+    kind: str
+    source: str
+    revision: str = ""
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("contract evidence id cannot be empty")
+
+
+@dataclass(frozen=True)
+class ContractChange:
+    id: str
+    classification: str
+    severity: str
+    summary: str
+    before_element_id: str | None = None
+    after_element_id: str | None = None
+    confidence: float = 1.0
+    evidence: tuple[ContractEvidence, ...] = ()
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("contract change id cannot be empty")
+        if not self.classification:
+            raise ValueError("contract change classification cannot be empty")
+        if not self.severity:
+            raise ValueError("contract change severity cannot be empty")
+        if self.before_element_id is None and self.after_element_id is None:
+            raise ValueError("contract change must identify an affected element")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("contract change confidence must be between 0 and 1")
+
+
+@dataclass(frozen=True)
+class ContractComparison:
+    id: str
+    before_snapshot_id: str
+    after_snapshot_id: str
+    compatible: bool
+    changes: tuple[ContractChange, ...] = ()
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("contract comparison id cannot be empty")
+        if not self.before_snapshot_id:
+            raise ValueError("comparison before_snapshot_id cannot be empty")
+        if not self.after_snapshot_id:
+            raise ValueError("comparison after_snapshot_id cannot be empty")
+        change_ids = [change.id for change in self.changes]
+        if len(change_ids) != len(set(change_ids)):
+            raise ValueError("contract comparison change ids must be unique")
+
+
+@dataclass(frozen=True)
+class ContractQuery:
+    scope: Scope
+    document_ids: frozenset[str] = field(default_factory=frozenset)
+    formats: frozenset[str] = field(default_factory=frozenset)
+    limit: int = 50
+    offset: int = 0
+
+    def __post_init__(self) -> None:
+        if not 1 <= self.limit <= 100:
+            raise ValueError("limit must be between 1 and 100")
+        if self.offset < 0:
+            raise ValueError("offset must not be negative")
+
+
+@dataclass(frozen=True)
+class ContractResult:
+    items: tuple[ContractSnapshot, ...]
+    total: int
+    has_more: bool

--- a/src/tests/unit/test_core_contracts.py
+++ b/src/tests/unit/test_core_contracts.py
@@ -1,0 +1,186 @@
+import pytest
+
+from src.core.contracts import (
+    ContractAdapter,
+    ContractChange,
+    ContractComparison,
+    ContractDocument,
+    ContractElement,
+    ContractEvidence,
+    ContractPayload,
+    ContractQuery,
+    ContractSnapshot,
+    InMemoryContractRepository,
+)
+from src.core.scope import Scope
+
+PRODUCT = Scope.from_mapping({"boundary": "product"})
+OTHER_PRODUCT = Scope.from_mapping({"boundary": "other"})
+
+
+def document(identifier="checkout", format="openapi", digest="sha256:abc"):
+    return ContractDocument(
+        identifier,
+        format,
+        "application/yaml",
+        digest,
+        3,
+        revision="abc123",
+    )
+
+
+def snapshot(identifier="checkout-v1", contract_document=None, elements=()):
+    return ContractSnapshot(
+        identifier,
+        contract_document or document(),
+        elements,
+    )
+
+
+def test_contract_payload_separates_content_from_immutable_descriptor():
+    descriptor = document()
+
+    payload = ContractPayload(descriptor, b"api")
+
+    assert payload.document.digest == "sha256:abc"
+    assert payload.content == b"api"
+    with pytest.raises(ValueError, match="payload size"):
+        ContractPayload(descriptor, b"wrong")
+
+
+def test_contract_snapshot_requires_stable_unique_element_identities():
+    operation = ContractElement("GET /orders", "operation", "List orders")
+
+    result = snapshot(elements=(operation,))
+
+    assert result.elements == (operation,)
+    with pytest.raises(ValueError, match="element ids must be unique"):
+        snapshot(elements=(operation, operation))
+
+
+def test_in_memory_repository_is_scoped_filtered_and_deterministic():
+    repository = InMemoryContractRepository()
+    openapi_a = snapshot("a", document("checkout", "openapi", "sha256:a"))
+    openapi_b = snapshot("b", document("checkout", "openapi", "sha256:b"))
+    graphql = snapshot("c", document("catalog", "graphql", "sha256:c"))
+    for scope in (PRODUCT, OTHER_PRODUCT):
+        for item in (openapi_b, openapi_a, graphql):
+            repository.put_snapshot(scope, item)
+
+    result = repository.search(
+        ContractQuery(
+            PRODUCT,
+            document_ids=frozenset({"checkout"}),
+            formats=frozenset({"openapi"}),
+            limit=1,
+        )
+    )
+
+    assert result.items == (openapi_a,)
+    assert result.total == 2
+    assert result.has_more is True
+    assert repository.get_snapshot(PRODUCT, "b") == openapi_b
+    assert repository.get_snapshot(Scope(), "b") is None
+
+
+def test_comparison_requires_both_snapshots_in_the_same_scope():
+    repository = InMemoryContractRepository()
+    before = snapshot("before")
+    after = snapshot("after", document(digest="sha256:def"))
+    repository.put_snapshot(PRODUCT, before)
+    repository.put_snapshot(OTHER_PRODUCT, after)
+    comparison = ContractComparison("comparison", "before", "after", True)
+
+    with pytest.raises(ValueError, match="after snapshot"):
+        repository.put_comparison(PRODUCT, comparison)
+
+    repository.put_snapshot(PRODUCT, after)
+    repository.put_comparison(PRODUCT, comparison)
+
+    assert repository.get_comparison(PRODUCT, comparison.id) == comparison
+    assert repository.get_comparison(OTHER_PRODUCT, comparison.id) is None
+
+
+def test_comparison_preserves_deterministic_compatibility_evidence():
+    evidence = ContractEvidence(
+        "parser-output",
+        "contract_diff",
+        "adapter",
+        "v1",
+    )
+    changes = tuple(
+        ContractChange(
+            classification,
+            classification,
+            "error" if classification in {"breaking", "removed"} else "info",
+            classification,
+            before_element_id="old" if classification != "additive" else None,
+            after_element_id="new" if classification != "removed" else None,
+            evidence=(evidence,),
+        )
+        for classification in (
+            "additive",
+            "breaking",
+            "renamed",
+            "removed",
+            "unsupported",
+        )
+    )
+
+    result = ContractComparison("diff", "before", "after", False, changes)
+    unchanged = ContractComparison("same", "before", "after", True)
+
+    assert tuple(change.classification for change in result.changes) == (
+        "additive",
+        "breaking",
+        "renamed",
+        "removed",
+        "unsupported",
+    )
+    assert unchanged.changes == ()
+
+
+def test_contract_adapter_protocol_is_format_neutral():
+    class Adapter:
+        def supports(self, contract_document):
+            return contract_document.format == "example"
+
+        def extract(self, payload):
+            return snapshot(contract_document=payload.document)
+
+        def compare(self, before, after):
+            return ContractComparison("diff", before.id, after.id, True)
+
+    assert isinstance(Adapter(), ContractAdapter)
+
+
+@pytest.mark.parametrize(
+    ("factory", "message"),
+    [
+        (lambda: document(identifier=""), "document id cannot be empty"),
+        (lambda: document(format=""), "document format cannot be empty"),
+        (lambda: document(digest="abc"), "digest must be algorithm:value"),
+        (
+            lambda: ContractElement("", "operation", "List orders"),
+            "element id cannot be empty",
+        ),
+        (
+            lambda: ContractChange("change", "removed", "error", "Removed"),
+            "identify an affected element",
+        ),
+        (
+            lambda: ContractChange(
+                "change",
+                "removed",
+                "error",
+                "Removed",
+                before_element_id="old",
+                confidence=1.1,
+            ),
+            "confidence must be between 0 and 1",
+        ),
+    ],
+)
+def test_contract_models_reject_invalid_boundaries(factory, message):
+    with pytest.raises(ValueError, match=message):
+        factory()


### PR DESCRIPTION
Adds format-neutral contract extraction, comparison, and persistence contracts so adapters can produce deterministic compatibility evidence without coupling core to a schema language or storage engine.

Closes #77