### PR TITLE
feat(core): Process versioned contract evidence

### DIFF
--- a/src/core/contracts/__init__.py
+++ b/src/core/contracts/__init__.py
@@ -2,6 +2,7 @@ from .interfaces import (
     ContractAdapter,
     ContractComparator,
     ContractExtractor,
+    ContractProcessor,
     ContractReader,
     ContractRepository,
     ContractWriter,
@@ -14,12 +15,19 @@ from .models import (
     ContractElement,
     ContractEvidence,
     ContractPayload,
+    ContractProcessingResult,
     ContractQuery,
     ContractResult,
     ContractSnapshot,
 )
+from .processor import (
+    AmbiguousContractAdapterError,
+    DefaultContractProcessor,
+    UnsupportedContractFormatError,
+)
 
 __all__ = [
+    "AmbiguousContractAdapterError",
     "ContractAdapter",
     "ContractChange",
     "ContractComparator",
@@ -29,11 +37,15 @@ __all__ = [
     "ContractEvidence",
     "ContractExtractor",
     "ContractPayload",
+    "ContractProcessingResult",
+    "ContractProcessor",
     "ContractQuery",
     "ContractReader",
     "ContractRepository",
     "ContractResult",
     "ContractSnapshot",
     "ContractWriter",
+    "DefaultContractProcessor",
     "InMemoryContractRepository",
+    "UnsupportedContractFormatError",
 ]

--- a/src/core/contracts/interfaces.py
+++ b/src/core/contracts/interfaces.py
@@ -8,6 +8,7 @@ from .models import (
     ContractComparison,
     ContractDocument,
     ContractPayload,
+    ContractProcessingResult,
     ContractQuery,
     ContractResult,
     ContractSnapshot,
@@ -56,3 +57,13 @@ class ContractWriter(Protocol):
 @runtime_checkable
 class ContractRepository(ContractReader, ContractWriter, Protocol):
     pass
+
+
+@runtime_checkable
+class ContractProcessor(Protocol):
+    def process(
+        self,
+        scope: Scope,
+        payload: ContractPayload,
+        baseline_snapshot_id: str | None = None,
+    ) -> ContractProcessingResult: ...

--- a/src/core/contracts/models.py
+++ b/src/core/contracts/models.py
@@ -148,3 +148,16 @@ class ContractResult:
     items: tuple[ContractSnapshot, ...]
     total: int
     has_more: bool
+
+
+@dataclass(frozen=True)
+class ContractProcessingResult:
+    snapshot: ContractSnapshot
+    comparison: ContractComparison | None = None
+
+    def __post_init__(self) -> None:
+        if (
+            self.comparison is not None
+            and self.comparison.after_snapshot_id != self.snapshot.id
+        ):
+            raise ValueError("comparison must target the processed snapshot")

--- a/src/core/contracts/processor.py
+++ b/src/core/contracts/processor.py
@@ -32,9 +32,7 @@ class DefaultContractProcessor:
         baseline_snapshot_id: str | None = None,
     ) -> ContractProcessingResult:
         adapters = tuple(
-            adapter
-            for adapter in self._adapters
-            if adapter.supports(payload.document)
+            adapter for adapter in self._adapters if adapter.supports(payload.document)
         )
         if not adapters:
             raise UnsupportedContractFormatError(

--- a/src/core/contracts/processor.py
+++ b/src/core/contracts/processor.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from src.core.scope import Scope
+
+from .interfaces import ContractAdapter, ContractRepository
+from .models import ContractPayload, ContractProcessingResult
+
+
+class UnsupportedContractFormatError(ValueError):
+    pass
+
+
+class AmbiguousContractAdapterError(ValueError):
+    pass
+
+
+class DefaultContractProcessor:
+    def __init__(
+        self,
+        adapters: Sequence[ContractAdapter],
+        repository: ContractRepository,
+    ) -> None:
+        self._adapters = tuple(adapters)
+        self._repository = repository
+
+    def process(
+        self,
+        scope: Scope,
+        payload: ContractPayload,
+        baseline_snapshot_id: str | None = None,
+    ) -> ContractProcessingResult:
+        adapters = tuple(
+            adapter
+            for adapter in self._adapters
+            if adapter.supports(payload.document)
+        )
+        if not adapters:
+            raise UnsupportedContractFormatError(
+                f"no contract adapter supports {payload.document.format}"
+            )
+        if len(adapters) > 1:
+            raise AmbiguousContractAdapterError(
+                f"multiple contract adapters support {payload.document.format}"
+            )
+
+        adapter = adapters[0]
+        snapshot = adapter.extract(payload)
+        if baseline_snapshot_id == snapshot.id:
+            self._repository.put_snapshot(scope, snapshot)
+            return ContractProcessingResult(snapshot)
+
+        comparison = None
+        if baseline_snapshot_id is not None:
+            baseline = self._repository.get_snapshot(scope, baseline_snapshot_id)
+            if baseline is None:
+                raise ValueError("baseline snapshot does not exist in scope")
+            comparison = adapter.compare(baseline, snapshot)
+
+        self._repository.put_snapshot(scope, snapshot)
+        if comparison is not None:
+            self._repository.put_comparison(scope, comparison)
+        return ContractProcessingResult(snapshot, comparison)

--- a/src/tests/unit/test_core_contracts.py
+++ b/src/tests/unit/test_core_contracts.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.core.contracts import (
+    AmbiguousContractAdapterError,
     ContractAdapter,
     ContractChange,
     ContractComparison,
@@ -8,9 +9,13 @@ from src.core.contracts import (
     ContractElement,
     ContractEvidence,
     ContractPayload,
+    ContractProcessingResult,
+    ContractProcessor,
     ContractQuery,
     ContractSnapshot,
+    DefaultContractProcessor,
     InMemoryContractRepository,
+    UnsupportedContractFormatError,
 )
 from src.core.scope import Scope
 
@@ -152,6 +157,107 @@ def test_contract_adapter_protocol_is_format_neutral():
             return ContractComparison("diff", before.id, after.id, True)
 
     assert isinstance(Adapter(), ContractAdapter)
+
+
+class ExampleContractAdapter:
+    def supports(self, contract_document):
+        return contract_document.format == "example"
+
+    def extract(self, payload):
+        return snapshot(
+            f"{payload.document.id}@{payload.document.digest}",
+            payload.document,
+        )
+
+    def compare(self, before, after):
+        return ContractComparison(
+            f"{before.id}:{after.id}",
+            before.id,
+            after.id,
+            True,
+        )
+
+
+def test_contract_processor_persists_extraction_and_explicit_baseline_comparison():
+    repository = InMemoryContractRepository()
+    processor = DefaultContractProcessor((ExampleContractAdapter(),), repository)
+    first_document = document(format="example", digest="sha256:first")
+    second_document = document(format="example", digest="sha256:second")
+
+    first = processor.process(PRODUCT, ContractPayload(first_document, b"api"))
+    second = processor.process(
+        PRODUCT,
+        ContractPayload(second_document, b"api"),
+        baseline_snapshot_id=first.snapshot.id,
+    )
+
+    assert first.comparison is None
+    assert repository.get_snapshot(PRODUCT, first.snapshot.id) == first.snapshot
+    assert second.comparison is not None
+    assert second.comparison.before_snapshot_id == first.snapshot.id
+    assert second.comparison.after_snapshot_id == second.snapshot.id
+    assert repository.get_comparison(PRODUCT, second.comparison.id) == (
+        second.comparison
+    )
+    assert isinstance(processor, ContractProcessor)
+
+
+def test_contract_processor_reuses_identical_snapshot_without_comparison():
+    repository = InMemoryContractRepository()
+    processor = DefaultContractProcessor((ExampleContractAdapter(),), repository)
+    descriptor = document(format="example", digest="sha256:same")
+    payload = ContractPayload(descriptor, b"api")
+    first = processor.process(PRODUCT, payload)
+
+    result = processor.process(
+        PRODUCT,
+        payload,
+        baseline_snapshot_id=first.snapshot.id,
+    )
+
+    assert result == ContractProcessingResult(first.snapshot)
+
+
+def test_contract_processor_rejects_missing_scoped_baseline():
+    repository = InMemoryContractRepository()
+    processor = DefaultContractProcessor((ExampleContractAdapter(),), repository)
+    descriptor = document(format="example", digest="sha256:first")
+    baseline = snapshot("baseline", descriptor)
+    repository.put_snapshot(OTHER_PRODUCT, baseline)
+
+    with pytest.raises(ValueError, match="baseline snapshot"):
+        processor.process(
+            PRODUCT,
+            ContractPayload(descriptor, b"api"),
+            baseline_snapshot_id=baseline.id,
+        )
+    processed_id = f"{descriptor.id}@{descriptor.digest}"
+    assert repository.get_snapshot(PRODUCT, processed_id) is None
+
+
+def test_contract_processor_requires_exactly_one_adapter():
+    repository = InMemoryContractRepository()
+    payload = ContractPayload(document(format="unknown"), b"api")
+    unsupported = DefaultContractProcessor((ExampleContractAdapter(),), repository)
+
+    with pytest.raises(UnsupportedContractFormatError, match="no contract adapter"):
+        unsupported.process(PRODUCT, payload)
+
+    example_payload = ContractPayload(document(format="example"), b"api")
+    ambiguous = DefaultContractProcessor(
+        (ExampleContractAdapter(), ExampleContractAdapter()),
+        repository,
+    )
+    with pytest.raises(AmbiguousContractAdapterError, match="multiple contract"):
+        ambiguous.process(PRODUCT, example_payload)
+
+
+def test_contract_processing_result_requires_comparison_to_target_snapshot():
+    processed = snapshot("processed")
+    comparison = ContractComparison("comparison", "before", "other", True)
+
+    with pytest.raises(ValueError, match="processed snapshot"):
+        ContractProcessingResult(processed, comparison)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Extends #77 with deterministic orchestration between contract adapters and storage. Callers choose the baseline explicitly, so processing never infers version order from a backend and scope isolation remains enforced by the repository boundary.

Refs #77