### PR TITLE
fix(review): Reject praise and replayed changes

### DIFF
--- a/src/plugins/builtin/code_reviewer/plugin.py
+++ b/src/plugins/builtin/code_reviewer/plugin.py
@@ -549,6 +549,13 @@ class CodeReviewerPlugin(BasePlugin):
         result = []
         filtered, _ = suggestion_filter.filter_suggestions(suggestions)
         for suggestion in filtered:
+            if line_mapper.suggestion_replays_diff(suggestion):
+                logger.info(
+                    f"Filtered out suggestion for "
+                    f"{suggestion.file_name}:{suggestion.start_line}: "
+                    f"suggested code is already applied"
+                )
+                continue
             mapped_result = line_mapper.validate_and_map_suggestion(
                 suggestion, strict_mode=(APP_ENV == "production")
             )

--- a/src/tests/unit/test_line_mapper.py
+++ b/src/tests/unit/test_line_mapper.py
@@ -49,6 +49,50 @@ def diff_data(request):
 
 
 class TestLineMapper:
+    def test_detects_replacement_already_applied_in_diff(self):
+        diff = """\
+--- a/components/SystemCanvas.vue
++++ b/components/SystemCanvas.vue
+@@ -1 +1 @@
+-const assetId = Number(targetEl.dataset.assetId)
++const assetId = targetEl?.dataset.assetId ?? null
+"""
+        mapper = LineMapper(parse_diff(diff))
+        suggestion = CodeSuggestion(
+            file_name="components/SystemCanvas.vue",
+            start_line=1,
+            end_line=1,
+            side=Side.RIGHT,
+            comment="Use the string identifier.",
+            category=SuggestionCategory.REFACTOR,
+            existing_code="-const assetId = Number(targetEl.dataset.assetId)",
+            suggested_code="const assetId = targetEl?.dataset.assetId ?? null",
+        )
+
+        assert mapper.suggestion_replays_diff(suggestion)
+
+    def test_does_not_reject_replacement_not_present_in_diff(self):
+        diff = """\
+--- a/components/SystemCanvas.vue
++++ b/components/SystemCanvas.vue
+@@ -1 +1 @@
+-const assetId = Number(targetEl.dataset.assetId)
++const assetId = targetEl?.dataset.assetId ?? null
+"""
+        mapper = LineMapper(parse_diff(diff))
+        suggestion = CodeSuggestion(
+            file_name="components/SystemCanvas.vue",
+            start_line=1,
+            end_line=1,
+            side=Side.RIGHT,
+            comment="Guard against an empty identifier.",
+            category=SuggestionCategory.BUG,
+            existing_code="const assetId = targetEl?.dataset.assetId ?? null",
+            suggested_code="const assetId = targetEl?.dataset.assetId || null",
+        )
+
+        assert not mapper.suggestion_replays_diff(suggestion)
+
     def test_successful_match(self, diff_data):
         """Test a successful match on a line that was modified."""
         parsed_diffs, file_name = diff_data

--- a/src/tests/unit/test_suggestion_filter.py
+++ b/src/tests/unit/test_suggestion_filter.py
@@ -145,3 +145,78 @@ def test_positive_with_actionable_verb_kept(suggestion_filter):
     kept, removed = suggestion_filter.filter_suggestions([suggestion])
     assert len(kept) == 1
     assert len(removed) == 0
+
+
+def test_completed_change_praise_with_negative_keyword_filtered(suggestion_filter):
+    suggestion = _make_suggestion(
+        comment=(
+            "The change from `Number(targetEl.dataset.assetId)` to "
+            "`targetEl?.dataset.assetId ?? null` correctly reflects the new "
+            "string-based ID system. This is a good simplification, removing "
+            "an unnecessary type conversion."
+        )
+    )
+
+    kept, removed = suggestion_filter.filter_suggestions([suggestion])
+
+    assert kept == []
+    assert removed == [suggestion]
+
+
+def test_completed_change_description_with_unresolved_problem_kept(suggestion_filter):
+    suggestion = _make_suggestion(
+        comment=(
+            "This change correctly preserves the string ID, but it still fails "
+            "when the target element is missing. Add a null guard."
+        )
+    )
+
+    kept, removed = suggestion_filter.filter_suggestions([suggestion])
+
+    assert kept == [suggestion]
+    assert removed == []
+
+
+@pytest.mark.parametrize(
+    "comment",
+    [
+        "This is a good simplification that removes an unnecessary type conversion.",
+        "Nice catch removing the redundant null check here.",
+        "The refactor here is clean and removes an unnecessary conversion.",
+    ],
+)
+def test_completed_change_praise_variants_filtered(suggestion_filter, comment):
+    suggestion = _make_suggestion(comment=comment)
+
+    kept, removed = suggestion_filter.filter_suggestions([suggestion])
+
+    assert kept == []
+    assert removed == [suggestion]
+
+
+def test_praise_followed_by_separate_unresolved_problem_kept(suggestion_filter):
+    suggestion = _make_suggestion(
+        comment=(
+            "The change correctly removes the conversion. "
+            "It introduces a null dereference at line 40."
+        )
+    )
+
+    kept, removed = suggestion_filter.filter_suggestions([suggestion])
+
+    assert kept == [suggestion]
+    assert removed == []
+
+
+def test_completed_change_praise_with_same_sentence_harm_kept(suggestion_filter):
+    suggestion = _make_suggestion(
+        comment=(
+            "The change correctly removes the conversion and introduces a "
+            "null dereference at line 40."
+        )
+    )
+
+    kept, removed = suggestion_filter.filter_suggestions([suggestion])
+
+    assert kept == [suggestion]
+    assert removed == []

