### PR TITLE
fix(review): Read a comment's sentences the way they are written

### DIFF
--- a/src/tests/unit/test_suggestion_filter.py
+++ b/src/tests/unit/test_suggestion_filter.py
@@ -220,3 +220,87 @@ def test_completed_change_praise_with_same_sentence_harm_kept(suggestion_filter)
 
     assert kept == [suggestion]
     assert removed == []
+
+
+def test_finding_in_a_lower_case_sentence_kept(suggestion_filter):
+    """A sentence need not begin in upper case, and the finding in one was being
+    read as part of the praise before it."""
+    suggestion = _make_suggestion(
+        comment="Correctly removed the cast. it now throws on null input."
+    )
+
+    kept, removed = suggestion_filter.filter_suggestions([suggestion])
+
+    assert kept == [suggestion]
+    assert removed == []
+
+
+def test_abbreviation_does_not_end_a_sentence(suggestion_filter):
+    suggestion = _make_suggestion(
+        comment=(
+            "The change correctly removes the cast e.g. the Number() call. "
+            "It now crashes on null."
+        )
+    )
+
+    kept, removed = suggestion_filter.filter_suggestions([suggestion])
+
+    assert kept == [suggestion]
+    assert removed == []
+
+
+def test_fault_reported_in_the_plural_kept(suggestion_filter):
+    for comment in (
+        "This crashes on null input.",
+        "This raises exceptions when the list is empty.",
+        "This introduces regressions in the mapper.",
+    ):
+        suggestion = _make_suggestion(comment=comment)
+
+        kept, removed = suggestion_filter.filter_suggestions([suggestion])
+
+        assert kept == [suggestion], comment
+        assert removed == [], comment
+
+
+def test_runtime_fault_without_an_actionable_verb_kept(suggestion_filter):
+    """A reviewer reports what goes wrong at runtime without always naming it a
+    bug or asking for a change."""
+    for comment in (
+        "Nicely simplified. This leaks the file handle.",
+        "It hangs when the queue is empty.",
+        "This panics on an empty slice.",
+    ):
+        suggestion = _make_suggestion(comment=comment)
+
+        kept, removed = suggestion_filter.filter_suggestions([suggestion])
+
+        assert kept == [suggestion], comment
+        assert removed == [], comment
+
+
+def test_praise_for_a_completed_change_still_filtered(suggestion_filter):
+    for comment in (
+        "This is a good simplification that removes an unnecessary type conversion.",
+        "Nice catch removing the redundant null check here.",
+        "The refactor here is clean and removes an unnecessary conversion.",
+    ):
+        suggestion = _make_suggestion(comment=comment)
+
+        kept, removed = suggestion_filter.filter_suggestions([suggestion])
+
+        assert kept == [], comment
+        assert removed == [suggestion], comment
+
+
+def test_inline_code_does_not_end_a_sentence(suggestion_filter):
+    """A comment quotes the code it is about, and that code carries the same
+    characters a sentence ends with."""
+    suggestion = _make_suggestion(
+        comment="Correctly uses `a ?? b` now. it still leaks the handle."
+    )
+
+    kept, removed = suggestion_filter.filter_suggestions([suggestion])
+
+    assert kept == [suggestion]
+    assert removed == []

--- a/src/utils/suggestion_filter.py
+++ b/src/utils/suggestion_filter.py
@@ -32,11 +32,14 @@ class SuggestionFilter:
     ]
 
     NEGATIVE_INDICATORS = [
-        r"\b(bug|error|issue|problem|flaw|vulnerability|crash|exception|regression)\b",
+        r"\b(bugs?|errors?|issues?|problems?|flaws?|vulnerabilit(?:y|ies)|"
+        r"crash(?:es)?|exceptions?|regressions?)\b",
         r"\bnull dereference\b",
         r"\b(should|could|might|consider|recommend|suggest)\b",
         r"\b(missing|lacks?|needs?|requires?)\b",
         r"\b(incorrect|wrong|invalid|broken|fails?)\b",
+        # How a reviewer reports a fault at runtime, rather than naming it.
+        r"\b(throws?|throwing|raises?|raising|panics?|hangs?|leaks?)\b",
         r"\b(improve|fix|refactor|optimize|simplify)\b",
         r"\b(avoid|don'?t|shouldn'?t|never)\b",
         r"\b(instead|rather|better|prefer)\b",
@@ -61,14 +64,17 @@ class SuggestionFilter:
         r"address(?:es|ed|ing)?|avoid(?:s|ed|ing)?)\b",
     ]
 
