### PR TITLE
feat(topology): Make software topology durable and writable in the open core

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -61,6 +61,7 @@ app = FastAPI(
 
 from src.api.routes import repos as repo_endpoints
 from src.api.routes import reviews as review_endpoints
+from src.api.routes import topology as topology_endpoints
 from src.api.routes import triage as triage_endpoints
 
 app.include_router(app_endpoints.router, tags=["general"])
@@ -68,5 +69,6 @@ app.include_router(pr_endpoints.router, prefix="/api/prs", tags=["pull_requests"
 app.include_router(repo_endpoints.router, prefix="/api/repos", tags=["repositories"])
 app.include_router(review_endpoints.router, prefix="/api/reviews", tags=["reviews"])
 app.include_router(triage_endpoints.router, prefix="/api/triage", tags=["triage"])
+app.include_router(topology_endpoints.router, prefix="/api/topology", tags=["topology"])
 if mcp_http_app is not None:
     app.mount("/mcp", mcp_http_app)

--- a/src/api/routes/topology.py
+++ b/src/api/routes/topology.py
@@ -1,0 +1,257 @@
+from dataclasses import asdict
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from src.auth import get_current_user
+from src.config.db import get_engine
+from src.core.responses import success_response
+from src.core.scope import Scope
+from src.core.services import service_registry
+from src.core.topology import (
+    InMemoryTopologyRepository,
+    SQLTopologyRepository,
+    TopologyEntity,
+    TopologyEvidence,
+    TopologyQuery,
+    TopologyRelationship,
+    TopologyRepository,
+    TopologyTraversal,
+)
+
+router = APIRouter()
+
+_fallback: TopologyRepository | None = None
+
+
+def get_topology_repository() -> TopologyRepository:
+    """The plugin-provided repository when one is registered, else core's own store.
+
+    ``ServiceRegistry.register`` allows a single provider per interface, so core
+    cannot pre-register alongside a plugin. Resolution has to happen per request.
+    """
+    global _fallback
+    try:
+        return service_registry.resolve(TopologyRepository)
+    except LookupError:
+        pass
+    if _fallback is None:
+        engine = get_engine()
+        _fallback = (
+            SQLTopologyRepository(engine)
+            if engine is not None
+            else InMemoryTopologyRepository()
+        )
+    return _fallback
+
+
+def get_scope(user: dict = Depends(get_current_user)) -> Scope:
+    workspace_id = (user.get("scope") or {}).get("workspace_id")
+    if workspace_id is None:
+        raise HTTPException(
+            status_code=403, detail="Token does not carry a workspace scope"
+        )
+    return Scope.from_mapping({"workspace": str(workspace_id)})
+
+
+class EvidenceInput(BaseModel):
+    id: str
+    kind: str
+    source: str
+    revision: str = ""
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+
+class EntityInput(BaseModel):
+    id: str
+    kind: str
+    status: str
+    confidence: float = 1.0
+    stale: bool = False
+    properties: dict[str, Any] = Field(default_factory=dict)
+    evidence: list[EvidenceInput] = Field(default_factory=list)
+
+
+class RelationshipInput(BaseModel):
+    id: str
+    source_id: str
+    target_id: str
+    type: str
+    status: str
+    confidence: float = 1.0
+    stale: bool = False
+    properties: dict[str, Any] = Field(default_factory=dict)
+    evidence: list[EvidenceInput] = Field(default_factory=list)
+
+
+class SearchInput(BaseModel):
+    ids: list[str] = Field(default_factory=list)
+    kinds: list[str] = Field(default_factory=list)
+    statuses: list[str] = Field(default_factory=list)
+    properties: dict[str, Any] = Field(default_factory=dict)
+    minimum_confidence: float = 0.0
+    include_stale: bool = True
+    limit: int = 50
+    offset: int = 0
+
+
+class TraversalInput(BaseModel):
+    entity_ids: list[str]
+    depth: int = 2
+    entity_kinds: list[str] = Field(default_factory=list)
+    entity_statuses: list[str] = Field(default_factory=list)
+    relationship_types: list[str] = Field(default_factory=list)
+    relationship_statuses: list[str] = Field(default_factory=list)
+    direction: Literal["outbound", "inbound", "both"] = "both"
+    minimum_confidence: float = 0.0
+    include_stale: bool = False
+    entity_limit: int = 50
+    relationship_limit: int = 100
+
+
+def _evidence(items: list[EvidenceInput]) -> tuple[TopologyEvidence, ...]:
+    return tuple(
+        TopologyEvidence(
+            item.id, item.kind, item.source, item.revision, item.properties
+        )
+        for item in items
+    )
+
+
+@router.put("/entities")
+async def put_entity(
+    payload: EntityInput,
+    scope: Scope = Depends(get_scope),
+    repository: TopologyRepository = Depends(get_topology_repository),
+):
+    """Create or replace one topology entity in the caller's workspace."""
+    try:
+        entity = TopologyEntity(
+            payload.id,
+            payload.kind,
+            payload.status,
+            payload.confidence,
+            payload.stale,
+            payload.properties,
+            _evidence(payload.evidence),
+        )
+    except ValueError as error:
+        raise HTTPException(status_code=422, detail=str(error))
+    repository.put_entity(scope, entity)
+    return success_response(asdict(entity))
+
+
+@router.put("/relationships")
+async def put_relationship(
+    payload: RelationshipInput,
+    scope: Scope = Depends(get_scope),
+    repository: TopologyRepository = Depends(get_topology_repository),
+):
+    """Create or replace one relationship between entities in the same workspace."""
+    try:
+        relationship = TopologyRelationship(
+            payload.id,
+            payload.source_id,
+            payload.target_id,
+            payload.type,
+            payload.status,
+            payload.confidence,
+            payload.stale,
+            payload.properties,
+            _evidence(payload.evidence),
+        )
+    except ValueError as error:
+        raise HTTPException(status_code=422, detail=str(error))
+    try:
+        repository.put_relationship(scope, relationship)
+    except ValueError as error:
+        raise HTTPException(status_code=422, detail=str(error))
+    return success_response(asdict(relationship))
+
+
+@router.delete("/entities/{entity_id:path}")
+async def remove_entity(
+    entity_id: str,
+    scope: Scope = Depends(get_scope),
+    repository: TopologyRepository = Depends(get_topology_repository),
+):
+    """Remove an entity and every relationship attached to it."""
+    if not repository.remove_entity(scope, entity_id):
+        raise HTTPException(status_code=404, detail="Entity not found")
+    return success_response(None, message="Entity removed")
+
+
+@router.delete("/relationships/{relationship_id:path}")
+async def remove_relationship(
+    relationship_id: str,
+    scope: Scope = Depends(get_scope),
+    repository: TopologyRepository = Depends(get_topology_repository),
+):
+    """Remove a single relationship, leaving both endpoints in place."""
+    if not repository.remove_relationship(scope, relationship_id):
+        raise HTTPException(status_code=404, detail="Relationship not found")
+    return success_response(None, message="Relationship removed")
+
+
+@router.post("/search")
+async def search_entities(
+    payload: SearchInput,
+    scope: Scope = Depends(get_scope),
+    repository: TopologyRepository = Depends(get_topology_repository),
+):
+    """List entities in the caller's workspace, with their relationships."""
+    try:
+        result = repository.search(
+            TopologyQuery(
+                scope,
+                ids=frozenset(payload.ids),
+                kinds=frozenset(payload.kinds),
+                statuses=frozenset(payload.statuses),
+                properties=payload.properties,
+                minimum_confidence=payload.minimum_confidence,
+                include_stale=payload.include_stale,
+                limit=payload.limit,
+                offset=payload.offset,
+            )
+        )
+    except ValueError as error:
+        raise HTTPException(status_code=422, detail=str(error))
+    relationships = repository.get_relationships(
+        scope, frozenset(entity.id for entity in result.entities)
+    )
+    return success_response(
+        {
+            **asdict(result),
+            "relationships": [asdict(item) for item in relationships],
+        }
+    )
+
+
+@router.post("/traverse")
+async def traverse(
+    payload: TraversalInput,
+    scope: Scope = Depends(get_scope),
+    repository: TopologyRepository = Depends(get_topology_repository),
+):
+    """Walk the workspace graph outward from a bounded set of seed entities."""
+    try:
+        result = repository.traverse(
+            TopologyTraversal(
+                scope,
+                tuple(payload.entity_ids),
+                depth=payload.depth,
+                entity_kinds=frozenset(payload.entity_kinds),
+                entity_statuses=frozenset(payload.entity_statuses),
+                relationship_types=frozenset(payload.relationship_types),
+                relationship_statuses=frozenset(payload.relationship_statuses),
+                direction=payload.direction,
+                minimum_confidence=payload.minimum_confidence,
+                include_stale=payload.include_stale,
+                entity_limit=payload.entity_limit,
+                relationship_limit=payload.relationship_limit,
+            )
+        )
+    except ValueError as error:
+        raise HTTPException(status_code=422, detail=str(error))
+    return success_response(asdict(result))

--- a/src/auth.py
+++ b/src/auth.py
@@ -21,10 +21,12 @@ async def get_current_user(authorization: str = Header(...)) -> dict:
             raise HTTPException(status_code=401, detail="Invalid authorization header")
         token = authorization[7:]
         payload = decode_access_token(token)
+        claimed_scope = payload.get("scope")
         return {
             "user_id": payload["sub"],
             "github_token": payload.get("github_token"),
             "username": payload.get("username"),
+            "scope": claimed_scope if isinstance(claimed_scope, dict) else {},
         }
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token has expired")

--- a/src/core/topology/__init__.py
+++ b/src/core/topology/__init__.py
@@ -3,18 +3,24 @@ from .memory import InMemoryTopologyRepository
 from .models import (
     TopologyEntity,
     TopologyEvidence,
+    TopologyQuery,
     TopologyRelationship,
+    TopologyResult,
     TopologySubgraph,
     TopologyTraversal,
 )
+from .sql import SQLTopologyRepository
 
 __all__ = [
     "InMemoryTopologyRepository",
+    "SQLTopologyRepository",
     "TopologyEntity",
     "TopologyEvidence",
+    "TopologyQuery",
     "TopologyReader",
     "TopologyRelationship",
     "TopologyRepository",
+    "TopologyResult",
     "TopologySubgraph",
     "TopologyTraversal",
     "TopologyWriter",

--- a/src/core/topology/interfaces.py
+++ b/src/core/topology/interfaces.py
@@ -6,7 +6,9 @@ from src.core.scope import Scope
 
 from .models import (
     TopologyEntity,
+    TopologyQuery,
     TopologyRelationship,
+    TopologyResult,
     TopologySubgraph,
     TopologyTraversal,
 )
@@ -14,6 +16,15 @@ from .models import (
 
 @runtime_checkable
 class TopologyReader(Protocol):
+    def search(self, query: TopologyQuery) -> TopologyResult: ...
+
+    def get_relationships(
+        self,
+        scope: Scope,
+        entity_ids: frozenset[str],
+        statuses: frozenset[str] = frozenset(),
+    ) -> tuple[TopologyRelationship, ...]: ...
+
     def traverse(self, traversal: TopologyTraversal) -> TopologySubgraph: ...
 
 
@@ -24,6 +35,12 @@ class TopologyWriter(Protocol):
     def put_relationship(
         self, scope: Scope, relationship: TopologyRelationship
     ) -> None: ...
+
+    def remove_entity(self, scope: Scope, entity_id: str) -> bool:
+        """Remove an entity and every relationship attached to it."""
+        ...
+
+    def remove_relationship(self, scope: Scope, relationship_id: str) -> bool: ...
 
 
 @runtime_checkable

--- a/src/core/topology/memory.py
+++ b/src/core/topology/memory.py
@@ -6,7 +6,9 @@ from src.core.scope import Scope
 
 from .models import (
     TopologyEntity,
+    TopologyQuery,
     TopologyRelationship,
+    TopologyResult,
     TopologySubgraph,
     TopologyTraversal,
 )
@@ -40,6 +42,71 @@ class InMemoryTopologyRepository:
         self._relationships[key] = relationship
         self._adjacency[(scope, relationship.source_id)].add(relationship.id)
         self._adjacency[(scope, relationship.target_id)].add(relationship.id)
+
+    def remove_entity(self, scope: Scope, entity_id: str) -> bool:
+        if (scope, entity_id) not in self._entities:
+            return False
+        for relationship_id in tuple(self._adjacency.get((scope, entity_id), ())):
+            self.remove_relationship(scope, relationship_id)
+        self._adjacency.pop((scope, entity_id), None)
+        del self._entities[(scope, entity_id)]
+        return True
+
+    def remove_relationship(self, scope: Scope, relationship_id: str) -> bool:
+        relationship = self._relationships.pop((scope, relationship_id), None)
+        if relationship is None:
+            return False
+        self._adjacency[(scope, relationship.source_id)].discard(relationship.id)
+        self._adjacency[(scope, relationship.target_id)].discard(relationship.id)
+        return True
+
+    def search(self, query: TopologyQuery) -> TopologyResult:
+        matches = sorted(
+            (
+                entity
+                for (scope, _), entity in self._entities.items()
+                if scope == query.scope
+                and (not query.ids or entity.id in query.ids)
+                and (not query.kinds or entity.kind in query.kinds)
+                and (not query.statuses or entity.status in query.statuses)
+                and entity.confidence >= query.minimum_confidence
+                and (query.include_stale or not entity.stale)
+                and all(
+                    entity.properties.get(key) == value
+                    for key, value in query.properties.items()
+                )
+            ),
+            key=lambda entity: entity.id,
+        )
+        entities = tuple(matches[query.offset : query.offset + query.limit])
+        return TopologyResult(
+            entities=entities,
+            total=len(matches),
+            has_more=query.offset + len(entities) < len(matches),
+        )
+
+    def get_relationships(
+        self,
+        scope: Scope,
+        entity_ids: frozenset[str],
+        statuses: frozenset[str] = frozenset(),
+    ) -> tuple[TopologyRelationship, ...]:
+        return tuple(
+            sorted(
+                (
+                    relationship
+                    for (
+                        relationship_scope,
+                        _,
+                    ), relationship in self._relationships.items()
+                    if relationship_scope == scope
+                    and (not statuses or relationship.status in statuses)
+                    and relationship.source_id in entity_ids
+                    and relationship.target_id in entity_ids
+                ),
+                key=lambda relationship: relationship.id,
+            )
+        )
 
     def traverse(self, traversal: TopologyTraversal) -> TopologySubgraph:
         scope = traversal.scope

--- a/src/core/topology/models.py
+++ b/src/core/topology/models.py
@@ -60,6 +60,34 @@ class TopologyRelationship:
 
 
 @dataclass(frozen=True)
+class TopologyQuery:
+    scope: Scope
+    ids: frozenset[str] = field(default_factory=frozenset)
+    kinds: frozenset[str] = field(default_factory=frozenset)
+    statuses: frozenset[str] = field(default_factory=frozenset)
+    properties: Mapping[str, Any] = field(default_factory=dict)
+    minimum_confidence: float = 0.0
+    include_stale: bool = True
+    limit: int = 50
+    offset: int = 0
+
+    def __post_init__(self) -> None:
+        if not 1 <= self.limit <= 100:
+            raise ValueError("limit must be between 1 and 100")
+        if self.offset < 0:
+            raise ValueError("offset must not be negative")
+        if not 0.0 <= self.minimum_confidence <= 1.0:
+            raise ValueError("minimum_confidence must be between 0 and 1")
+
+
+@dataclass(frozen=True)
+class TopologyResult:
+    entities: tuple[TopologyEntity, ...]
+    total: int
+    has_more: bool
+
+
+@dataclass(frozen=True)
 class TopologyTraversal:
     scope: Scope
     entity_ids: tuple[str, ...]

--- a/src/core/topology/sql.py
+++ b/src/core/topology/sql.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from threading import RLock
+from typing import Any
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Engine,
+    Float,
+    MetaData,
+    String,
+    Table,
+    Text,
+    delete,
+    select,
+)
+
+from src.core.scope import Scope
+
+from .memory import InMemoryTopologyRepository
+from .models import (
+    TopologyEntity,
+    TopologyEvidence,
+    TopologyQuery,
+    TopologyRelationship,
+    TopologyResult,
+    TopologySubgraph,
+    TopologyTraversal,
+)
+
+metadata = MetaData()
+scope_type = Text().with_variant(String(500), "mysql")
+entity_table = Table(
+    "topology_entities",
+    metadata,
+    Column("scope", scope_type, primary_key=True),
+    Column("id", String(255), primary_key=True),
+    Column("kind", String(255), nullable=False),
+    Column("status", String(255), nullable=False),
+    Column("confidence", Float, nullable=False),
+    Column("stale", Boolean, nullable=False),
+    Column("properties", Text, nullable=False),
+    Column("evidence", Text, nullable=False),
+)
+relationship_table = Table(
+    "topology_relationships",
+    metadata,
+    Column("scope", scope_type, primary_key=True),
+    Column("id", String(255), primary_key=True),
+    Column("source_id", String(255), nullable=False),
+    Column("target_id", String(255), nullable=False),
+    Column("type", String(255), nullable=False),
+    Column("status", String(255), nullable=False),
+    Column("confidence", Float, nullable=False),
+    Column("stale", Boolean, nullable=False),
+    Column("properties", Text, nullable=False),
+    Column("evidence", Text, nullable=False),
+)
+
+
+class SQLTopologyRepository:
+    def __init__(self, engine: Engine, *, create_schema: bool = False) -> None:
+        self._engine = engine
+        self._lock = RLock()
+        self._memory = InMemoryTopologyRepository()
+        if create_schema:
+            metadata.create_all(engine)
+        self._refresh()
+
+    def put_entity(self, scope: Scope, entity: TopologyEntity) -> None:
+        values = {
+            "scope": self._scope_key(scope),
+            "id": entity.id,
+            "kind": entity.kind,
+            "status": entity.status,
+            "confidence": entity.confidence,
+            "stale": entity.stale,
+            "properties": self._encode(entity.properties),
+            "evidence": self._encode_evidence(entity.evidence),
+        }
+        with self._lock:
+            with self._engine.begin() as connection:
+                connection.execute(
+                    delete(entity_table).where(
+                        entity_table.c.scope == values["scope"],
+                        entity_table.c.id == entity.id,
+                    )
+                )
+                connection.execute(entity_table.insert().values(**values))
+            self._refresh()
+
+    def put_relationship(
+        self, scope: Scope, relationship: TopologyRelationship
+    ) -> None:
+        values = {
+            "scope": self._scope_key(scope),
+            "id": relationship.id,
+            "source_id": relationship.source_id,
+            "target_id": relationship.target_id,
+            "type": relationship.type,
+            "status": relationship.status,
+            "confidence": relationship.confidence,
+            "stale": relationship.stale,
+            "properties": self._encode(relationship.properties),
+            "evidence": self._encode_evidence(relationship.evidence),
+        }
+        with self._lock:
+            self._refresh()
+            self._memory.put_relationship(scope, relationship)
+            with self._engine.begin() as connection:
+                connection.execute(
+                    delete(relationship_table).where(
+                        relationship_table.c.scope == values["scope"],
+                        relationship_table.c.id == relationship.id,
+                    )
+                )
+                connection.execute(relationship_table.insert().values(**values))
+            self._refresh()
+
+    def remove_entity(self, scope: Scope, entity_id: str) -> bool:
+        scope_key = self._scope_key(scope)
+        with self._lock:
+            self._refresh()
+            if not self._memory.remove_entity(scope, entity_id):
+                return False
+            with self._engine.begin() as connection:
+                connection.execute(
+                    delete(relationship_table).where(
+                        relationship_table.c.scope == scope_key,
+                        (relationship_table.c.source_id == entity_id)
+                        | (relationship_table.c.target_id == entity_id),
+                    )
+                )
+                connection.execute(
+                    delete(entity_table).where(
+                        entity_table.c.scope == scope_key,
+                        entity_table.c.id == entity_id,
+                    )
+                )
+            self._refresh()
+            return True
+
+    def remove_relationship(self, scope: Scope, relationship_id: str) -> bool:
+        scope_key = self._scope_key(scope)
+        with self._lock:
+            self._refresh()
+            if not self._memory.remove_relationship(scope, relationship_id):
+                return False
+            with self._engine.begin() as connection:
+                connection.execute(
+                    delete(relationship_table).where(
+                        relationship_table.c.scope == scope_key,
+                        relationship_table.c.id == relationship_id,
+                    )
+                )
+            self._refresh()
+            return True
+
+    def search(self, query: TopologyQuery) -> TopologyResult:
+        with self._lock:
+            self._refresh()
+            return self._memory.search(query)
+
+    def get_relationships(
+        self,
+        scope: Scope,
+        entity_ids: frozenset[str],
+        statuses: frozenset[str] = frozenset(),
+    ) -> tuple[TopologyRelationship, ...]:
+        with self._lock:
+            self._refresh()
+            return self._memory.get_relationships(scope, entity_ids, statuses)
+
+    def traverse(self, traversal: TopologyTraversal) -> TopologySubgraph:
+        with self._lock:
+            self._refresh()
+            return self._memory.traverse(traversal)
+
+    def close(self) -> None:
+        self._engine.dispose()
+
+    def _refresh(self) -> None:
+        memory = InMemoryTopologyRepository()
+        with self._engine.connect() as connection:
+            for row in connection.execute(select(entity_table)).mappings():
+                memory.put_entity(
+                    self._decode_scope(row["scope"]),
+                    TopologyEntity(
+                        row["id"],
+                        row["kind"],
+                        row["status"],
+                        row["confidence"],
+                        bool(row["stale"]),
+                        json.loads(row["properties"]),
+                        self._decode_evidence(row["evidence"]),
+                    ),
+                )
+            for row in connection.execute(select(relationship_table)).mappings():
+                memory.put_relationship(
+                    self._decode_scope(row["scope"]),
+                    TopologyRelationship(
+                        row["id"],
+                        row["source_id"],
+                        row["target_id"],
+                        row["type"],
+                        row["status"],
+                        row["confidence"],
+                        bool(row["stale"]),
+                        json.loads(row["properties"]),
+                        self._decode_evidence(row["evidence"]),
+                    ),
+                )
+        self._memory = memory
+
+    @staticmethod
+    def _scope_key(scope: Scope) -> str:
+        return json.dumps(scope.values, separators=(",", ":"))
+
+    @staticmethod
+    def _decode_scope(value: str) -> Scope:
+        return Scope(tuple(tuple(item) for item in json.loads(value)))
+
+    @staticmethod
+    def _encode(value: Mapping[str, Any]) -> str:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def _encode_evidence(cls, evidence: Sequence[TopologyEvidence]) -> str:
+        return json.dumps(
+            [
+                {
+                    "id": item.id,
+                    "kind": item.kind,
+                    "source": item.source,
+                    "revision": item.revision,
+                    "properties": item.properties,
+                }
+                for item in evidence
+            ],
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    @staticmethod
+    def _decode_evidence(value: str) -> tuple[TopologyEvidence, ...]:
+        return tuple(
+            TopologyEvidence(
+                item["id"],
+                item["kind"],
+                item["source"],
+                item.get("revision", ""),
+                item.get("properties", {}),
+            )
+            for item in json.loads(value)
+        )

--- a/src/mcp_server/application.py
+++ b/src/mcp_server/application.py
@@ -13,7 +13,7 @@ from src.core.knowledge import (
     SQLKnowledgeRepository,
 )
 from src.core.review_state import InMemoryReviewStateRepository
-from src.core.topology import InMemoryTopologyRepository
+from src.core.topology import InMemoryTopologyRepository, SQLTopologyRepository
 
 from .auth import PrincipalScopeResolver, SourceAntTokenVerifier
 from .server import create_mcp_server
@@ -26,16 +26,22 @@ def create_default_mcp_server():
         if engine is not None
         else InMemoryKnowledgeRepository()
     )
+    topology = (
+        SQLTopologyRepository(engine)
+        if engine is not None
+        else InMemoryTopologyRepository()
+    )
     provider = DefaultContextProvider(
         code=InMemoryCodeIndex(),
         knowledge=knowledge,
-        topology=InMemoryTopologyRepository(),
+        topology=topology,
         contracts=InMemoryContractRepository(),
         review_state=InMemoryReviewStateRepository(),
     )
     return create_mcp_server(
         provider,
         knowledge=knowledge,
+        topology=topology,
     )
 
 
@@ -65,16 +71,22 @@ def create_http_mcp_server():
         if engine is not None
         else InMemoryKnowledgeRepository()
     )
+    topology = (
+        SQLTopologyRepository(engine)
+        if engine is not None
+        else InMemoryTopologyRepository()
+    )
     provider = DefaultContextProvider(
         code=InMemoryCodeIndex(),
         knowledge=knowledge,
-        topology=InMemoryTopologyRepository(),
+        topology=topology,
         contracts=InMemoryContractRepository(),
         review_state=InMemoryReviewStateRepository(),
     )
     return create_mcp_server(
         provider,
         knowledge=knowledge,
+        topology=topology,
         scope_resolver=PrincipalScopeResolver(),
         auth=AuthSettings(
             issuer_url=values["issuer"],

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -19,13 +19,20 @@ from src.core.knowledge import (
 )
 from src.core.review_state import FindingQuery
 from src.core.scope import Scope
-from src.core.topology import TopologyTraversal
+from src.core.topology import (
+    TopologyEntity,
+    TopologyEvidence,
+    TopologyRelationship,
+    TopologyRepository,
+    TopologyTraversal,
+)
 
 
 def create_mcp_server(
     provider: ContextProvider,
     *,
     knowledge: KnowledgeRepository | None = None,
+    topology: TopologyRepository | None = None,
     scope_resolver: Callable[[Scope], Scope] | None = None,
     auth: AuthSettings | None = None,
     token_verifier: TokenVerifier | None = None,
@@ -197,6 +204,106 @@ def create_mcp_server(
         )
         return asdict(result)
 
+    @server.tool(
+        name="put_topology_entity",
+        description="Create or update a scoped software topology entity.",
+        structured_output=True,
+    )
+    def put_topology_entity(
+        scope: dict[str, str],
+        id: str,
+        kind: str,
+        status: str,
+        confidence: float = 1.0,
+        stale: bool = False,
+        properties: dict[str, Any] | None = None,
+        evidence: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        repository = _require_topology(topology)
+        entity = TopologyEntity(
+            id,
+            kind,
+            status,
+            confidence,
+            stale,
+            properties or {},
+            _build_evidence(evidence),
+        )
+        repository.put_entity(resolve_scope(Scope.from_mapping(scope)), entity)
+        return asdict(entity)
+
+    @server.tool(
+        name="put_topology_relationship",
+        description="Create or update a relationship between scoped topology entities.",
+        structured_output=True,
+    )
+    def put_topology_relationship(
+        scope: dict[str, str],
+        id: str,
+        source_id: str,
+        target_id: str,
+        type: str,
+        status: str,
+        confidence: float = 1.0,
+        stale: bool = False,
+        properties: dict[str, Any] | None = None,
+        evidence: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        repository = _require_topology(topology)
+        relationship = TopologyRelationship(
+            id,
+            source_id,
+            target_id,
+            type,
+            status,
+            confidence,
+            stale,
+            properties or {},
+            _build_evidence(evidence),
+        )
+        repository.put_relationship(
+            resolve_scope(Scope.from_mapping(scope)), relationship
+        )
+        return asdict(relationship)
+
+    @server.tool(
+        name="traverse_topology",
+        description="Traverse scoped software topology from a set of seed entities.",
+        structured_output=True,
+    )
+    def traverse_topology(
+        scope: dict[str, str],
+        entity_ids: list[str],
+        depth: int = 2,
+        entity_kinds: list[str] | None = None,
+        entity_statuses: list[str] | None = None,
+        relationship_types: list[str] | None = None,
+        relationship_statuses: list[str] | None = None,
+        direction: str = "both",
+        minimum_confidence: float = 0.0,
+        include_stale: bool = False,
+        entity_limit: int = 50,
+        relationship_limit: int = 100,
+    ) -> dict[str, Any]:
+        repository = _require_topology(topology)
+        result = repository.traverse(
+            TopologyTraversal(
+                resolve_scope(Scope.from_mapping(scope)),
+                tuple(entity_ids),
+                depth=depth,
+                entity_kinds=frozenset(entity_kinds or ()),
+                entity_statuses=frozenset(entity_statuses or ()),
+                relationship_types=frozenset(relationship_types or ()),
+                relationship_statuses=frozenset(relationship_statuses or ()),
+                direction=direction,
+                minimum_confidence=minimum_confidence,
+                include_stale=include_stale,
+                entity_limit=entity_limit,
+                relationship_limit=relationship_limit,
+            )
+        )
+        return asdict(result)
+
     return server
 
 
@@ -206,3 +313,26 @@ def _require_knowledge(
     if knowledge is None:
         raise ValueError("knowledge management is not configured")
     return knowledge
+
+
+def _require_topology(
+    topology: TopologyRepository | None,
+) -> TopologyRepository:
+    if topology is None:
+        raise ValueError("topology management is not configured")
+    return topology
+
+
+def _build_evidence(
+    evidence: list[dict[str, Any]] | None,
+) -> tuple[TopologyEvidence, ...]:
+    return tuple(
+        TopologyEvidence(
+            item["id"],
+            item["kind"],
+            item["source"],
+            item.get("revision", ""),
+            item.get("properties", {}),
+        )
+        for item in evidence or ()
+    )

--- a/src/migrations/versions/create_topology_tables.py
+++ b/src/migrations/versions/create_topology_tables.py
@@ -1,0 +1,51 @@
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "topology_001"
+down_revision = "knowledge_001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "topology_entities",
+        sa.Column(
+            "scope",
+            sa.Text().with_variant(sa.String(length=500), "mysql"),
+            nullable=False,
+        ),
+        sa.Column("id", sa.String(length=255), nullable=False),
+        sa.Column("kind", sa.String(length=255), nullable=False),
+        sa.Column("status", sa.String(length=255), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("stale", sa.Boolean(), nullable=False),
+        sa.Column("properties", sa.Text(), nullable=False),
+        sa.Column("evidence", sa.Text(), nullable=False),
+        sa.PrimaryKeyConstraint("scope", "id"),
+    )
+    op.create_table(
+        "topology_relationships",
+        sa.Column(
+            "scope",
+            sa.Text().with_variant(sa.String(length=500), "mysql"),
+            nullable=False,
+        ),
+        sa.Column("id", sa.String(length=255), nullable=False),
+        sa.Column("source_id", sa.String(length=255), nullable=False),
+        sa.Column("target_id", sa.String(length=255), nullable=False),
+        sa.Column("type", sa.String(length=255), nullable=False),
+        sa.Column("status", sa.String(length=255), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("stale", sa.Boolean(), nullable=False),
+        sa.Column("properties", sa.Text(), nullable=False),
+        sa.Column("evidence", sa.Text(), nullable=False),
+        sa.PrimaryKeyConstraint("scope", "id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("topology_relationships")
+    op.drop_table("topology_entities")

--- a/src/tests/test_topology_api.py
+++ b/src/tests/test_topology_api.py
@@ -1,0 +1,336 @@
+import os
+import time
+import uuid
+
+import jwt
+import pytest
+from sqlalchemy import create_engine
+
+from src.api.main import app
+from src.api.routes import topology as topology_routes
+from src.api.routes.topology import get_topology_repository
+from src.core.services import service_registry
+from src.core.topology import (
+    InMemoryTopologyRepository,
+    SQLTopologyRepository,
+    TopologyRepository,
+)
+from src.tests.base_test import BaseTestCase
+
+TEST_JWT_SECRET = "topology-api-test-secret"
+
+
+def _token(workspace_id: str, repository_ids=None) -> str:
+    return jwt.encode(
+        {
+            "sub": "1",
+            "username": "octocat",
+            "scope": {
+                "workspace_id": workspace_id,
+                "repository_ids": repository_ids or [],
+            },
+            "exp": int(time.time()) + 300,
+        },
+        os.environ["JWT_SECRET"],
+        algorithm="HS256",
+    )
+
+
+@pytest.fixture
+def empty_registry():
+    """Isolate the global registry so provider tests do not depend on plugin load order."""
+    saved = dict(service_registry._registrations)
+    service_registry._registrations.clear()
+    yield service_registry
+    service_registry._registrations.clear()
+    service_registry._registrations.update(saved)
+
+
+def test_topology_repository_prefers_a_registered_provider(empty_registry):
+    provided = InMemoryTopologyRepository()
+    empty_registry.register(TopologyRepository, provided, "test")
+
+    assert get_topology_repository() is provided
+
+
+def test_topology_repository_falls_back_when_no_plugin_provides_one(
+    empty_registry, monkeypatch
+):
+    monkeypatch.setattr(topology_routes, "_fallback", None)
+    monkeypatch.setattr(topology_routes, "get_engine", lambda: None)
+
+    resolved = get_topology_repository()
+
+    assert isinstance(resolved, InMemoryTopologyRepository)
+    assert get_topology_repository() is resolved
+
+
+class TestTopologyApi(BaseTestCase):
+    """Drives /api/topology the way the gateway does: real HTTP, real service JWT."""
+
+    @pytest.fixture(autouse=True)
+    def workspace(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JWT_SECRET", TEST_JWT_SECRET)
+        self.workspace_id = uuid.uuid4().hex
+        self.headers = {"Authorization": f"Bearer {_token(self.workspace_id)}"}
+        repository = SQLTopologyRepository(
+            create_engine(f"sqlite:///{tmp_path / 'topology.db'}"),
+            create_schema=True,
+        )
+        app.dependency_overrides[get_topology_repository] = lambda: repository
+        yield
+        app.dependency_overrides.pop(get_topology_repository, None)
+
+    def put_entity(self, identifier, headers=None, **overrides):
+        return self.client.put(
+            "/api/topology/entities",
+            json={
+                "id": identifier,
+                "kind": "service",
+                "status": "approved",
+                **overrides,
+            },
+            headers=headers or self.headers,
+        )
+
+    def test_entities_and_relationships_round_trip_through_http(self):
+        assert self.put_entity("checkout").status_code == 200
+        assert self.put_entity("ledger").status_code == 200
+
+        created = self.client.put(
+            "/api/topology/relationships",
+            json={
+                "id": "checkout-ledger",
+                "source_id": "checkout",
+                "target_id": "ledger",
+                "type": "depends_on",
+                "status": "pending",
+                "confidence": 0.6,
+                "evidence": [{"id": "commit-1", "kind": "commit", "source": "github"}],
+            },
+            headers=self.headers,
+        )
+        listing = self.client.post(
+            "/api/topology/search", json={}, headers=self.headers
+        )
+        traversal = self.client.post(
+            "/api/topology/traverse",
+            json={"entity_ids": ["checkout"]},
+            headers=self.headers,
+        )
+
+        assert created.status_code == 200
+        body = listing.json()["data"]
+        assert [entity["id"] for entity in body["entities"]] == ["checkout", "ledger"]
+        assert body["total"] == 2
+        assert [edge["id"] for edge in body["relationships"]] == ["checkout-ledger"]
+        walked = traversal.json()["data"]
+        assert [entity["id"] for entity in walked["entities"]] == [
+            "checkout",
+            "ledger",
+        ]
+        assert walked["relationships"][0]["evidence"][0]["id"] == "commit-1"
+
+    def test_another_workspace_cannot_read_or_link_the_graph(self):
+        self.put_entity("checkout")
+        self.put_entity("ledger")
+        self.client.put(
+            "/api/topology/relationships",
+            json={
+                "id": "checkout-ledger",
+                "source_id": "checkout",
+                "target_id": "ledger",
+                "type": "depends_on",
+                "status": "approved",
+            },
+            headers=self.headers,
+        )
+        intruder = {"Authorization": f"Bearer {_token(uuid.uuid4().hex)}"}
+
+        listing = self.client.post("/api/topology/search", json={}, headers=intruder)
+        traversal = self.client.post(
+            "/api/topology/traverse",
+            json={"entity_ids": ["checkout"]},
+            headers=intruder,
+        )
+        borrowed = self.client.put(
+            "/api/topology/relationships",
+            json={
+                "id": "stolen",
+                "source_id": "checkout",
+                "target_id": "ledger",
+                "type": "depends_on",
+                "status": "approved",
+            },
+            headers=intruder,
+        )
+
+        assert listing.json()["data"]["entities"] == []
+        assert listing.json()["data"]["total"] == 0
+        assert traversal.json()["data"]["entities"] == []
+        assert borrowed.status_code == 422
+
+    def test_search_filters_by_kind_status_and_properties(self):
+        self.put_entity("checkout", kind="service", status="approved")
+        self.put_entity("legacy", kind="service", status="rejected")
+        self.put_entity(
+            "orders-db",
+            kind="datastore",
+            status="approved",
+            properties={"team": "payments"},
+        )
+
+        by_kind = self.client.post(
+            "/api/topology/search", json={"kinds": ["datastore"]}, headers=self.headers
+        )
+        by_status = self.client.post(
+            "/api/topology/search",
+            json={"statuses": ["approved"]},
+            headers=self.headers,
+        )
+        by_property = self.client.post(
+            "/api/topology/search",
+            json={"properties": {"team": "payments"}},
+            headers=self.headers,
+        )
+
+        assert [e["id"] for e in by_kind.json()["data"]["entities"]] == ["orders-db"]
+        assert sorted(e["id"] for e in by_status.json()["data"]["entities"]) == [
+            "checkout",
+            "orders-db",
+        ]
+        assert [e["id"] for e in by_property.json()["data"]["entities"]] == [
+            "orders-db"
+        ]
+
+    def test_relationship_endpoints_reject_unknown_entities(self):
+        self.put_entity("checkout")
+
+        response = self.client.put(
+            "/api/topology/relationships",
+            json={
+                "id": "dangling",
+                "source_id": "checkout",
+                "target_id": "nowhere",
+                "type": "depends_on",
+                "status": "pending",
+            },
+            headers=self.headers,
+        )
+
+        assert response.status_code == 422
+        assert "does not exist in scope" in response.json()["detail"]
+
+    def test_traversal_bounds_are_enforced(self):
+        self.put_entity("checkout")
+
+        too_deep = self.client.post(
+            "/api/topology/traverse",
+            json={"entity_ids": ["checkout"], "depth": 4},
+            headers=self.headers,
+        )
+        empty_seed = self.client.post(
+            "/api/topology/traverse",
+            json={"entity_ids": []},
+            headers=self.headers,
+        )
+
+        assert too_deep.status_code == 422
+        assert empty_seed.status_code == 422
+
+    def test_a_token_without_a_workspace_scope_is_refused(self):
+        unscoped = jwt.encode(
+            {"sub": "1", "exp": int(time.time()) + 300},
+            os.environ["JWT_SECRET"],
+            algorithm="HS256",
+        )
+
+        response = self.client.post(
+            "/api/topology/search",
+            json={},
+            headers={"Authorization": f"Bearer {unscoped}"},
+        )
+
+        assert response.status_code == 403
+
+    def test_requests_without_a_token_are_refused(self):
+        response = self.client.post("/api/topology/search", json={})
+
+        assert response.status_code in (401, 422)
+
+    def test_removing_an_entity_takes_its_relationships_with_it(self):
+        for identifier in ("checkout", "ledger", "search"):
+            self.put_entity(identifier)
+        for edge, source, target in (
+            ("a", "checkout", "ledger"),
+            ("b", "search", "checkout"),
+            ("c", "search", "ledger"),
+        ):
+            self.client.put(
+                "/api/topology/relationships",
+                json={
+                    "id": edge,
+                    "source_id": source,
+                    "target_id": target,
+                    "type": "depends_on",
+                    "status": "approved",
+                },
+                headers=self.headers,
+            )
+
+        removed = self.client.delete(
+            "/api/topology/entities/checkout", headers=self.headers
+        )
+        again = self.client.delete(
+            "/api/topology/entities/checkout", headers=self.headers
+        )
+        listing = self.client.post(
+            "/api/topology/search", json={}, headers=self.headers
+        )
+
+        assert removed.status_code == 200
+        assert again.status_code == 404
+        body = listing.json()["data"]
+        assert [entity["id"] for entity in body["entities"]] == ["ledger", "search"]
+        assert [edge["id"] for edge in body["relationships"]] == ["c"]
+
+    def test_removing_a_relationship_keeps_both_endpoints(self):
+        self.put_entity("checkout")
+        self.put_entity("ledger")
+        self.client.put(
+            "/api/topology/relationships",
+            json={
+                "id": "edge",
+                "source_id": "checkout",
+                "target_id": "ledger",
+                "type": "depends_on",
+                "status": "approved",
+            },
+            headers=self.headers,
+        )
+
+        removed = self.client.delete(
+            "/api/topology/relationships/edge", headers=self.headers
+        )
+        listing = self.client.post(
+            "/api/topology/search", json={}, headers=self.headers
+        )
+
+        assert removed.status_code == 200
+        body = listing.json()["data"]
+        assert [entity["id"] for entity in body["entities"]] == ["checkout", "ledger"]
+        assert body["relationships"] == []
+
+    def test_another_workspace_cannot_remove_the_graph(self):
+        self.put_entity("checkout")
+        intruder = {"Authorization": f"Bearer {_token(uuid.uuid4().hex)}"}
+
+        response = self.client.delete(
+            "/api/topology/entities/checkout", headers=intruder
+        )
+        listing = self.client.post(
+            "/api/topology/search", json={}, headers=self.headers
+        )
+
+        assert response.status_code == 404
+        assert [e["id"] for e in listing.json()["data"]["entities"]] == ["checkout"]

--- a/src/tests/unit/test_core_sqlite_topology.py
+++ b/src/tests/unit/test_core_sqlite_topology.py
@@ -1,0 +1,252 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.dialects import mysql, postgresql
+from sqlalchemy.schema import CreateTable
+
+from src.core.scope import Scope
+from src.core.topology import (
+    SQLTopologyRepository,
+    TopologyEntity,
+    TopologyEvidence,
+    TopologyQuery,
+    TopologyRelationship,
+    TopologyTraversal,
+)
+from src.core.topology.sql import entity_table, relationship_table
+
+PROJECT = Scope.from_mapping({"project": "one"})
+OTHER_PROJECT = Scope.from_mapping({"project": "two"})
+
+
+def test_sql_topology_scope_keys_compile_for_supported_databases():
+    for table in (entity_table, relationship_table):
+        mysql_ddl = str(CreateTable(table).compile(dialect=mysql.dialect()))
+        postgres_ddl = str(CreateTable(table).compile(dialect=postgresql.dialect()))
+
+        assert "scope VARCHAR(500) NOT NULL" in mysql_ddl
+        assert "scope TEXT NOT NULL" in postgres_ddl
+
+
+def test_sql_topology_survives_restart_and_preserves_scope(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'topology.db'}")
+    repository = SQLTopologyRepository(engine, create_schema=True)
+    for scope, owner in ((PROJECT, "one"), (OTHER_PROJECT, "two")):
+        repository.put_entity(
+            scope,
+            TopologyEntity("checkout", "service", "approved", properties={"by": owner}),
+        )
+        repository.put_entity(
+            scope,
+            TopologyEntity("ledger", "service", "approved", properties={"by": owner}),
+        )
+        repository.put_relationship(
+            scope,
+            TopologyRelationship(
+                "checkout-ledger",
+                "checkout",
+                "ledger",
+                "depends_on",
+                "approved",
+            ),
+        )
+    reopened = SQLTopologyRepository(engine)
+    result = reopened.traverse(TopologyTraversal(PROJECT, ("checkout",)))
+    other = reopened.traverse(TopologyTraversal(OTHER_PROJECT, ("checkout",)))
+
+    assert [entity.id for entity in result.entities] == ["checkout", "ledger"]
+    assert [edge.id for edge in result.relationships] == ["checkout-ledger"]
+    assert [entity.properties["by"] for entity in result.entities] == ["one", "one"]
+    assert [entity.properties["by"] for entity in other.entities] == ["two", "two"]
+
+
+def test_sql_topology_round_trips_confidence_stale_and_evidence(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'topology.db'}")
+    repository = SQLTopologyRepository(engine, create_schema=True)
+    evidence = (
+        TopologyEvidence(
+            "commit-1",
+            "commit",
+            "github",
+            "abc123",
+            {"path": "src/checkout.py"},
+        ),
+    )
+    entity = TopologyEntity(
+        "checkout",
+        "service",
+        "pending",
+        confidence=0.4,
+        stale=True,
+        properties={"team": "payments"},
+        evidence=evidence,
+    )
+    repository.put_entity(PROJECT, entity)
+
+    reopened = SQLTopologyRepository(engine)
+    result = reopened.traverse(
+        TopologyTraversal(PROJECT, ("checkout",), include_stale=True)
+    )
+
+    assert result.entities == (entity,)
+
+
+def test_sql_topology_traversal_filters_exclude_unapproved_edges(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'topology.db'}")
+    repository = SQLTopologyRepository(engine, create_schema=True)
+    for identifier in ("checkout", "ledger", "search"):
+        repository.put_entity(
+            PROJECT, TopologyEntity(identifier, "service", "approved")
+        )
+    repository.put_relationship(
+        PROJECT,
+        TopologyRelationship(
+            "approved-edge", "checkout", "ledger", "depends_on", "approved"
+        ),
+    )
+    repository.put_relationship(
+        PROJECT,
+        TopologyRelationship(
+            "pending-edge", "checkout", "search", "depends_on", "pending"
+        ),
+    )
+
+    result = repository.traverse(
+        TopologyTraversal(
+            PROJECT,
+            ("checkout",),
+            relationship_statuses=frozenset({"approved"}),
+        )
+    )
+
+    assert [edge.id for edge in result.relationships] == ["approved-edge"]
+    assert [entity.id for entity in result.entities] == ["checkout", "ledger"]
+
+
+def test_sql_topology_updates_entities_and_relationships(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'topology.db'}")
+    repository = SQLTopologyRepository(engine, create_schema=True)
+    for identifier in ("one", "two", "three"):
+        repository.put_entity(PROJECT, TopologyEntity(identifier, "service", "pending"))
+    repository.put_relationship(
+        PROJECT,
+        TopologyRelationship("edge", "one", "two", "depends_on", "pending"),
+    )
+    repository.put_entity(PROJECT, TopologyEntity("one", "datastore", "approved"))
+    repository.put_relationship(
+        PROJECT,
+        TopologyRelationship("edge", "one", "three", "consumes", "approved"),
+    )
+
+    result = repository.traverse(TopologyTraversal(PROJECT, ("one",)))
+
+    assert result.entities[0] == TopologyEntity("one", "datastore", "approved")
+    assert [entity.id for entity in result.entities] == ["one", "three"]
+    assert [edge.type for edge in result.relationships] == ["consumes"]
+
+
+def test_sql_topology_rejects_relationship_with_missing_endpoint(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'topology.db'}")
+    repository = SQLTopologyRepository(engine, create_schema=True)
+    repository.put_entity(PROJECT, TopologyEntity("checkout", "service", "approved"))
+
+    with pytest.raises(ValueError, match="does not exist in scope"):
+        repository.put_relationship(
+            PROJECT,
+            TopologyRelationship("edge", "checkout", "ledger", "depends_on", "pending"),
+        )
+
+    reopened = SQLTopologyRepository(engine)
+    result = reopened.traverse(TopologyTraversal(PROJECT, ("checkout",)))
+
+    assert result.relationships == ()
+
+
+def test_sql_topology_will_not_link_across_scopes(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'topology.db'}")
+    repository = SQLTopologyRepository(engine, create_schema=True)
+    repository.put_entity(PROJECT, TopologyEntity("checkout", "service", "approved"))
+    repository.put_entity(
+        OTHER_PROJECT, TopologyEntity("ledger", "service", "approved")
+    )
+
+    with pytest.raises(ValueError, match="does not exist in scope"):
+        repository.put_relationship(
+            PROJECT,
+            TopologyRelationship("edge", "checkout", "ledger", "depends_on", "pending"),
+        )
+
+
+def test_sql_topology_reads_writes_from_another_repository_instance(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'topology.db'}")
+    reader = SQLTopologyRepository(engine, create_schema=True)
+    writer = SQLTopologyRepository(engine)
+
+    writer.put_entity(PROJECT, TopologyEntity("checkout", "service", "approved"))
+
+    result = reader.traverse(TopologyTraversal(PROJECT, ("checkout",)))
+
+    assert [entity.id for entity in result.entities] == ["checkout"]
+
+
+def test_sql_topology_removes_an_entity_and_its_relationships(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'topology.db'}")
+    repository = SQLTopologyRepository(engine, create_schema=True)
+    for identifier in ("checkout", "ledger", "search"):
+        repository.put_entity(
+            PROJECT, TopologyEntity(identifier, "service", "approved")
+        )
+    repository.put_relationship(
+        PROJECT,
+        TopologyRelationship("a", "checkout", "ledger", "depends_on", "approved"),
+    )
+    repository.put_relationship(
+        PROJECT,
+        TopologyRelationship("b", "search", "checkout", "depends_on", "approved"),
+    )
+    repository.put_relationship(
+        PROJECT,
+        TopologyRelationship("c", "search", "ledger", "depends_on", "approved"),
+    )
+
+    assert repository.remove_entity(PROJECT, "checkout") is True
+    assert repository.remove_entity(PROJECT, "checkout") is False
+
+    reopened = SQLTopologyRepository(engine)
+    result = reopened.traverse(TopologyTraversal(PROJECT, ("search",)))
+
+    assert [entity.id for entity in result.entities] == ["search", "ledger"]
+    assert [edge.id for edge in result.relationships] == ["c"]
+
+
+def test_sql_topology_removes_one_relationship_and_keeps_its_endpoints(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'topology.db'}")
+    repository = SQLTopologyRepository(engine, create_schema=True)
+    for identifier in ("checkout", "ledger"):
+        repository.put_entity(
+            PROJECT, TopologyEntity(identifier, "service", "approved")
+        )
+    repository.put_relationship(
+        PROJECT,
+        TopologyRelationship("edge", "checkout", "ledger", "depends_on", "approved"),
+    )
+
+    assert repository.remove_relationship(PROJECT, "edge") is True
+    assert repository.remove_relationship(PROJECT, "edge") is False
+
+    reopened = SQLTopologyRepository(engine)
+    listing = reopened.search(TopologyQuery(PROJECT))
+
+    assert [entity.id for entity in listing.entities] == ["checkout", "ledger"]
+    assert reopened.get_relationships(PROJECT, frozenset({"checkout", "ledger"})) == ()
+
+
+def test_sql_topology_removal_is_confined_to_its_scope(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'topology.db'}")
+    repository = SQLTopologyRepository(engine, create_schema=True)
+    for scope in (PROJECT, OTHER_PROJECT):
+        repository.put_entity(scope, TopologyEntity("checkout", "service", "approved"))
+
+    assert repository.remove_entity(PROJECT, "checkout") is True
+
+    assert repository.search(TopologyQuery(PROJECT)).total == 0
+    assert repository.search(TopologyQuery(OTHER_PROJECT)).total == 1

--- a/src/tests/unit/test_mcp_server.py
+++ b/src/tests/unit/test_mcp_server.py
@@ -20,6 +20,7 @@ from src.core.knowledge import (
     SQLKnowledgeRepository,
 )
 from src.core.scope import Scope
+from src.core.topology import SQLTopologyRepository
 from src.mcp_server import create_mcp_server
 from src.mcp_server.application import create_http_mcp_server
 from src.mcp_server.auth import PrincipalScopeResolver, SourceAntTokenVerifier
@@ -78,6 +79,9 @@ async def test_mcp_get_context_uses_protocol_boundary_and_isolates_scope():
         "put_knowledge",
         "put_knowledge_relationship",
         "search_knowledge",
+        "put_topology_entity",
+        "put_topology_relationship",
+        "traverse_topology",
     }
     assert result.isError is False
     assert result.structuredContent["scope"] == {"project": "one"}
@@ -183,6 +187,99 @@ async def test_mcp_manages_durable_knowledge_through_protocol_boundary(tmp_path)
         "decision",
         "constraint",
     ]
+
+
+@pytest.mark.asyncio
+async def test_mcp_manages_durable_topology_through_protocol_boundary(tmp_path):
+    topology = SQLTopologyRepository(
+        create_engine(f"sqlite:///{tmp_path / 'topology.db'}"),
+        create_schema=True,
+    )
+    server = create_mcp_server(
+        DefaultContextProvider(topology=topology),
+        topology=topology,
+    )
+
+    async with create_connected_server_and_client_session(server) as session:
+        for identifier in ("checkout", "ledger"):
+            entity = await session.call_tool(
+                "put_topology_entity",
+                {
+                    "scope": {"workspace": "one"},
+                    "id": identifier,
+                    "kind": "service",
+                    "status": "approved",
+                },
+            )
+            assert entity.isError is False
+        relationship = await session.call_tool(
+            "put_topology_relationship",
+            {
+                "scope": {"workspace": "one"},
+                "id": "checkout-ledger",
+                "source_id": "checkout",
+                "target_id": "ledger",
+                "type": "depends_on",
+                "status": "pending",
+                "confidence": 0.6,
+                "evidence": [{"id": "commit-1", "kind": "commit", "source": "github"}],
+            },
+        )
+        traversal = await session.call_tool(
+            "traverse_topology",
+            {"scope": {"workspace": "one"}, "entity_ids": ["checkout"]},
+        )
+        approved_only = await session.call_tool(
+            "traverse_topology",
+            {
+                "scope": {"workspace": "one"},
+                "entity_ids": ["checkout"],
+                "relationship_statuses": ["approved"],
+            },
+        )
+        other_scope = await session.call_tool(
+            "traverse_topology",
+            {"scope": {"workspace": "two"}, "entity_ids": ["checkout"]},
+        )
+        context = await session.call_tool(
+            "get_context",
+            {
+                "scope": {"workspace": "one"},
+                "topology_entity_ids": ["checkout"],
+            },
+        )
+
+    assert relationship.isError is False
+    assert [edge["id"] for edge in traversal.structuredContent["relationships"]] == [
+        "checkout-ledger"
+    ]
+    assert traversal.structuredContent["relationships"][0]["evidence"][0]["id"] == (
+        "commit-1"
+    )
+    assert approved_only.structuredContent["relationships"] == []
+    assert other_scope.structuredContent["entities"] == []
+    assert [
+        entity["id"] for entity in context.structuredContent["topology"]["entities"]
+    ] == ["checkout", "ledger"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_topology_tools_are_unavailable_without_a_repository():
+    server = create_mcp_server(DefaultContextProvider(code=InMemoryCodeIndex()))
+
+    async with create_connected_server_and_client_session(server) as session:
+        result = await session.call_tool(
+            "put_topology_entity",
+            {
+                "scope": {"workspace": "one"},
+                "id": "checkout",
+                "kind": "service",
+                "status": "approved",
+            },
+        )
+
+    assert result.isError is True
+    assert "topology management is not configured" in result.content[0].text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The core modelled topology properly but could not store or write it, so `DefaultContextProvider` and the review impact preparer always read an empty graph. The only real system map lived in the hosted gateway's own database, out of reach of reviews and MCP clients. This makes the README's claim about system topology true.

Three things worth a reviewer's attention:

Workspace scope was being decoded from the service token and thrown away. It is now carried through and required on every topology route. Without that, moving systems into the core would have let one workspace traverse another's graph.

`ServiceRegistry.register` allows one provider per interface and the memory plugin already registers this one, so the route resolves the registered provider per request and falls back to the core store. Pre-registering the core store alongside it raises.

Removal is real deletion with cascade rather than a status change. A soft-deleted system keeps surfacing in traversals and context packs, which is worse than leaving it alone.
