### PR TITLE
feat(api): Expose reviews and triage, and run reviews on demand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ docker-compose.override.yml
 # External plugins (only builtin plugins are tracked)
 src/plugins/*/
 !src/plugins/builtin/
+.memory-data/

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -60,9 +60,13 @@ app = FastAPI(
 )
 
 from src.api.routes import repos as repo_endpoints
+from src.api.routes import reviews as review_endpoints
+from src.api.routes import triage as triage_endpoints
 
 app.include_router(app_endpoints.router, tags=["general"])
 app.include_router(pr_endpoints.router, prefix="/api/prs", tags=["pull_requests"])
 app.include_router(repo_endpoints.router, prefix="/api/repos", tags=["repositories"])
+app.include_router(review_endpoints.router, prefix="/api/reviews", tags=["reviews"])
+app.include_router(triage_endpoints.router, prefix="/api/triage", tags=["triage"])
 if mcp_http_app is not None:
     app.mount("/mcp", mcp_http_app)

--- a/src/api/routes/reviews.py
+++ b/src/api/routes/reviews.py
@@ -1,5 +1,6 @@
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 from sqlmodel import Session, select
 
 from src.auth import get_current_user
@@ -10,6 +11,75 @@ from src.models.review_record import ReviewRecord
 router = APIRouter()
 
 _GITHUB_API = "https://api.github.com"
+
+
+class RerunRequest(BaseModel):
+    repo: str
+    number: int
+    # Preview by default: generate the review and return it without posting.
+    post: bool = False
+
+
+@router.post("/rerun")
+async def rerun_review(
+    data: RerunRequest,
+    user: dict = Depends(get_current_user),
+):
+    """Re-run the reviewer for a pull request; preview to the dashboard or post to GitHub."""
+    from src.core.plugins.plugin_registry import plugin_registry
+    from src.models.pull_request import PullRequest
+    from src.models.repository import Repository
+
+    github_token = user.get("github_token")
+    if not github_token:
+        raise HTTPException(status_code=400, detail="No GitHub token available")
+
+    owner, _, name = data.repo.partition("/")
+    if not owner or not name:
+        raise HTTPException(status_code=400, detail="Invalid repository name")
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        pr_resp = await client.get(
+            f"{_GITHUB_API}/repos/{data.repo}/pulls/{data.number}",
+            headers={
+                "Authorization": f"token {github_token}",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+    if pr_resp.status_code != 200:
+        raise HTTPException(status_code=502, detail="Could not load the pull request")
+    pr = pr_resp.json()
+
+    plugin = plugin_registry.get_plugin("code_reviewer")
+    if plugin is None:
+        raise HTTPException(status_code=503, detail="Reviewer is not available")
+
+    repository = Repository(name=name, owner=owner)
+    pull_request = PullRequest(
+        number=pr["number"],
+        title=pr.get("title"),
+        draft=pr.get("draft", False),
+        merged=pr.get("merged", False),
+        base_sha=(pr.get("base") or {}).get("sha"),
+        head_sha=(pr.get("head") or {}).get("sha"),
+    )
+    pr_metadata = {
+        "title": pr.get("title"),
+        "description": pr.get("body"),
+        "number": pr["number"],
+        "base_ref": (pr.get("base") or {}).get("ref"),
+        "head_ref": (pr.get("head") or {}).get("ref"),
+    }
+
+    result = await plugin._generate_and_post_review(
+        repository,
+        pull_request,
+        pr_metadata=pr_metadata,
+        event_type=None,
+        repository_full_name=data.repo,
+        post=data.post,
+    )
+    return success_response(result)
 
 
 async def _fetch_pull_request(

--- a/src/api/routes/reviews.py
+++ b/src/api/routes/reviews.py
@@ -1,0 +1,72 @@
+import httpx
+from fastapi import APIRouter, Depends, Query
+from sqlmodel import Session, select
+
+from src.auth import get_current_user
+from src.config.db import get_session
+from src.core.responses import success_response
+from src.models.review_record import ReviewRecord
+
+router = APIRouter()
+
+_GITHUB_API = "https://api.github.com"
+
+
+async def _fetch_pull_request(
+    client: httpx.AsyncClient, repo: str, number: int, token: str | None
+) -> dict | None:
+    if not token:
+        return None
+    try:
+        resp = await client.get(
+            f"{_GITHUB_API}/repos/{repo}/pulls/{number}",
+            headers={
+                "Authorization": f"token {token}",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+    except httpx.HTTPError:
+        return None
+    return resp.json() if resp.status_code == 200 else None
+
+
+@router.get("")
+async def list_reviews(
+    repo: str = Query(..., description="Repository full name, e.g. owner/name"),
+    session: Session = Depends(get_session),
+    user: dict = Depends(get_current_user),
+):
+    """List SourceAnt's reviews for a repository, enriched with live GitHub PR state."""
+    github_token = user.get("github_token")
+
+    records = session.exec(
+        select(ReviewRecord)
+        .where(ReviewRecord.repository_full_name == repo)
+        .order_by(ReviewRecord.id.desc())
+    ).all()
+
+    pr_cache: dict[int, dict | None] = {}
+    results = []
+    async with httpx.AsyncClient(timeout=10) as client:
+        for record in records:
+            if record.pr_number not in pr_cache:
+                pr_cache[record.pr_number] = await _fetch_pull_request(
+                    client, repo, record.pr_number, github_token
+                )
+            pr = pr_cache[record.pr_number]
+            results.append(
+                {
+                    "id": record.id,
+                    "repository_full_name": record.repository_full_name,
+                    "pr_number": record.pr_number,
+                    "status": record.status,
+                    "reviewed_head_sha": record.reviewed_head_sha,
+                    "title": pr.get("title") if pr else None,
+                    "state": pr.get("state") if pr else None,
+                    "author": (pr.get("user") or {}).get("login") if pr else None,
+                    "url": pr.get("html_url") if pr else None,
+                    "updated_at": pr.get("updated_at") if pr else None,
+                }
+            )
+
+    return success_response(results)

--- a/src/api/routes/reviews.py
+++ b/src/api/routes/reviews.py
@@ -100,6 +100,45 @@ async def _fetch_pull_request(
     return resp.json() if resp.status_code == 200 else None
 
 
+@router.get("/pulls")
+async def list_pulls(
+    repo: str = Query(..., description="Repository full name, e.g. owner/name"),
+    user: dict = Depends(get_current_user),
+):
+    """Open pull requests for a repository, from live GitHub."""
+    github_token = user.get("github_token")
+    if not github_token:
+        return success_response([])
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(
+            f"{_GITHUB_API}/repos/{repo}/pulls",
+            headers={
+                "Authorization": f"token {github_token}",
+                "Accept": "application/vnd.github+json",
+            },
+            params={"state": "open", "per_page": 50, "sort": "updated"},
+        )
+    if resp.status_code != 200:
+        raise HTTPException(status_code=502, detail="GitHub API error")
+
+    results = []
+    for pr in resp.json():
+        results.append(
+            {
+                "number": pr["number"],
+                "title": pr["title"],
+                "state": pr["state"],
+                "draft": pr.get("draft", False),
+                "author": (pr.get("user") or {}).get("login"),
+                "url": pr.get("html_url"),
+                "updated_at": pr.get("updated_at"),
+            }
+        )
+
+    return success_response(results)
+
+
 @router.get("/detail")
 async def review_detail(
     repo: str = Query(..., description="Repository full name, e.g. owner/name"),

--- a/src/api/routes/reviews.py
+++ b/src/api/routes/reviews.py
@@ -1,5 +1,5 @@
 import httpx
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlmodel import Session, select
 
 from src.auth import get_current_user
@@ -28,6 +28,58 @@ async def _fetch_pull_request(
     except httpx.HTTPError:
         return None
     return resp.json() if resp.status_code == 200 else None
+
+
+@router.get("/detail")
+async def review_detail(
+    repo: str = Query(..., description="Repository full name, e.g. owner/name"),
+    number: int = Query(..., description="Pull request number"),
+    user: dict = Depends(get_current_user),
+):
+    """A pull request with the reviews posted on it, from live GitHub."""
+    github_token = user.get("github_token")
+    if not github_token:
+        raise HTTPException(status_code=400, detail="No GitHub token available")
+
+    headers = {
+        "Authorization": f"token {github_token}",
+        "Accept": "application/vnd.github+json",
+    }
+    async with httpx.AsyncClient(timeout=10) as client:
+        pr_resp = await client.get(
+            f"{_GITHUB_API}/repos/{repo}/pulls/{number}", headers=headers
+        )
+        if pr_resp.status_code != 200:
+            raise HTTPException(status_code=502, detail="GitHub API error")
+        pr = pr_resp.json()
+
+        reviews_resp = await client.get(
+            f"{_GITHUB_API}/repos/{repo}/pulls/{number}/reviews",
+            headers=headers,
+            params={"per_page": 50},
+        )
+        reviews = reviews_resp.json() if reviews_resp.status_code == 200 else []
+
+    return success_response(
+        {
+            "number": pr["number"],
+            "title": pr["title"],
+            "body": pr.get("body") or "",
+            "state": pr["state"],
+            "author": (pr.get("user") or {}).get("login"),
+            "url": pr.get("html_url"),
+            "reviews": [
+                {
+                    "author": (r.get("user") or {}).get("login"),
+                    "state": r.get("state"),
+                    "body": r.get("body") or "",
+                    "submitted_at": r.get("submitted_at"),
+                }
+                for r in reviews
+                if r.get("body")
+            ],
+        }
+    )
 
 
 @router.get("")

--- a/src/api/routes/triage.py
+++ b/src/api/routes/triage.py
@@ -134,7 +134,9 @@ async def triage_action(
             )
         elif data.action == "label":
             if not data.labels:
-                raise HTTPException(status_code=400, detail="At least one label is required")
+                raise HTTPException(
+                    status_code=400, detail="At least one label is required"
+                )
             resp = await client.post(
                 f"{base}/labels",
                 headers=_headers(github_token),
@@ -147,7 +149,9 @@ async def triage_action(
                 json={"state": "closed"},
             )
         else:
-            raise HTTPException(status_code=400, detail=f"Unknown action: {data.action}")
+            raise HTTPException(
+                status_code=400, detail=f"Unknown action: {data.action}"
+            )
 
     if resp.status_code >= 300:
         raise HTTPException(status_code=502, detail="GitHub rejected the action")

--- a/src/api/routes/triage.py
+++ b/src/api/routes/triage.py
@@ -1,5 +1,6 @@
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 
 from src.auth import get_current_user
 from src.core.responses import success_response
@@ -7,6 +8,21 @@ from src.core.responses import success_response
 router = APIRouter()
 
 _GITHUB_API = "https://api.github.com"
+
+
+def _headers(token: str) -> dict:
+    return {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+
+
+class TriageAction(BaseModel):
+    repo: str
+    number: int
+    action: str  # comment | label | close
+    comment: str | None = None
+    labels: list[str] | None = None
 
 
 @router.get("")
@@ -22,10 +38,7 @@ async def list_triage(
     async with httpx.AsyncClient(timeout=10) as client:
         resp = await client.get(
             f"{_GITHUB_API}/repos/{repo}/issues",
-            headers={
-                "Authorization": f"token {github_token}",
-                "Accept": "application/vnd.github+json",
-            },
+            headers=_headers(github_token),
             params={"state": "open", "per_page": 50, "sort": "updated"},
         )
     if resp.status_code != 200:
@@ -33,7 +46,6 @@ async def list_triage(
 
     results = []
     for issue in resp.json():
-        # GitHub returns pull requests through the issues endpoint too; exclude them.
         if "pull_request" in issue:
             continue
         results.append(
@@ -50,3 +62,94 @@ async def list_triage(
         )
 
     return success_response(results)
+
+
+@router.get("/detail")
+async def triage_detail(
+    repo: str = Query(...),
+    number: int = Query(...),
+    user: dict = Depends(get_current_user),
+):
+    """A single issue with its body and comments, from live GitHub."""
+    github_token = user.get("github_token")
+    if not github_token:
+        raise HTTPException(status_code=400, detail="No GitHub token available")
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        issue_resp = await client.get(
+            f"{_GITHUB_API}/repos/{repo}/issues/{number}",
+            headers=_headers(github_token),
+        )
+        if issue_resp.status_code != 200:
+            raise HTTPException(status_code=502, detail="GitHub API error")
+        issue = issue_resp.json()
+
+        comments_resp = await client.get(
+            f"{_GITHUB_API}/repos/{repo}/issues/{number}/comments",
+            headers=_headers(github_token),
+            params={"per_page": 50},
+        )
+        comments = comments_resp.json() if comments_resp.status_code == 200 else []
+
+    return success_response(
+        {
+            "number": issue["number"],
+            "title": issue["title"],
+            "body": issue.get("body") or "",
+            "state": issue["state"],
+            "author": (issue.get("user") or {}).get("login"),
+            "labels": [label["name"] for label in issue.get("labels", [])],
+            "url": issue.get("html_url"),
+            "comments": [
+                {
+                    "author": (c.get("user") or {}).get("login"),
+                    "body": c.get("body") or "",
+                    "created_at": c.get("created_at"),
+                }
+                for c in comments
+            ],
+        }
+    )
+
+
+@router.post("/action")
+async def triage_action(
+    data: TriageAction,
+    user: dict = Depends(get_current_user),
+):
+    """Take an action on an issue: comment, add labels, or close."""
+    github_token = user.get("github_token")
+    if not github_token:
+        raise HTTPException(status_code=400, detail="No GitHub token available")
+
+    base = f"{_GITHUB_API}/repos/{data.repo}/issues/{data.number}"
+    async with httpx.AsyncClient(timeout=10) as client:
+        if data.action == "comment":
+            if not data.comment:
+                raise HTTPException(status_code=400, detail="Comment body is required")
+            resp = await client.post(
+                f"{base}/comments",
+                headers=_headers(github_token),
+                json={"body": data.comment},
+            )
+        elif data.action == "label":
+            if not data.labels:
+                raise HTTPException(status_code=400, detail="At least one label is required")
+            resp = await client.post(
+                f"{base}/labels",
+                headers=_headers(github_token),
+                json={"labels": data.labels},
+            )
+        elif data.action == "close":
+            resp = await client.patch(
+                base,
+                headers=_headers(github_token),
+                json={"state": "closed"},
+            )
+        else:
+            raise HTTPException(status_code=400, detail=f"Unknown action: {data.action}")
+
+    if resp.status_code >= 300:
+        raise HTTPException(status_code=502, detail="GitHub rejected the action")
+
+    return success_response({"ok": True})

--- a/src/api/routes/triage.py
+++ b/src/api/routes/triage.py
@@ -1,0 +1,52 @@
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from src.auth import get_current_user
+from src.core.responses import success_response
+
+router = APIRouter()
+
+_GITHUB_API = "https://api.github.com"
+
+
+@router.get("")
+async def list_triage(
+    repo: str = Query(..., description="Repository full name, e.g. owner/name"),
+    user: dict = Depends(get_current_user),
+):
+    """The open-issue triage queue for a repository, from live GitHub state."""
+    github_token = user.get("github_token")
+    if not github_token:
+        return success_response([])
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(
+            f"{_GITHUB_API}/repos/{repo}/issues",
+            headers={
+                "Authorization": f"token {github_token}",
+                "Accept": "application/vnd.github+json",
+            },
+            params={"state": "open", "per_page": 50, "sort": "updated"},
+        )
+    if resp.status_code != 200:
+        raise HTTPException(status_code=502, detail="GitHub API error")
+
+    results = []
+    for issue in resp.json():
+        # GitHub returns pull requests through the issues endpoint too; exclude them.
+        if "pull_request" in issue:
+            continue
+        results.append(
+            {
+                "number": issue["number"],
+                "title": issue["title"],
+                "state": issue["state"],
+                "author": (issue.get("user") or {}).get("login"),
+                "labels": [label["name"] for label in issue.get("labels", [])],
+                "comments": issue.get("comments", 0),
+                "url": issue.get("html_url"),
+                "updated_at": issue.get("updated_at"),
+            }
+        )
+
+    return success_response(results)

--- a/src/plugins/builtin/code_reviewer/plugin.py
+++ b/src/plugins/builtin/code_reviewer/plugin.py
@@ -271,6 +271,7 @@ class CodeReviewerPlugin(BasePlugin):
         pr_metadata: Optional[Dict[str, Any]] = None,
         event_type: Optional[str] = None,
         repository_full_name: Optional[str] = None,
+        post: bool = True,
     ) -> Dict[str, Any]:
         """
         Generate code review and post it to GitHub.
@@ -401,29 +402,32 @@ class CodeReviewerPlugin(BasePlugin):
                     final_review = result.review
                     logger.info(f"Review modified by guard: {result.reason}")
 
-            # Post review to GitHub
-            post_result = github.post_review(
-                repository=repository,
-                pull_request=pull_request,
-                code_review=final_review,
-                line_mapper=line_mapper,
-            )
+            # Post review to GitHub, unless this is a preview run
+            post_result = None
+            if post:
+                post_result = github.post_review(
+                    repository=repository,
+                    pull_request=pull_request,
+                    code_review=final_review,
+                    line_mapper=line_mapper,
+                )
+                if pull_request.head_sha and pull_request.base_sha:
+                    save_review_record(
+                        repo_full_name,
+                        pull_request.number,
+                        pull_request.head_sha,
+                        pull_request.base_sha,
+                    )
 
             logger.info(
-                f"Review generation and posting completed for PR #{pull_request.number}"
+                f"Review generation {'and posting ' if post else '(preview) '}"
+                f"completed for PR #{pull_request.number}"
             )
-
-            if pull_request.head_sha and pull_request.base_sha:
-                save_review_record(
-                    repo_full_name,
-                    pull_request.number,
-                    pull_request.head_sha,
-                    pull_request.base_sha,
-                )
 
             return {
                 "status": "success",
                 "review_posted": post_result,
+                "review": final_review.model_dump() if final_review else None,
                 "suggestions_count": (
                     len(final_review.code_suggestions)
                     if final_review.code_suggestions


### PR DESCRIPTION
Adds read endpoints for a repository's reviews (joined with live GitHub pull-request state) and its open-issue triage queue, plus issue detail and issue actions (comment, label, close). A new endpoint re-runs the reviewer for a chosen pull request and either returns the result for preview or posts it to GitHub; the reviewer gained a preview mode that generates without posting.

Existing behavior is unchanged and posting stays the reviewer's default.
