### PR TITLE
fix(core): Support MySQL knowledge migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   </picture>
 </p>
 
-<p align="center"><strong>Open engineering knowledge and context infrastructure.</strong></p>
+<p align="center"><strong>Code knowledge management.</strong></p>
 
 SourceAnt helps engineering tools remember how software works. Its open core models code structure, decisions, rules, system topology, API contracts, and review findings behind storage-neutral interfaces. MCP clients can manage and retrieve that context without requiring the hosted SourceAnt service.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   </picture>
 </p>
 
-<p align="center"><strong>Code knowledge management.</strong></p>
+<p align="center"><strong>Open-source infrastructure for engineering knowledge and context.</strong></p>
 
 SourceAnt helps the agents and humans building your software remember how it works. Its open core models code structure, decisions, rules, system topology, API contracts, and review findings behind storage-neutral interfaces. MCP clients can manage and retrieve that context without requiring the hosted SourceAnt service.
 

--- a/src/core/knowledge/sql.py
+++ b/src/core/knowledge/sql.py
@@ -29,10 +29,11 @@ from .models import (
 )
 
 metadata = MetaData()
+scope_type = Text().with_variant(String(500), "mysql")
 knowledge_table = Table(
     "knowledge",
     metadata,
-    Column("scope", Text, primary_key=True),
+    Column("scope", scope_type, primary_key=True),
     Column("id", String(255), primary_key=True),
     Column("kind", String(255), nullable=False),
     Column("status", String(255), nullable=False),
@@ -42,7 +43,7 @@ knowledge_table = Table(
 relationship_table = Table(
     "knowledge_relationships",
     metadata,
-    Column("scope", Text, primary_key=True),
+    Column("scope", scope_type, primary_key=True),
     Column("id", String(255), primary_key=True),
     Column("source_id", String(255), nullable=False),
     Column("target_id", String(255), nullable=False),

--- a/src/migrations/versions/create_knowledge_tables.py
+++ b/src/migrations/versions/create_knowledge_tables.py
@@ -12,7 +12,11 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.create_table(
         "knowledge",
-        sa.Column("scope", sa.Text(), nullable=False),
+        sa.Column(
+            "scope",
+            sa.Text().with_variant(sa.String(length=500), "mysql"),
+            nullable=False,
+        ),
         sa.Column("id", sa.String(length=255), nullable=False),
         sa.Column("kind", sa.String(length=255), nullable=False),
         sa.Column("status", sa.String(length=255), nullable=False),
@@ -22,7 +26,11 @@ def upgrade() -> None:
     )
     op.create_table(
         "knowledge_relationships",
-        sa.Column("scope", sa.Text(), nullable=False),
+        sa.Column(
+            "scope",
+            sa.Text().with_variant(sa.String(length=500), "mysql"),
+            nullable=False,
+        ),
         sa.Column("id", sa.String(length=255), nullable=False),
         sa.Column("source_id", sa.String(length=255), nullable=False),
         sa.Column("target_id", sa.String(length=255), nullable=False),

--- a/src/tests/unit/test_core_sqlite_knowledge.py
+++ b/src/tests/unit/test_core_sqlite_knowledge.py
@@ -1,4 +1,6 @@
 from sqlalchemy import create_engine
+from sqlalchemy.dialects import mysql, postgresql
+from sqlalchemy.schema import CreateTable
 
 from src.core.knowledge import (
     Knowledge,
@@ -7,10 +9,21 @@ from src.core.knowledge import (
     KnowledgeTraversal,
     SQLKnowledgeRepository,
 )
+from src.core.knowledge.sql import knowledge_table, relationship_table
 from src.core.scope import Scope
 
 PROJECT = Scope.from_mapping({"project": "one"})
 OTHER_PROJECT = Scope.from_mapping({"project": "two"})
+
+
+def test_sql_knowledge_scope_keys_compile_for_supported_databases():
+    mysql_ddl = str(CreateTable(knowledge_table).compile(dialect=mysql.dialect()))
+    postgres_ddl = str(
+        CreateTable(relationship_table).compile(dialect=postgresql.dialect())
+    )
+
+    assert "scope VARCHAR(500) NOT NULL" in mysql_ddl
+    assert "scope TEXT NOT NULL" in postgres_ddl
 
 
 def test_sql_knowledge_survives_restart_and_preserves_scope(tmp_path):

--- a/src/tests/unit/test_core_sqlite_knowledge.py
+++ b/src/tests/unit/test_core_sqlite_knowledge.py
@@ -19,9 +19,7 @@ OTHER_PROJECT = Scope.from_mapping({"project": "two"})
 def test_sql_knowledge_scope_keys_compile_for_supported_databases():
     for table in (knowledge_table, relationship_table):
         mysql_ddl = str(CreateTable(table).compile(dialect=mysql.dialect()))
-        postgres_ddl = str(
-            CreateTable(table).compile(dialect=postgresql.dialect())
-        )
+        postgres_ddl = str(CreateTable(table).compile(dialect=postgresql.dialect()))
 
         assert "scope VARCHAR(500) NOT NULL" in mysql_ddl
         assert "scope TEXT NOT NULL" in postgres_ddl

--- a/src/tests/unit/test_core_sqlite_knowledge.py
+++ b/src/tests/unit/test_core_sqlite_knowledge.py
@@ -17,13 +17,14 @@ OTHER_PROJECT = Scope.from_mapping({"project": "two"})
 
 
 def test_sql_knowledge_scope_keys_compile_for_supported_databases():
-    mysql_ddl = str(CreateTable(knowledge_table).compile(dialect=mysql.dialect()))
-    postgres_ddl = str(
-        CreateTable(relationship_table).compile(dialect=postgresql.dialect())
-    )
+    for table in (knowledge_table, relationship_table):
+        mysql_ddl = str(CreateTable(table).compile(dialect=mysql.dialect()))
+        postgres_ddl = str(
+            CreateTable(table).compile(dialect=postgresql.dialect())
+        )
 
-    assert "scope VARCHAR(500) NOT NULL" in mysql_ddl
-    assert "scope TEXT NOT NULL" in postgres_ddl
+        assert "scope VARCHAR(500) NOT NULL" in mysql_ddl
+        assert "scope TEXT NOT NULL" in postgres_ddl
 
 
 def test_sql_knowledge_survives_restart_and_preserves_scope(tmp_path):


### PR DESCRIPTION
MySQL rejects the knowledge migration because a text scope participates in a composite primary key. Keep PostgreSQL behavior unchanged while using an indexable MySQL representation, allowing plugins to share the migration chain across supported SQL backends.