### PR TITLE
feat(core): Add opaque scope resolution

### DIFF
--- a/src/core/scope.py
+++ b/src/core/scope.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Mapping
+from typing import Mapping, Protocol, runtime_checkable
 
 
 @dataclass(frozen=True)
@@ -27,3 +27,66 @@ class Scope:
         combined = dict(self.values)
         combined.update(values)
         return self.from_mapping(combined)
+
+
+@dataclass(frozen=True)
+class ScopeReference:
+    kind: str
+    id: str
+    qualifiers: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.kind or not self.id:
+            raise ValueError("scope reference kind and identity must not be empty")
+        keys = [key for key, _ in self.qualifiers]
+        if len(keys) != len(set(keys)):
+            raise ValueError("scope reference qualifier keys must be unique")
+        if any(not key or not value for key, value in self.qualifiers):
+            raise ValueError("scope reference qualifiers must not be empty")
+        object.__setattr__(self, "qualifiers", tuple(sorted(self.qualifiers)))
+
+    @classmethod
+    def from_mapping(
+        cls,
+        kind: str,
+        id: str,
+        qualifiers: Mapping[str, str],
+    ) -> "ScopeReference":
+        return cls(kind, id, tuple(sorted(qualifiers.items())))
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return dict(self.qualifiers).get(key, default)
+
+
+@runtime_checkable
+class ScopeResolver(Protocol):
+    def resolve(self, reference: ScopeReference) -> Scope | None: ...
+
+
+@runtime_checkable
+class ScopeBindingWriter(Protocol):
+    def bind(self, reference: ScopeReference, scope: Scope) -> None: ...
+
+    def unbind(self, reference: ScopeReference) -> None: ...
+
+
+@runtime_checkable
+class ScopeRepository(ScopeResolver, ScopeBindingWriter, Protocol):
+    pass
+
+
+class InMemoryScopeRepository:
+    def __init__(
+        self,
+        bindings: Mapping[ScopeReference, Scope] | None = None,
+    ) -> None:
+        self._bindings = dict(bindings or {})
+
+    def resolve(self, reference: ScopeReference) -> Scope | None:
+        return self._bindings.get(reference)
+
+    def bind(self, reference: ScopeReference, scope: Scope) -> None:
+        self._bindings[reference] = scope
+
+    def unbind(self, reference: ScopeReference) -> None:
+        self._bindings.pop(reference, None)

--- a/src/core/scope.py
+++ b/src/core/scope.py
@@ -18,10 +18,13 @@ class Scope:
 
     @classmethod
     def from_mapping(cls, values: Mapping[str, str]) -> "Scope":
-        return cls(tuple(sorted(values.items())))
+        return cls(tuple(values.items()))
 
     def get(self, key: str, default: str | None = None) -> str | None:
-        return dict(self.values).get(key, default)
+        for candidate, value in self.values:
+            if candidate == key:
+                return value
+        return default
 
     def extend(self, values: Mapping[str, str]) -> "Scope":
         combined = dict(self.values)
@@ -52,10 +55,13 @@ class ScopeReference:
         id: str,
         qualifiers: Mapping[str, str],
     ) -> "ScopeReference":
-        return cls(kind, id, tuple(sorted(qualifiers.items())))
+        return cls(kind, id, tuple(qualifiers.items()))
 
     def get(self, key: str, default: str | None = None) -> str | None:
-        return dict(self.qualifiers).get(key, default)
+        for candidate, value in self.qualifiers:
+            if candidate == key:
+                return value
+        return default
 
 
 @runtime_checkable

--- a/src/tests/unit/test_core_scope.py
+++ b/src/tests/unit/test_core_scope.py
@@ -1,0 +1,74 @@
+import pytest
+
+from src.core.scope import (
+    InMemoryScopeRepository,
+    Scope,
+    ScopeReference,
+    ScopeRepository,
+    ScopeResolver,
+)
+
+PRODUCT = Scope.from_mapping({"boundary": "product"})
+OTHER_PRODUCT = Scope.from_mapping({"boundary": "other"})
+
+
+def test_scope_reference_is_order_independent():
+    first = ScopeReference.from_mapping(
+        "repository",
+        "123",
+        {"provider": "github", "owner": "sourceant"},
+    )
+    second = ScopeReference(
+        "repository",
+        "123",
+        (("owner", "sourceant"), ("provider", "github")),
+    )
+
+    assert first == second
+    assert first.get("provider") == "github"
+
+
+def test_scope_reference_rejects_invalid_identity_and_qualifiers():
+    with pytest.raises(ValueError, match="kind and identity"):
+        ScopeReference("", "123")
+    with pytest.raises(ValueError, match="qualifier keys"):
+        ScopeReference(
+            "repository",
+            "123",
+            (("provider", "github"), ("provider", "gitlab")),
+        )
+
+
+def test_scope_repository_binds_replaces_and_removes_references():
+    reference = ScopeReference("repository", "123")
+    repository = InMemoryScopeRepository()
+
+    assert isinstance(repository, ScopeResolver)
+    assert isinstance(repository, ScopeRepository)
+    assert repository.resolve(reference) is None
+
+    repository.bind(reference, PRODUCT)
+    assert repository.resolve(reference) == PRODUCT
+
+    repository.bind(reference, OTHER_PRODUCT)
+    assert repository.resolve(reference) == OTHER_PRODUCT
+
+    repository.unbind(reference)
+    assert repository.resolve(reference) is None
+
+
+def test_scope_repository_keeps_references_isolated():
+    first = ScopeReference.from_mapping(
+        "repository",
+        "123",
+        {"provider": "github"},
+    )
+    second = ScopeReference.from_mapping(
+        "repository",
+        "123",
+        {"provider": "gitlab"},
+    )
+    repository = InMemoryScopeRepository({first: PRODUCT, second: OTHER_PRODUCT})
+
+    assert repository.resolve(first) == PRODUCT
+    assert repository.resolve(second) == OTHER_PRODUCT


### PR DESCRIPTION
Linked-software review needs its active scope selected outside the review engine. Opaque reference lookup lets a hosting application bind repository identities to arbitrary scopes while core remains unaware of organization or authorization models. The in-memory repository keeps this boundary usable in community deployments and tests.

Refs #73