+    ABBREVIATIONS = ("e.g.", "i.e.", "etc.", "vs.", "cf.", "approx.", "resp.")
+
     UNRESOLVED_TRANSITIONS = [
         r"\b(?:but|however|although|though|yet|nevertheless)\b",
     ]
 
     UNRESOLVED_HARM = [
         r"\b(?:introduces?|causes?|creates?|leads? to|still|remains?|fails?)\b"
-        r".{0,80}\b(?:bug|error|failure|crash|exception|vulnerability|"
-        r"regression|null dereference)\b",
+        r".{0,80}\b(?:bugs?|errors?|failures?|crash(?:es)?|exceptions?|"
+        r"vulnerabilit(?:y|ies)|"
+        r"regressions?|null dereferences?)\b",
     ]
 
     def __init__(self):
@@ -247,11 +253,36 @@ class SuggestionFilter:
         return not has_negative or has_completed_action
 
     def _sentences(self, comment: str) -> List[str]:
-        return [
-            sentence.strip()
-            for sentence in re.split(r"(?<=[.!?])\s+(?=[A-Z])|\n+", comment)
-            if sentence.strip()
-        ]
+        sentences: List[str] = []
+        for part in self._split_sentences(comment):
+            part = part.strip()
+            if not part:
+                continue
+            # An abbreviation ends in a full stop without ending a sentence, so
+            # what follows belongs to the sentence before it.
+            if sentences and sentences[-1].lower().endswith(self.ABBREVIATIONS):
+                sentences[-1] = f"{sentences[-1]} {part}"
+            else:
+                sentences.append(part)
+        return sentences
+
+    def _split_sentences(self, comment: str) -> List[str]:
+        """Split on sentence ends, but not on punctuation inside inline code.
+
+        A comment quotes the code it is about, and that code carries the same
+        characters a sentence ends with.
+        """
+        parts: List[str] = []
+        cursor = 0
+        for match in re.finditer(r"(?<=[.!?])\s+|\n+", comment):
+            # An odd number of backticks before this point means it falls inside
+            # a quoted span, where a full stop ends nothing.
+            if comment.count("`", 0, match.start()) % 2:
+                continue
+            parts.append(comment[cursor : match.start()])
+            cursor = match.end()
+        parts.append(comment[cursor:])
+        return parts
 
     def _is_positive_only(self, comment: str) -> bool:
         """


### PR DESCRIPTION
Follow-up to #98. Rejecting praise for a change already made rests on reading a comment sentence by sentence, and the reading was too narrow to be relied on. Four ways a real finding was still being discarded:

- A sentence beginning in lower case was swallowed by the one before it, so `Correctly removed the cast. it now throws on null input.` read as pure praise.
- An abbreviation ended a sentence, cutting one in half at `e.g.`
- A fault reported in the plural was not recognised as a fault: `crash` matched but `crashes` did not, while the existing `fails?` handled both.
- A fault reported by what it does at runtime, rather than by naming it, matched nothing at all. `it throws on null input` and `this leaks the file handle` were discarded as remarks with nothing to act on.

Sentence ends are also no longer looked for inside quoted code. A comment quotes the code it is about, and that code carries the same characters a sentence ends with. Without this, `` `targetEl?.dataset.assetId ?? null` `` splits the sentence at the `??` and the comment stops being readable as praise, which regressed the case #98 was written to catch.

Each is covered by a test, and the cases #98 added still pass.
