### PR TITLE
feat(topology): Add portable graph snapshots

### DIFF
--- a/src/core/topology/__init__.py
+++ b/src/core/topology/__init__.py
@@ -1,4 +1,9 @@
-from .interfaces import TopologyReader, TopologyRepository, TopologyWriter
+from .interfaces import (
+    TopologyReader,
+    TopologyRepository,
+    TopologySnapshotCodec,
+    TopologyWriter,
+)
 from .memory import InMemoryTopologyRepository
 from .models import (
     TopologyEntity,
@@ -7,14 +12,18 @@ from .models import (
     TopologySubgraph,
     TopologyTraversal,
 )
+from .snapshots import JSONTopologySnapshotCodec, TopologySnapshot
 
 __all__ = [
     "InMemoryTopologyRepository",
+    "JSONTopologySnapshotCodec",
     "TopologyEntity",
     "TopologyEvidence",
     "TopologyReader",
     "TopologyRelationship",
     "TopologyRepository",
+    "TopologySnapshot",
+    "TopologySnapshotCodec",
     "TopologySubgraph",
     "TopologyTraversal",
     "TopologyWriter",

--- a/src/core/topology/interfaces.py
+++ b/src/core/topology/interfaces.py
@@ -10,6 +10,7 @@ from .models import (
     TopologySubgraph,
     TopologyTraversal,
 )
+from .snapshots import TopologySnapshot
 
 
 @runtime_checkable
@@ -29,3 +30,12 @@ class TopologyWriter(Protocol):
 @runtime_checkable
 class TopologyRepository(TopologyReader, TopologyWriter, Protocol):
     pass
+
+
+@runtime_checkable
+class TopologySnapshotCodec(Protocol):
+    media_type: str
+
+    def encode(self, snapshot: TopologySnapshot) -> bytes: ...
+
+    def decode(self, payload: bytes) -> TopologySnapshot: ...

--- a/src/core/topology/snapshots.py
+++ b/src/core/topology/snapshots.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
+from itertools import chain
 from typing import Any
 
 from .models import TopologyEntity, TopologyEvidence, TopologyRelationship
@@ -31,10 +32,9 @@ class TopologySnapshot:
             for relationship in self.relationships
         ):
             raise ValueError("topology snapshot relationship endpoints must exist")
-        values = (*self.entities, *self.relationships)
         if any(
             len(item.evidence) != len({evidence.id for evidence in item.evidence})
-            for item in values
+            for item in chain(self.entities, self.relationships)
         ):
             raise ValueError("topology snapshot evidence ids must be unique")
         object.__setattr__(

--- a/src/core/topology/snapshots.py
+++ b/src/core/topology/snapshots.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from .models import TopologyEntity, TopologyEvidence, TopologyRelationship
+
+
+@dataclass(frozen=True)
+class TopologySnapshot:
+    entities: tuple[TopologyEntity, ...]
+    relationships: tuple[TopologyRelationship, ...]
+    format_version: int = 1
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.format_version != 1:
+            raise ValueError("unsupported topology snapshot version")
+        entity_ids = [entity.id for entity in self.entities]
+        if len(entity_ids) != len(set(entity_ids)):
+            raise ValueError("topology snapshot entity ids must be unique")
+        relationship_ids = [relationship.id for relationship in self.relationships]
+        if len(relationship_ids) != len(set(relationship_ids)):
+            raise ValueError("topology snapshot relationship ids must be unique")
+        known_ids = frozenset(entity_ids)
+        if any(
+            relationship.source_id not in known_ids
+            or relationship.target_id not in known_ids
+            for relationship in self.relationships
+        ):
+            raise ValueError("topology snapshot relationship endpoints must exist")
+        values = (*self.entities, *self.relationships)
+        if any(
+            len(item.evidence) != len({evidence.id for evidence in item.evidence})
+            for item in values
+        ):
+            raise ValueError("topology snapshot evidence ids must be unique")
+        object.__setattr__(
+            self,
+            "entities",
+            tuple(
+                sorted(
+                    (
+                        replace(
+                            entity,
+                            evidence=tuple(
+                                sorted(entity.evidence, key=lambda item: item.id)
+                            ),
+                        )
+                        for entity in self.entities
+                    ),
+                    key=lambda entity: entity.id,
+                )
+            ),
+        )
+        object.__setattr__(
+            self,
+            "relationships",
+            tuple(
+                sorted(
+                    (
+                        replace(
+                            relationship,
+                            evidence=tuple(
+                                sorted(relationship.evidence, key=lambda item: item.id)
+                            ),
+                        )
+                        for relationship in self.relationships
+                    ),
+                    key=lambda relationship: relationship.id,
+                )
+            ),
+        )
+
+
+class JSONTopologySnapshotCodec:
+    media_type = "application/vnd.sourceant.topology+json"
+
+    def encode(self, snapshot: TopologySnapshot) -> bytes:
+        value = {
+            "entities": [self._entity(entity) for entity in snapshot.entities],
+            "format": "sourceant.topology",
+            "properties": dict(snapshot.properties),
+            "relationships": [
+                self._relationship(relationship)
+                for relationship in snapshot.relationships
+            ],
+            "version": snapshot.format_version,
+        }
+        return json.dumps(
+            value,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+    def decode(self, payload: bytes) -> TopologySnapshot:
+        value = json.loads(payload.decode("utf-8"))
+        if not isinstance(value, dict) or value.get("format") != "sourceant.topology":
+            raise ValueError("invalid topology snapshot format")
+        if value.get("version") != 1:
+            raise ValueError("unsupported topology snapshot version")
+        entities = value.get("entities")
+        relationships = value.get("relationships")
+        properties = value.get("properties", {})
+        if not isinstance(entities, list) or not isinstance(relationships, list):
+            raise TypeError("topology snapshot collections must be lists")
+        if not isinstance(properties, dict):
+            raise TypeError("topology snapshot properties must be an object")
+        return TopologySnapshot(
+            tuple(self._entity_from_value(entity) for entity in entities),
+            tuple(
+                self._relationship_from_value(relationship)
+                for relationship in relationships
+            ),
+            value["version"],
+            properties,
+        )
+
+    @classmethod
+    def _entity(cls, entity: TopologyEntity) -> dict:
+        return {
+            "confidence": entity.confidence,
+            "evidence": [cls._evidence(item) for item in entity.evidence],
+            "id": entity.id,
+            "kind": entity.kind,
+            "properties": dict(entity.properties),
+            "stale": entity.stale,
+            "status": entity.status,
+        }
+
+    @classmethod
+    def _relationship(cls, relationship: TopologyRelationship) -> dict:
+        return {
+            "confidence": relationship.confidence,
+            "evidence": [cls._evidence(item) for item in relationship.evidence],
+            "id": relationship.id,
+            "properties": dict(relationship.properties),
+            "source_id": relationship.source_id,
+            "stale": relationship.stale,
+            "status": relationship.status,
+            "target_id": relationship.target_id,
+            "type": relationship.type,
+        }
+
+    @staticmethod
+    def _evidence(evidence: TopologyEvidence) -> dict:
+        return {
+            "id": evidence.id,
+            "kind": evidence.kind,
+            "properties": dict(evidence.properties),
+            "revision": evidence.revision,
+            "source": evidence.source,
+        }
+
+    @classmethod
+    def _entity_from_value(cls, value) -> TopologyEntity:
+        if not isinstance(value, dict):
+            raise TypeError("topology snapshot entity must be an object")
+        return TopologyEntity(
+            id=value["id"],
+            kind=value["kind"],
+            status=value["status"],
+            confidence=value.get("confidence", 1.0),
+            stale=value.get("stale", False),
+            properties=value.get("properties", {}),
+            evidence=tuple(
+                cls._evidence_from_value(item) for item in value.get("evidence", [])
+            ),
+        )
+
+    @classmethod
+    def _relationship_from_value(cls, value) -> TopologyRelationship:
+        if not isinstance(value, dict):
+            raise TypeError("topology snapshot relationship must be an object")
+        return TopologyRelationship(
+            id=value["id"],
+            source_id=value["source_id"],
+            target_id=value["target_id"],
+            type=value["type"],
+            status=value["status"],
+            confidence=value.get("confidence", 1.0),
+            stale=value.get("stale", False),
+            properties=value.get("properties", {}),
+            evidence=tuple(
+                cls._evidence_from_value(item) for item in value.get("evidence", [])
+            ),
+        )
+
+    @staticmethod
+    def _evidence_from_value(value) -> TopologyEvidence:
+        if not isinstance(value, dict):
+            raise TypeError("topology snapshot evidence must be an object")
+        return TopologyEvidence(
+            id=value["id"],
+            kind=value["kind"],
+            source=value["source"],
+            revision=value.get("revision", ""),
+            properties=value.get("properties", {}),
+        )

--- a/src/tests/unit/test_topology_snapshots.py
+++ b/src/tests/unit/test_topology_snapshots.py
@@ -1,0 +1,196 @@
+import json
+
+import pytest
+
+from src.core.topology import (
+    JSONTopologySnapshotCodec,
+    TopologyEntity,
+    TopologyEvidence,
+    TopologyRelationship,
+    TopologySnapshot,
+    TopologySnapshotCodec,
+)
+
+
+def graph_values():
+    evidence = TopologyEvidence(
+        "contract-v2",
+        "openapi",
+        "provider",
+        "abc123",
+        {"path": "openapi.yaml"},
+    )
+    provider = TopologyEntity(
+        "provider",
+        "service",
+        "active",
+        properties={"versions": ["v1", "v2"]},
+        evidence=(evidence,),
+    )
+    consumer = TopologyEntity(
+        "consumer",
+        "component",
+        "inactive",
+        confidence=0.75,
+        stale=True,
+    )
+    relationship = TopologyRelationship(
+        "consumer-provider",
+        consumer.id,
+        provider.id,
+        "depends_on",
+        "approved",
+        confidence=0.8,
+        stale=True,
+        properties={"operation": "createOrder"},
+        evidence=(evidence,),
+    )
+    return provider, consumer, relationship
+
+
+def test_round_trips_a_canonical_topology_snapshot():
+    provider, consumer, relationship = graph_values()
+    codec = JSONTopologySnapshotCodec()
+    snapshot = TopologySnapshot(
+        (provider, consumer),
+        (relationship,),
+        properties={"revision": "def456"},
+    )
+
+    payload = codec.encode(snapshot)
+    restored = codec.decode(payload)
+
+    assert isinstance(codec, TopologySnapshotCodec)
+    assert restored == snapshot
+    assert tuple(entity.id for entity in restored.entities) == (
+        "consumer",
+        "provider",
+    )
+    assert json.loads(payload) == {
+        "entities": [
+            {
+                "confidence": 0.75,
+                "evidence": [],
+                "id": "consumer",
+                "kind": "component",
+                "properties": {},
+                "stale": True,
+                "status": "inactive",
+            },
+            {
+                "confidence": 1.0,
+                "evidence": [
+                    {
+                        "id": "contract-v2",
+                        "kind": "openapi",
+                        "properties": {"path": "openapi.yaml"},
+                        "revision": "abc123",
+                        "source": "provider",
+                    }
+                ],
+                "id": "provider",
+                "kind": "service",
+                "properties": {"versions": ["v1", "v2"]},
+                "stale": False,
+                "status": "active",
+            },
+        ],
+        "format": "sourceant.topology",
+        "properties": {"revision": "def456"},
+        "relationships": [
+            {
+                "confidence": 0.8,
+                "evidence": [
+                    {
+                        "id": "contract-v2",
+                        "kind": "openapi",
+                        "properties": {"path": "openapi.yaml"},
+                        "revision": "abc123",
+                        "source": "provider",
+                    }
+                ],
+                "id": "consumer-provider",
+                "properties": {"operation": "createOrder"},
+                "source_id": "consumer",
+                "stale": True,
+                "status": "approved",
+                "target_id": "provider",
+                "type": "depends_on",
+            }
+        ],
+        "version": 1,
+    }
+
+
+def test_encoding_is_stable_across_input_and_property_order():
+    provider, consumer, relationship = graph_values()
+    deployment = TopologyEvidence("deployment-7", "deployment", "build", "def456")
+    provider = TopologyEntity(
+        provider.id,
+        provider.kind,
+        provider.status,
+        properties=provider.properties,
+        evidence=(*provider.evidence, deployment),
+    )
+    codec = JSONTopologySnapshotCodec()
+    first = TopologySnapshot(
+        (provider, consumer),
+        (relationship,),
+        properties={"branch": "main", "revision": "abc123"},
+    )
+    second = TopologySnapshot(
+        (
+            consumer,
+            TopologyEntity(
+                provider.id,
+                provider.kind,
+                provider.status,
+                properties=provider.properties,
+                evidence=tuple(reversed(provider.evidence)),
+            ),
+        ),
+        (relationship,),
+        properties={"revision": "abc123", "branch": "main"},
+    )
+
+    assert codec.encode(first) == codec.encode(second)
+
+
+def test_rejects_duplicate_ids_and_missing_relationship_endpoints():
+    provider, consumer, relationship = graph_values()
+    with pytest.raises(ValueError, match="entity ids must be unique"):
+        TopologySnapshot((provider, provider), ())
+    with pytest.raises(ValueError, match="relationship ids must be unique"):
+        TopologySnapshot(
+            (provider, consumer),
+            (relationship, relationship),
+        )
+    with pytest.raises(ValueError, match="endpoints must exist"):
+        TopologySnapshot((provider,), (relationship,))
+    duplicate_evidence = TopologyEvidence("same", "commit", "git")
+    with pytest.raises(ValueError, match="evidence ids must be unique"):
+        TopologySnapshot(
+            (
+                TopologyEntity(
+                    "duplicate",
+                    "component",
+                    "active",
+                    evidence=(duplicate_evidence, duplicate_evidence),
+                ),
+            ),
+            (),
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        b"[]",
+        b'{"format":"unknown","version":1,"entities":[],"relationships":[]}',
+        b'{"format":"sourceant.topology","version":2,"entities":[],"relationships":[]}',
+        b'{"format":"sourceant.topology","version":1,"entities":{},"relationships":[]}',
+    ),
+)
+def test_rejects_invalid_snapshot_documents(payload):
+    with pytest.raises((TypeError, ValueError)):
+        JSONTopologySnapshotCodec().decode(payload)


### PR DESCRIPTION
Storage adapters need a portable topology interchange boundary instead of database-specific exports. Canonical snapshots preserve provenance and lifecycle state while producing stable output across equivalent graphs.