### PR TITLE
fix(api): Address review feedback on reviews and triage

### DIFF
--- a/src/api/routes/reviews.py
+++ b/src/api/routes/reviews.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
@@ -71,7 +73,7 @@ async def rerun_review(
         "head_ref": (pr.get("head") or {}).get("ref"),
     }
 
-    result = await plugin._generate_and_post_review(
+    result = await plugin.generate_review(
         repository,
         pull_request,
         pr_metadata=pr_metadata,
@@ -206,28 +208,38 @@ async def list_reviews(
         .order_by(ReviewRecord.id.desc())
     ).all()
 
-    pr_cache: dict[int, dict | None] = {}
-    results = []
+    # Fetch each distinct pull request once, concurrently but bounded so a
+    # repository with many reviewed PRs does not open a flood of requests that
+    # trips GitHub's secondary rate limits.
+    pr_numbers = list({record.pr_number for record in records})
+    semaphore = asyncio.Semaphore(8)
+
     async with httpx.AsyncClient(timeout=10) as client:
-        for record in records:
-            if record.pr_number not in pr_cache:
-                pr_cache[record.pr_number] = await _fetch_pull_request(
-                    client, repo, record.pr_number, github_token
+
+        async def _fetch(number: int):
+            async with semaphore:
+                return number, await _fetch_pull_request(
+                    client, repo, number, github_token
                 )
-            pr = pr_cache[record.pr_number]
-            results.append(
-                {
-                    "id": record.id,
-                    "repository_full_name": record.repository_full_name,
-                    "pr_number": record.pr_number,
-                    "status": record.status,
-                    "reviewed_head_sha": record.reviewed_head_sha,
-                    "title": pr.get("title") if pr else None,
-                    "state": pr.get("state") if pr else None,
-                    "author": (pr.get("user") or {}).get("login") if pr else None,
-                    "url": pr.get("html_url") if pr else None,
-                    "updated_at": pr.get("updated_at") if pr else None,
-                }
-            )
+
+        pr_cache = dict(await asyncio.gather(*[_fetch(n) for n in pr_numbers]))
+
+    results = []
+    for record in records:
+        pr = pr_cache.get(record.pr_number)
+        results.append(
+            {
+                "id": record.id,
+                "repository_full_name": record.repository_full_name,
+                "pr_number": record.pr_number,
+                "status": record.status,
+                "reviewed_head_sha": record.reviewed_head_sha,
+                "title": pr.get("title") if pr else None,
+                "state": pr.get("state") if pr else None,
+                "author": (pr.get("user") or {}).get("login") if pr else None,
+                "url": pr.get("html_url") if pr else None,
+                "updated_at": pr.get("updated_at") if pr else None,
+            }
+        )
 
     return success_response(results)

--- a/src/api/routes/triage.py
+++ b/src/api/routes/triage.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
@@ -20,7 +22,7 @@ def _headers(token: str) -> dict:
 class TriageAction(BaseModel):
     repo: str
     number: int
-    action: str  # comment | label | close
+    action: Literal["comment", "label", "close"]
     comment: str | None = None
     labels: list[str] | None = None
 

--- a/src/plugins/builtin/code_reviewer/plugin.py
+++ b/src/plugins/builtin/code_reviewer/plugin.py
@@ -190,7 +190,7 @@ class CodeReviewerPlugin(BasePlugin):
             }
 
             # Generate and post review
-            review_result = await self._generate_and_post_review(
+            review_result = await self.generate_review(
                 repository,
                 pull_request,
                 pr_metadata=pr_metadata,
@@ -264,7 +264,7 @@ class CodeReviewerPlugin(BasePlugin):
 
         return None
 
-    async def _generate_and_post_review(
+    async def generate_review(
         self,
         repository: Repository,
         pull_request: PullRequest,

--- a/src/tests/unit/test_code_reviewer_plugin.py
+++ b/src/tests/unit/test_code_reviewer_plugin.py
@@ -72,7 +72,7 @@ class TestIncrementalReview:
         import asyncio
 
         result = asyncio.get_event_loop().run_until_complete(
-            plugin._generate_and_post_review(
+            plugin.generate_review(
                 repository,
                 pull_request,
                 event_type="pull_request.synchronize",
@@ -125,7 +125,7 @@ class TestIncrementalReview:
         import asyncio
 
         result = asyncio.get_event_loop().run_until_complete(
-            plugin._generate_and_post_review(
+            plugin.generate_review(
                 repository,
                 pull_request,
                 event_type="pull_request.synchronize",
@@ -171,7 +171,7 @@ class TestIncrementalReview:
         import asyncio
 
         result = asyncio.get_event_loop().run_until_complete(
-            plugin._generate_and_post_review(
+            plugin.generate_review(
                 repository,
                 pull_request,
                 event_type="pull_request.synchronize",
@@ -218,7 +218,7 @@ class TestIncrementalReview:
         import asyncio
 
         asyncio.get_event_loop().run_until_complete(
-            plugin._generate_and_post_review(
+            plugin.generate_review(
                 repository,
                 pull_request,
                 event_type="pull_request.opened",


### PR DESCRIPTION
Listing a repository's reviews fetches each distinct pull request once and in parallel, bounded so a busy repository does not flood GitHub, so the endpoint stays fast instead of walking requests serially.

The review generator is now a public method, since the API calls it directly, and the triage action only accepts its known values so an invalid action is rejected at the request boundary.
