### PR TITLE
feat(core): Prepare linked software impact

### DIFF
--- a/src/core/review_impact/__init__.py
+++ b/src/core/review_impact/__init__.py
@@ -7,6 +7,7 @@ from .memory import InMemoryCompatibilityEvidenceReader, InMemoryImpactSeedResol
 from .models import (
     ChangedCodeReference,
     CompatibilityEvidence,
+    CompatibilityEvidenceQuery,
     ImpactFinding,
     ReviewImpact,
     ReviewImpactRequest,
@@ -16,6 +17,7 @@ from .preparer import DefaultReviewImpactPreparer
 __all__ = [
     "ChangedCodeReference",
     "CompatibilityEvidence",
+    "CompatibilityEvidenceQuery",
     "CompatibilityEvidenceReader",
     "DefaultReviewImpactPreparer",
     "ImpactFinding",

--- a/src/core/review_impact/__init__.py
+++ b/src/core/review_impact/__init__.py
@@ -1,0 +1,28 @@
+from .interfaces import (
+    CompatibilityEvidenceReader,
+    ImpactSeedResolver,
+    ReviewImpactPreparer,
+)
+from .memory import InMemoryCompatibilityEvidenceReader, InMemoryImpactSeedResolver
+from .models import (
+    ChangedCodeReference,
+    CompatibilityEvidence,
+    ImpactFinding,
+    ReviewImpact,
+    ReviewImpactRequest,
+)
+from .preparer import DefaultReviewImpactPreparer
+
+__all__ = [
+    "ChangedCodeReference",
+    "CompatibilityEvidence",
+    "CompatibilityEvidenceReader",
+    "DefaultReviewImpactPreparer",
+    "ImpactFinding",
+    "ImpactSeedResolver",
+    "InMemoryCompatibilityEvidenceReader",
+    "InMemoryImpactSeedResolver",
+    "ReviewImpact",
+    "ReviewImpactPreparer",
+    "ReviewImpactRequest",
+]

--- a/src/core/review_impact/interfaces.py
+++ b/src/core/review_impact/interfaces.py
@@ -7,6 +7,7 @@ from src.core.scope import Scope
 from .models import (
     ChangedCodeReference,
     CompatibilityEvidence,
+    CompatibilityEvidenceQuery,
     ReviewImpact,
     ReviewImpactRequest,
 )
@@ -22,7 +23,7 @@ class ImpactSeedResolver(Protocol):
 @runtime_checkable
 class CompatibilityEvidenceReader(Protocol):
     def read(
-        self, scope: Scope, entity_ids: frozenset[str], limit: int
+        self, query: CompatibilityEvidenceQuery
     ) -> tuple[CompatibilityEvidence, ...]: ...
 
 

--- a/src/core/review_impact/interfaces.py
+++ b/src/core/review_impact/interfaces.py
@@ -22,6 +22,8 @@ class ImpactSeedResolver(Protocol):
 
 @runtime_checkable
 class CompatibilityEvidenceReader(Protocol):
+    """Read deterministically ordered evidence after filtering, up to the limit."""
+
     def read(
         self, query: CompatibilityEvidenceQuery
     ) -> tuple[CompatibilityEvidence, ...]: ...

--- a/src/core/review_impact/interfaces.py
+++ b/src/core/review_impact/interfaces.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from src.core.scope import Scope
+
+from .models import (
+    ChangedCodeReference,
+    CompatibilityEvidence,
+    ReviewImpact,
+    ReviewImpactRequest,
+)
+
+
+@runtime_checkable
+class ImpactSeedResolver(Protocol):
+    def resolve(
+        self, scope: Scope, changes: tuple[ChangedCodeReference, ...]
+    ) -> tuple[str, ...]: ...
+
+
+@runtime_checkable
+class CompatibilityEvidenceReader(Protocol):
+    def read(
+        self, scope: Scope, entity_ids: frozenset[str], limit: int
+    ) -> tuple[CompatibilityEvidence, ...]: ...
+
+
+@runtime_checkable
+class ReviewImpactPreparer(Protocol):
+    def prepare(self, request: ReviewImpactRequest) -> ReviewImpact: ...

--- a/src/core/review_impact/memory.py
+++ b/src/core/review_impact/memory.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from src.core.scope import Scope
+
+from .models import ChangedCodeReference, CompatibilityEvidence
+
+
+class InMemoryImpactSeedResolver:
+    def __init__(self) -> None:
+        self._mappings: dict[tuple[Scope, str], tuple[str, ...]] = {}
+
+    def put(self, scope: Scope, code_id: str, entity_ids: tuple[str, ...]) -> None:
+        if not code_id or not entity_ids or any(not item for item in entity_ids):
+            raise ValueError("code and topology identities are required")
+        self._mappings[(scope, code_id)] = tuple(sorted(set(entity_ids)))
+
+    def resolve(
+        self, scope: Scope, changes: tuple[ChangedCodeReference, ...]
+    ) -> tuple[str, ...]:
+        return tuple(
+            sorted(
+                {
+                    entity_id
+                    for change in changes
+                    for entity_id in self._mappings.get((scope, change.id), ())
+                }
+            )
+        )
+
+
+class InMemoryCompatibilityEvidenceReader:
+    def __init__(self) -> None:
+        self._items: dict[tuple[Scope, str], CompatibilityEvidence] = {}
+
+    def put(self, scope: Scope, evidence: CompatibilityEvidence) -> None:
+        self._items[(scope, evidence.id)] = evidence
+
+    def read(
+        self, scope: Scope, entity_ids: frozenset[str], limit: int
+    ) -> tuple[CompatibilityEvidence, ...]:
+        matches = sorted(
+            (
+                item
+                for (item_scope, _), item in self._items.items()
+                if item_scope == scope
+                and item.provider_entity_id in entity_ids
+                and item.consumer_entity_id in entity_ids
+            ),
+            key=lambda item: item.id,
+        )
+        return tuple(matches[:limit])

--- a/src/core/review_impact/memory.py
+++ b/src/core/review_impact/memory.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from src.core.scope import Scope
 
-from .models import ChangedCodeReference, CompatibilityEvidence
+from .models import (
+    ChangedCodeReference,
+    CompatibilityEvidence,
+    CompatibilityEvidenceQuery,
+)
 
 
 class InMemoryImpactSeedResolver:
@@ -36,16 +40,19 @@ class InMemoryCompatibilityEvidenceReader:
         self._items[(scope, evidence.id)] = evidence
 
     def read(
-        self, scope: Scope, entity_ids: frozenset[str], limit: int
+        self, query: CompatibilityEvidenceQuery
     ) -> tuple[CompatibilityEvidence, ...]:
         matches = sorted(
             (
                 item
                 for (item_scope, _), item in self._items.items()
-                if item_scope == scope
-                and item.provider_entity_id in entity_ids
-                and item.consumer_entity_id in entity_ids
+                if item_scope == query.scope
+                and item.provider_entity_id in query.entity_ids
+                and item.consumer_entity_id in query.entity_ids
+                and (not query.statuses or item.status in query.statuses)
+                and item.confidence >= query.minimum_confidence
+                and (query.include_stale or not item.stale)
             ),
             key=lambda item: item.id,
         )
-        return tuple(matches[:limit])
+        return tuple(matches[: query.limit])

--- a/src/core/review_impact/models.py
+++ b/src/core/review_impact/models.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from src.core.scope import Scope
+from src.core.topology import TopologyEvidence, TopologySubgraph
+
+
+@dataclass(frozen=True)
+class ChangedCodeReference:
+    id: str
+    kind: str
+    revision: str
+    path: str = ""
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.id or not self.kind or not self.revision:
+            raise ValueError("changed code identity, kind, and revision are required")
+
+
+@dataclass(frozen=True)
+class CompatibilityEvidence:
+    id: str
+    provider_entity_id: str
+    consumer_entity_id: str
+    status: str
+    compatible: bool | None
+    before_revision: str
+    after_revision: str
+    summary: str
+    confidence: float = 1.0
+    stale: bool = False
+    evidence: tuple[TopologyEvidence, ...] = ()
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("compatibility evidence id cannot be empty")
+        if not self.provider_entity_id or not self.consumer_entity_id:
+            raise ValueError("compatibility evidence must identify both endpoints")
+        if not self.before_revision or not self.after_revision:
+            raise ValueError("compatibility evidence must identify compared revisions")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be between 0 and 1")
+
+
+@dataclass(frozen=True)
+class ReviewImpactRequest:
+    scope: Scope
+    changes: tuple[ChangedCodeReference, ...]
+    depth: int = 2
+    entity_limit: int = 50
+    relationship_limit: int = 100
+    minimum_confidence: float = 1.0
+
+    def __post_init__(self) -> None:
+        if not self.changes or len(self.changes) > 100:
+            raise ValueError("changes must contain between 1 and 100 values")
+        change_ids = [change.id for change in self.changes]
+        if len(change_ids) != len(set(change_ids)):
+            raise ValueError("changed code identities must be unique")
+        if not 1 <= self.depth <= 3:
+            raise ValueError("depth must be between 1 and 3")
+        if not 1 <= self.entity_limit <= 50:
+            raise ValueError("entity_limit must be between 1 and 50")
+        if not 1 <= self.relationship_limit <= 500:
+            raise ValueError("relationship_limit must be between 1 and 500")
+        if not 0.0 <= self.minimum_confidence <= 1.0:
+            raise ValueError("minimum_confidence must be between 0 and 1")
+
+
+@dataclass(frozen=True)
+class ImpactFinding:
+    id: str
+    state: str
+    summary: str
+    changed_code_ids: tuple[str, ...]
+    topology_entity_ids: tuple[str, ...]
+    compatibility_evidence_id: str
+    certain: bool
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ReviewImpact:
+    topology: TopologySubgraph
+    compatibility: tuple[CompatibilityEvidence, ...]
+    findings: tuple[ImpactFinding, ...]
+    truncated: bool

--- a/src/core/review_impact/models.py
+++ b/src/core/review_impact/models.py
@@ -82,6 +82,18 @@ class ImpactFinding:
     certain: bool
     properties: Mapping[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        if not self.id or not self.state or not self.summary:
+            raise ValueError("impact finding identity, state, and summary are required")
+        if not self.changed_code_ids or any(not item for item in self.changed_code_ids):
+            raise ValueError("impact finding must identify changed code")
+        if not self.topology_entity_ids or any(
+            not item for item in self.topology_entity_ids
+        ):
+            raise ValueError("impact finding must identify topology entities")
+        if not self.compatibility_evidence_id:
+            raise ValueError("impact finding must identify compatibility evidence")
+
 
 @dataclass(frozen=True)
 class ReviewImpact:

--- a/src/core/review_impact/models.py
+++ b/src/core/review_impact/models.py
@@ -60,8 +60,8 @@ class CompatibilityEvidenceQuery:
             raise ValueError("entity_ids must contain non-empty values")
         if not 0.0 <= self.minimum_confidence <= 1.0:
             raise ValueError("minimum_confidence must be between 0 and 1")
-        if not 1 <= self.limit <= 51:
-            raise ValueError("limit must be between 1 and 51")
+        if self.limit < 1:
+            raise ValueError("limit must be positive")
 
 
 @dataclass(frozen=True)

--- a/src/core/review_impact/models.py
+++ b/src/core/review_impact/models.py
@@ -47,6 +47,24 @@ class CompatibilityEvidence:
 
 
 @dataclass(frozen=True)
+class CompatibilityEvidenceQuery:
+    scope: Scope
+    entity_ids: frozenset[str]
+    statuses: frozenset[str] = field(default_factory=frozenset)
+    minimum_confidence: float = 0.0
+    include_stale: bool = False
+    limit: int = 50
+
+    def __post_init__(self) -> None:
+        if not self.entity_ids or any(not item for item in self.entity_ids):
+            raise ValueError("entity_ids must contain non-empty values")
+        if not 0.0 <= self.minimum_confidence <= 1.0:
+            raise ValueError("minimum_confidence must be between 0 and 1")
+        if not 1 <= self.limit <= 51:
+            raise ValueError("limit must be between 1 and 51")
+
+
+@dataclass(frozen=True)
 class ReviewImpactRequest:
     scope: Scope
     changes: tuple[ChangedCodeReference, ...]

--- a/src/core/review_impact/preparer.py
+++ b/src/core/review_impact/preparer.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from src.core.topology import TopologyReader, TopologySubgraph, TopologyTraversal
 
 from .interfaces import CompatibilityEvidenceReader, ImpactSeedResolver
-from .models import ImpactFinding, ReviewImpact, ReviewImpactRequest
+from .models import (
+    CompatibilityEvidence,
+    ImpactFinding,
+    ReviewImpact,
+    ReviewImpactRequest,
+)
 
 
 class DefaultReviewImpactPreparer:
@@ -61,7 +66,9 @@ class DefaultReviewImpactPreparer:
         )
 
     @staticmethod
-    def _finding(request, evidence):
+    def _finding(
+        request: ReviewImpactRequest, evidence: CompatibilityEvidence
+    ) -> ImpactFinding:
         certain = evidence.compatible is False
         return ImpactFinding(
             id=f"compatibility:{evidence.id}",

--- a/src/core/review_impact/preparer.py
+++ b/src/core/review_impact/preparer.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from src.core.topology import TopologyReader, TopologySubgraph, TopologyTraversal
+
+from .interfaces import CompatibilityEvidenceReader, ImpactSeedResolver
+from .models import ImpactFinding, ReviewImpact, ReviewImpactRequest
+
+
+class DefaultReviewImpactPreparer:
+    def __init__(
+        self,
+        *,
+        seeds: ImpactSeedResolver,
+        topology: TopologyReader,
+        compatibility: CompatibilityEvidenceReader,
+    ) -> None:
+        self._seeds = seeds
+        self._topology = topology
+        self._compatibility = compatibility
+
+    def prepare(self, request: ReviewImpactRequest) -> ReviewImpact:
+        seed_ids = self._seeds.resolve(request.scope, request.changes)
+        if not seed_ids:
+            return ReviewImpact(TopologySubgraph((), (), False), (), (), False)
+        seed_truncated = len(seed_ids) > request.entity_limit
+        seed_ids = seed_ids[: request.entity_limit]
+        topology = self._topology.traverse(
+            TopologyTraversal(
+                request.scope,
+                seed_ids,
+                depth=request.depth,
+                relationship_statuses=frozenset({"approved"}),
+                minimum_confidence=request.minimum_confidence,
+                entity_limit=request.entity_limit,
+                relationship_limit=request.relationship_limit,
+            )
+        )
+        entity_ids = frozenset(entity.id for entity in topology.entities)
+        evidence = self._compatibility.read(
+            request.scope, entity_ids, request.entity_limit + 1
+        )
+        evidence_truncated = len(evidence) > request.entity_limit
+        evidence = evidence[: request.entity_limit]
+        accepted = tuple(
+            item
+            for item in evidence
+            if not item.stale
+            and item.status == "approved"
+            and item.confidence >= request.minimum_confidence
+        )
+        findings = tuple(
+            self._finding(request, item)
+            for item in accepted
+            if item.compatible is not True
+        )
+        return ReviewImpact(
+            topology,
+            accepted,
+            findings,
+            topology.truncated or seed_truncated or evidence_truncated,
+        )
+
+    @staticmethod
+    def _finding(request, evidence):
+        certain = evidence.compatible is False
+        return ImpactFinding(
+            id=f"compatibility:{evidence.id}",
+            state="incompatible" if certain else "uncertain",
+            summary=evidence.summary,
+            changed_code_ids=tuple(change.id for change in request.changes),
+            topology_entity_ids=(
+                evidence.provider_entity_id,
+                evidence.consumer_entity_id,
+            ),
+            compatibility_evidence_id=evidence.id,
+            certain=certain,
+            properties={
+                "after_revision": evidence.after_revision,
+                "before_revision": evidence.before_revision,
+            },
+        )

--- a/src/core/review_impact/preparer.py
+++ b/src/core/review_impact/preparer.py
@@ -5,6 +5,7 @@ from src.core.topology import TopologyReader, TopologySubgraph, TopologyTraversa
 from .interfaces import CompatibilityEvidenceReader, ImpactSeedResolver
 from .models import (
     CompatibilityEvidence,
+    CompatibilityEvidenceQuery,
     ImpactFinding,
     ReviewImpact,
     ReviewImpactRequest,
@@ -42,17 +43,16 @@ class DefaultReviewImpactPreparer:
         )
         entity_ids = frozenset(entity.id for entity in topology.entities)
         evidence = self._compatibility.read(
-            request.scope, entity_ids, request.entity_limit + 1
+            CompatibilityEvidenceQuery(
+                scope=request.scope,
+                entity_ids=entity_ids,
+                statuses=frozenset({"approved"}),
+                minimum_confidence=request.minimum_confidence,
+                limit=request.entity_limit + 1,
+            )
         )
         evidence_truncated = len(evidence) > request.entity_limit
-        evidence = evidence[: request.entity_limit]
-        accepted = tuple(
-            item
-            for item in evidence
-            if not item.stale
-            and item.status == "approved"
-            and item.confidence >= request.minimum_confidence
-        )
+        accepted = evidence[: request.entity_limit]
         findings = tuple(
             self._finding(request, item)
             for item in accepted

--- a/src/core/review_impact/preparer.py
+++ b/src/core/review_impact/preparer.py
@@ -41,6 +41,8 @@ class DefaultReviewImpactPreparer:
                 relationship_limit=request.relationship_limit,
             )
         )
+        if not topology.entities:
+            return ReviewImpact(topology, (), (), topology.truncated or seed_truncated)
         entity_ids = frozenset(entity.id for entity in topology.entities)
         evidence = self._compatibility.read(
             CompatibilityEvidenceQuery(

--- a/src/tests/unit/test_core_review_impact.py
+++ b/src/tests/unit/test_core_review_impact.py
@@ -1,7 +1,10 @@
+import pytest
+
 from src.core.review_impact import (
     ChangedCodeReference,
     CompatibilityEvidence,
     DefaultReviewImpactPreparer,
+    ImpactFinding,
     InMemoryCompatibilityEvidenceReader,
     InMemoryImpactSeedResolver,
     ReviewImpactRequest,
@@ -126,3 +129,8 @@ def test_preserves_scope_and_returns_empty_when_code_has_no_mapping():
     assert result.topology.entities == ()
     assert result.compatibility == ()
     assert result.findings == ()
+
+
+def test_rejects_impact_findings_without_traceable_evidence():
+    with pytest.raises(ValueError, match="must identify changed code"):
+        ImpactFinding("finding", "incompatible", "Failure", (), (), "", True)

--- a/src/tests/unit/test_core_review_impact.py
+++ b/src/tests/unit/test_core_review_impact.py
@@ -119,6 +119,27 @@ def test_ignores_compatible_stale_pending_and_weak_evidence():
     assert result.findings == ()
 
 
+def test_filters_evidence_before_applying_the_result_limit():
+    preparer, seeds, topology, compatibility = build_preparer()
+    add_topology(seeds, topology)
+    for item in (
+        evidence(id="a-stale", stale=True),
+        evidence(id="b-pending", status="pending"),
+        evidence(id="c-weak", confidence=0.5),
+        evidence(id="z-valid"),
+    ):
+        compatibility.put(PRODUCT, item)
+
+    result = preparer.prepare(
+        ReviewImpactRequest(PRODUCT, (CHANGE,), entity_limit=2)
+    )
+
+    assert tuple(item.id for item in result.compatibility) == ("z-valid",)
+    assert tuple(item.compatibility_evidence_id for item in result.findings) == (
+        "z-valid",
+    )
+
+
 def test_preserves_scope_and_returns_empty_when_code_has_no_mapping():
     preparer, seeds, topology, compatibility = build_preparer()
     add_topology(seeds, topology, OTHER)

--- a/src/tests/unit/test_core_review_impact.py
+++ b/src/tests/unit/test_core_review_impact.py
@@ -151,6 +151,17 @@ def test_preserves_scope_and_returns_empty_when_code_has_no_mapping():
     assert result.findings == ()
 
 
+def test_returns_empty_when_mapped_topology_entity_does_not_exist():
+    preparer, seeds, _, _ = build_preparer()
+    seeds.put(PRODUCT, CHANGE.id, ("missing",))
+
+    result = preparer.prepare(ReviewImpactRequest(PRODUCT, (CHANGE,)))
+
+    assert result.topology.entities == ()
+    assert result.compatibility == ()
+    assert result.findings == ()
+
+
 def test_rejects_impact_findings_without_traceable_evidence():
     with pytest.raises(ValueError, match="must identify changed code"):
         ImpactFinding("finding", "incompatible", "Failure", (), (), "", True)

--- a/src/tests/unit/test_core_review_impact.py
+++ b/src/tests/unit/test_core_review_impact.py
@@ -1,0 +1,128 @@
+from src.core.review_impact import (
+    ChangedCodeReference,
+    CompatibilityEvidence,
+    DefaultReviewImpactPreparer,
+    InMemoryCompatibilityEvidenceReader,
+    InMemoryImpactSeedResolver,
+    ReviewImpactRequest,
+)
+from src.core.scope import Scope
+from src.core.topology import (
+    InMemoryTopologyRepository,
+    TopologyEntity,
+    TopologyEvidence,
+    TopologyRelationship,
+)
+
+PRODUCT = Scope.from_mapping({"boundary": "product"})
+OTHER = Scope.from_mapping({"boundary": "other"})
+CHANGE = ChangedCodeReference("checkout.create", "symbol", "provider-2", "api.py")
+PROVENANCE = TopologyEvidence(
+    "comparison-2", "contract_comparison", "openapi", "provider-2"
+)
+
+
+def build_preparer():
+    seeds = InMemoryImpactSeedResolver()
+    topology = InMemoryTopologyRepository()
+    compatibility = InMemoryCompatibilityEvidenceReader()
+    preparer = DefaultReviewImpactPreparer(
+        seeds=seeds,
+        topology=topology,
+        compatibility=compatibility,
+    )
+    return preparer, seeds, topology, compatibility
+
+
+def add_topology(seeds, topology, scope=PRODUCT):
+    seeds.put(scope, CHANGE.id, ("provider",))
+    topology.put_entity(scope, TopologyEntity("provider", "service", "active"))
+    topology.put_entity(scope, TopologyEntity("consumer", "service", "active"))
+    topology.put_relationship(
+        scope,
+        TopologyRelationship(
+            "consumer-provider",
+            "consumer",
+            "provider",
+            "depends_on",
+            "approved",
+            evidence=(PROVENANCE,),
+        ),
+    )
+
+
+def evidence(**values):
+    defaults = {
+        "id": "comparison-2",
+        "provider_entity_id": "provider",
+        "consumer_entity_id": "consumer",
+        "status": "approved",
+        "compatible": False,
+        "before_revision": "provider-1",
+        "after_revision": "provider-2",
+        "summary": "Required response field was removed",
+        "evidence": (PROVENANCE,),
+    }
+    defaults.update(values)
+    return CompatibilityEvidence(**defaults)
+
+
+def test_prepares_deterministic_incompatible_impact_with_provenance():
+    preparer, seeds, topology, compatibility = build_preparer()
+    add_topology(seeds, topology)
+    compatibility.put(PRODUCT, evidence())
+
+    first = preparer.prepare(ReviewImpactRequest(PRODUCT, (CHANGE,)))
+    second = preparer.prepare(ReviewImpactRequest(PRODUCT, (CHANGE,)))
+
+    assert first == second
+    assert tuple(entity.id for entity in first.topology.entities) == (
+        "provider",
+        "consumer",
+    )
+    assert first.findings[0].state == "incompatible"
+    assert first.findings[0].certain is True
+    assert first.findings[0].properties == {
+        "after_revision": "provider-2",
+        "before_revision": "provider-1",
+    }
+
+
+def test_keeps_uncertain_evidence_out_of_certain_findings():
+    preparer, seeds, topology, compatibility = build_preparer()
+    add_topology(seeds, topology)
+    compatibility.put(PRODUCT, evidence(compatible=None))
+
+    result = preparer.prepare(ReviewImpactRequest(PRODUCT, (CHANGE,)))
+
+    assert result.findings[0].state == "uncertain"
+    assert result.findings[0].certain is False
+
+
+def test_ignores_compatible_stale_pending_and_weak_evidence():
+    preparer, seeds, topology, compatibility = build_preparer()
+    add_topology(seeds, topology)
+    for item in (
+        evidence(id="compatible", compatible=True),
+        evidence(id="stale", stale=True),
+        evidence(id="pending", status="pending"),
+        evidence(id="weak", confidence=0.5),
+    ):
+        compatibility.put(PRODUCT, item)
+
+    result = preparer.prepare(ReviewImpactRequest(PRODUCT, (CHANGE,)))
+
+    assert tuple(item.id for item in result.compatibility) == ("compatible",)
+    assert result.findings == ()
+
+
+def test_preserves_scope_and_returns_empty_when_code_has_no_mapping():
+    preparer, seeds, topology, compatibility = build_preparer()
+    add_topology(seeds, topology, OTHER)
+    compatibility.put(OTHER, evidence())
+
+    result = preparer.prepare(ReviewImpactRequest(PRODUCT, (CHANGE,)))
+
+    assert result.topology.entities == ()
+    assert result.compatibility == ()
+    assert result.findings == ()

--- a/src/tests/unit/test_core_review_impact.py
+++ b/src/tests/unit/test_core_review_impact.py
@@ -3,6 +3,7 @@ import pytest
 from src.core.review_impact import (
     ChangedCodeReference,
     CompatibilityEvidence,
+    CompatibilityEvidenceQuery,
     DefaultReviewImpactPreparer,
     ImpactFinding,
     InMemoryCompatibilityEvidenceReader,
@@ -153,3 +154,14 @@ def test_preserves_scope_and_returns_empty_when_code_has_no_mapping():
 def test_rejects_impact_findings_without_traceable_evidence():
     with pytest.raises(ValueError, match="must identify changed code"):
         ImpactFinding("finding", "incompatible", "Failure", (), (), "", True)
+
+
+def test_compatibility_query_accepts_limits_independent_of_review_defaults():
+    query = CompatibilityEvidenceQuery(PRODUCT, frozenset({"provider"}), limit=500)
+
+    assert query.limit == 500
+
+
+def test_compatibility_query_requires_a_positive_limit():
+    with pytest.raises(ValueError, match="limit must be positive"):
+        CompatibilityEvidenceQuery(PRODUCT, frozenset({"provider"}), limit=0)

--- a/src/tests/unit/test_core_review_impact.py
+++ b/src/tests/unit/test_core_review_impact.py
@@ -130,9 +130,7 @@ def test_filters_evidence_before_applying_the_result_limit():
     ):
         compatibility.put(PRODUCT, item)
 
-    result = preparer.prepare(
-        ReviewImpactRequest(PRODUCT, (CHANGE,), entity_limit=2)
-    )
+    result = preparer.prepare(ReviewImpactRequest(PRODUCT, (CHANGE,), entity_limit=2))
 
     assert tuple(item.id for item in result.compatibility) == ("z-valid",)
     assert tuple(item.compatibility_evidence_id for item in result.findings) == (


### PR DESCRIPTION
Core has topology and contract models, but no deterministic boundary for turning changed code into linked software impact. This adds storage-neutral review preparation so adapters can supply mappings and compatibility evidence without introducing provider or authorization concerns.

Uncertain evidence remains explicitly non-certain and cannot be treated as a confirmed compatibility failure.

Refs #73