--- a/src/utils/diff_parser.py
+++ b/src/utils/diff_parser.py
@@ -125,6 +125,43 @@ class ParsedDiff:
         """Return the number of added + removed lines in this diff."""
         return len(self.commentable_lines)
 
+    def contains_applied_replacement(
+        self, existing_code: str, suggested_code: str
+    ) -> bool:
+        existing_lines = self._normalize_snippet(existing_code)
+        suggested_lines = self._normalize_snippet(suggested_code)
+        if not existing_lines or not suggested_lines:
+            return False
+
+        for hunk in self._patched_file:
+            removed_lines = [line.value.strip() for line in hunk if line.is_removed]
+            added_lines = [line.value.strip() for line in hunk if line.is_added]
+            if self._contains_lines(
+                removed_lines, existing_lines
+            ) and self._contains_lines(added_lines, suggested_lines):
+                return True
+
+        return False
+
+    @staticmethod
+    def _normalize_snippet(code: str) -> List[str]:
+        lines = []
+        for line in code.splitlines():
+            normalized = line.strip()
+            if normalized.startswith(("+", "-")):
+                normalized = normalized[1:].strip()
+            if normalized:
+                lines.append(normalized)
+        return lines
+
+    @staticmethod
+    def _contains_lines(lines: List[str], expected: List[str]) -> bool:
+        width = len(expected)
+        return any(
+            lines[index : index + width] == expected
+            for index in range(len(lines) - width + 1)
+        )
+
     def to_decoupled_format(self) -> str:
         """Convert the parsed diff into a decoupled old/new hunk format.
 

--- a/src/utils/line_mapper.py
+++ b/src/utils/line_mapper.py
@@ -35,6 +35,23 @@ class LineMapper:
             mapping["start_side"] = side
         return mapping
 
+    def suggestion_replays_diff(self, suggestion: CodeSuggestion) -> bool:
+        normalized_file_name = suggestion.file_name
+        if normalized_file_name.startswith(("a/", "b/")):
+            normalized_file_name = normalized_file_name[2:]
+
+        parsed_file = self.file_map.get(normalized_file_name)
+        if (
+            not parsed_file
+            or not suggestion.existing_code
+            or not suggestion.suggested_code
+        ):
+            return False
+
+        return parsed_file.contains_applied_replacement(
+            suggestion.existing_code, suggestion.suggested_code
+        )
+
     def validate_and_map_suggestion(
         self, suggestion: CodeSuggestion, strict_mode: bool = False
     ) -> Optional[Tuple[Dict, str]]:

--- a/src/utils/suggestion_filter.py
+++ b/src/utils/suggestion_filter.py
@@ -20,7 +20,7 @@ class SuggestionFilter:
     """
 
     POSITIVE_PATTERNS = [
-        r"\b(good|great|excellent|nice|well done|perfect|correctly|properly)\b",
+        r"\b(good|great|excellent|nice|clean|well done|perfect|correctly|properly)\b",
         r"\b(looks good|lgtm|ship it|no issues|no problems)\b",
         r"\b(appropriate|suitable|adequate|sufficient)\b",
         r"\bthis is (a )?(good|great|correct|proper)\b",
@@ -32,7 +32,8 @@ class SuggestionFilter:
     ]
 
     NEGATIVE_INDICATORS = [
-        r"\b(bug|error|issue|problem|flaw|vulnerability)\b",
+        r"\b(bug|error|issue|problem|flaw|vulnerability|crash|exception|regression)\b",
+        r"\bnull dereference\b",
         r"\b(should|could|might|consider|recommend|suggest)\b",
         r"\b(missing|lacks?|needs?|requires?)\b",
         r"\b(incorrect|wrong|invalid|broken|fails?)\b",
@@ -54,6 +55,22 @@ class SuggestionFilter:
         r"\bavoid\s+\w+",
     ]
 
