### PR TITLE
feat(core): Filter code index by identity

### DIFF
--- a/src/core/code_index/memory.py
+++ b/src/core/code_index/memory.py
@@ -51,12 +51,14 @@ class InMemoryCodeIndex:
             node
             for (scope, _), node in self._nodes.items()
             if scope == query.scope
+            and (not query.node_ids or node.id in query.node_ids)
             and query.labels.issubset(node.labels)
             and all(
                 node.properties.get(key) == value
                 for key, value in query.properties.items()
             )
         ]
+        matches.sort(key=lambda node: node.id)
         nodes = tuple(matches[query.offset : query.offset + query.limit])
         return CodeSearchResult(
             nodes=nodes,

--- a/src/core/code_index/memory.py
+++ b/src/core/code_index/memory.py
@@ -53,9 +53,7 @@ class InMemoryCodeIndex:
             )
         else:
             candidates = (
-                node
-                for (scope, _), node in self._nodes.items()
-                if scope == query.scope
+                node for (scope, _), node in self._nodes.items() if scope == query.scope
             )
         matches = [
             node

--- a/src/core/code_index/memory.py
+++ b/src/core/code_index/memory.py
@@ -47,11 +47,20 @@ class InMemoryCodeIndex:
                 del self._edges[key]
 
     def search(self, query: CodeSearch) -> CodeSearchResult:
+        if query.node_ids:
+            candidates = (
+                self._nodes.get((query.scope, node_id)) for node_id in query.node_ids
+            )
+        else:
+            candidates = (
+                node
+                for (scope, _), node in self._nodes.items()
+                if scope == query.scope
+            )
         matches = [
             node
-            for (scope, _), node in self._nodes.items()
-            if scope == query.scope
-            and (not query.node_ids or node.id in query.node_ids)
+            for node in candidates
+            if node is not None
             and query.labels.issubset(node.labels)
             and all(
                 node.properties.get(key) == value

--- a/src/core/code_index/models.py
+++ b/src/core/code_index/models.py
@@ -51,8 +51,11 @@ class CodeSearch:
     properties: Mapping[str, Any] = field(default_factory=dict)
     limit: int = 50
     offset: int = 0
+    node_ids: frozenset[str] = field(default_factory=frozenset)
 
     def __post_init__(self) -> None:
+        if len(self.node_ids) > 100 or any(not node_id for node_id in self.node_ids):
+            raise ValueError("node_ids must contain at most 100 non-empty values")
         if not 1 <= self.limit <= 100:
             raise ValueError("limit must be between 1 and 100")
         if self.offset < 0:

--- a/src/tests/unit/test_core_memory_services.py
+++ b/src/tests/unit/test_core_memory_services.py
@@ -86,9 +86,7 @@ def test_code_index_searches_exact_node_identities():
     index.put_node(PROJECT, code_node("two"))
     index.put_node(OTHER_PROJECT, code_node("two"))
 
-    result = index.search(
-        CodeSearch(PROJECT, node_ids=frozenset({"two", "missing"}))
-    )
+    result = index.search(CodeSearch(PROJECT, node_ids=frozenset({"two", "missing"})))
 
     assert [node.id for node in result.nodes] == ["two"]
     assert result.total == 1

--- a/src/tests/unit/test_core_memory_services.py
+++ b/src/tests/unit/test_core_memory_services.py
@@ -80,6 +80,26 @@ def test_code_index_searches_open_labels_properties_and_pages():
     assert result.has_more is True
 
 
+def test_code_index_searches_exact_node_identities():
+    index = InMemoryCodeIndex()
+    index.put_node(PROJECT, code_node("one"))
+    index.put_node(PROJECT, code_node("two"))
+    index.put_node(OTHER_PROJECT, code_node("two"))
+
+    result = index.search(
+        CodeSearch(PROJECT, node_ids=frozenset({"two", "missing"}))
+    )
+
+    assert [node.id for node in result.nodes] == ["two"]
+    assert result.total == 1
+    assert result.has_more is False
+
+
+def test_code_index_rejects_invalid_identity_filters():
+    with pytest.raises(ValueError, match="at most 100 non-empty"):
+        CodeSearch(PROJECT, node_ids=frozenset({""}))
+
+
 def test_code_index_traverses_cycles_with_limits():
     index = InMemoryCodeIndex()
     for identifier in ("a", "b", "c"):


### PR DESCRIPTION
Review-impact mapping must confirm structural identities without scanning the complete code graph. This adds a bounded exact-identity filter to the storage-neutral code-index query while preserving existing query compatibility.

Refs #73