+    COMPLETED_ACTIONS = [
+        r"\b(?:remov(?:e|es|ed|ing)|replac(?:e|es|ed|ing)|"
+        r"simplif(?:y|ies|ied|ying)|fix(?:es|ed|ing)?|"
+        r"address(?:es|ed|ing)?|avoid(?:s|ed|ing)?)\b",
+    ]
+
+    UNRESOLVED_TRANSITIONS = [
+        r"\b(?:but|however|although|though|yet|nevertheless)\b",
+    ]
+
+    UNRESOLVED_HARM = [
+        r"\b(?:introduces?|causes?|creates?|leads? to|still|remains?|fails?)\b"
+        r".{0,80}\b(?:bug|error|failure|crash|exception|vulnerability|"
+        r"regression|null dereference)\b",
+    ]
+
     def __init__(self):
         self._positive_regex = re.compile(
             "|".join(self.POSITIVE_PATTERNS), re.IGNORECASE
@@ -63,6 +80,15 @@ class SuggestionFilter:
         )
         self._actionable_regex = re.compile(
             "|".join(self.ACTIONABLE_VERBS), re.IGNORECASE
+        )
+        self._completed_action_regex = re.compile(
+            "|".join(self.COMPLETED_ACTIONS), re.IGNORECASE
+        )
+        self._unresolved_transition_regex = re.compile(
+            "|".join(self.UNRESOLVED_TRANSITIONS), re.IGNORECASE
+        )
+        self._unresolved_harm_regex = re.compile(
+            "|".join(self.UNRESOLVED_HARM), re.IGNORECASE
         )
         self._sentiment_analyzer = SentimentIntensityAnalyzer()
 
@@ -128,6 +154,9 @@ class SuggestionFilter:
         if self._is_code_identical(suggestion.existing_code, suggestion.suggested_code):
             return False, "suggested code identical to existing code"
 
+        if self._is_completed_change_praise(suggestion.comment):
+            return False, "comment praises a completed change"
+
         if self._is_positive_only(suggestion.comment):
             return False, "positive-only comment without actionable feedback"
 
@@ -187,20 +216,49 @@ class SuggestionFilter:
         """Check if a comment contains actionable verbs."""
         return bool(self._actionable_regex.search(comment))
 
+    def _is_completed_change_praise(self, comment: str) -> bool:
+        sentences = self._sentences(comment)
+        return (
+            bool(sentences)
+            and any(
+                self._completed_action_regex.search(sentence) for sentence in sentences
+            )
+            and all(self._is_positive_sentence(sentence) for sentence in sentences)
+        )
+
+    def _is_positive_sentence(self, sentence: str) -> bool:
+        if self._unresolved_transition_regex.search(
+            sentence
+        ) or self._unresolved_harm_regex.search(sentence):
+            return False
+
+        has_completed_action = bool(self._completed_action_regex.search(sentence))
+        if self._has_actionable_verbs(sentence) and not has_completed_action:
+            return False
+
+        scores = self._sentiment_analyzer.polarity_scores(sentence)
+        has_positive = scores["compound"] >= POSITIVE_SENTIMENT_THRESHOLD or bool(
+            self._positive_regex.search(sentence)
+        )
+        if not has_positive:
+            return False
+
+        has_negative = bool(self._negative_regex.search(sentence))
+        return not has_negative or has_completed_action
+
+    def _sentences(self, comment: str) -> List[str]:
+        return [
+            sentence.strip()
+            for sentence in re.split(r"(?<=[.!?])\s+(?=[A-Z])|\n+", comment)
+            if sentence.strip()
+        ]
+
     def _is_positive_only(self, comment: str) -> bool:
         """
         Detect if a comment is purely positive without actionable feedback.
         Returns True if the comment is just praise without criticism.
         """
-        has_negative = bool(self._negative_regex.search(comment))
-        if has_negative:
-            return False
-
-        if self._has_actionable_verbs(comment):
-            return False
-
-        scores = self._sentiment_analyzer.polarity_scores(comment)
-        if scores["compound"] >= POSITIVE_SENTIMENT_THRESHOLD:
-            return True
-
-        return bool(self._positive_regex.search(comment))
+        sentences = self._sentences(comment)
+        return bool(sentences) and all(
+            self._is_positive_sentence(sentence) for sentence in sentences
+        )


### PR DESCRIPTION
Review suggestions could pass the positive-feedback filter when praise described removing something unnecessary, then appear as risk findings. This rejects completed-change praise sentence by sentence, preserves comments that identify unresolved harm, and drops suggestions that replay the replacement already present in the pull request.