### PR TITLE
feat(reviews): Serve what a change touches, and let a repository configure reuse

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -61,6 +61,7 @@ app = FastAPI(
 
 from src.api.routes import repos as repo_endpoints
 from src.api.routes import reviews as review_endpoints
+from src.api.routes import settings as settings_endpoints
 from src.api.routes import triage as triage_endpoints
 
 app.include_router(app_endpoints.router, tags=["general"])
@@ -68,5 +69,6 @@ app.include_router(pr_endpoints.router, prefix="/api/prs", tags=["pull_requests"
 app.include_router(repo_endpoints.router, prefix="/api/repos", tags=["repositories"])
 app.include_router(review_endpoints.router, prefix="/api/reviews", tags=["reviews"])
 app.include_router(triage_endpoints.router, prefix="/api/triage", tags=["triage"])
+app.include_router(settings_endpoints.router, prefix="/api/settings", tags=["settings"])
 if mcp_http_app is not None:
     app.mount("/mcp", mcp_http_app)

--- a/src/api/routes/reviews.py
+++ b/src/api/routes/reviews.py
@@ -9,6 +9,8 @@ from src.auth import get_current_user
 from src.config.db import get_session
 from src.core.responses import success_response
 from src.models.review_record import ReviewRecord
+from src.utils.review_cache import get_review as get_cached_review
+from src.utils.review_cache import save_review as save_cached_review
 
 router = APIRouter()
 
@@ -20,6 +22,8 @@ class RerunRequest(BaseModel):
     number: int
     # Preview by default: generate the review and return it without posting.
     post: bool = False
+    # Ignore a review already generated for this revision and pay for a new one.
+    refresh: bool = False
 
 
 @router.post("/rerun")
@@ -52,6 +56,12 @@ async def rerun_review(
         raise HTTPException(status_code=502, detail="Could not load the pull request")
     pr = pr_resp.json()
 
+    head_sha = (pr.get("head") or {}).get("sha")
+    if not data.post and not data.refresh:
+        cached = get_cached_review(data.repo, data.number, head_sha)
+        if cached:
+            return success_response({**cached, "cached": True})
+
     plugin = plugin_registry.get_plugin("code_reviewer")
     if plugin is None:
         raise HTTPException(status_code=503, detail="Reviewer is not available")
@@ -81,7 +91,9 @@ async def rerun_review(
         repository_full_name=data.repo,
         post=data.post,
     )
-    return success_response(result)
+    if result.get("status") == "success":
+        save_cached_review(data.repo, data.number, head_sha, result)
+    return success_response({**result, "cached": False})
 
 
 async def _fetch_pull_request(

--- a/src/api/routes/reviews.py
+++ b/src/api/routes/reviews.py
@@ -179,6 +179,8 @@ async def review_detail(
             "state": pr["state"],
             "author": (pr.get("user") or {}).get("login"),
             "url": pr.get("html_url"),
+            "head_sha": (pr.get("head") or {}).get("sha"),
+            "base_sha": (pr.get("base") or {}).get("sha"),
             "reviews": [
                 {
                     "author": (r.get("user") or {}).get("login"),

--- a/src/api/routes/reviews.py
+++ b/src/api/routes/reviews.py
@@ -176,7 +176,7 @@ async def review_detail(
             raise HTTPException(status_code=502, detail="GitHub API error")
         pr = pr_resp.json()
 
-        reviews_resp, comments_resp = await asyncio.gather(
+        reviews_resp, comments_resp, files_resp = await asyncio.gather(
             client.get(
                 f"{_GITHUB_API}/repos/{repo}/pulls/{number}/reviews",
                 headers=headers,
@@ -187,9 +187,15 @@ async def review_detail(
                 headers=headers,
                 params={"per_page": 100},
             ),
+            client.get(
+                f"{_GITHUB_API}/repos/{repo}/pulls/{number}/files",
+                headers=headers,
+                params={"per_page": 100},
+            ),
         )
         reviews = reviews_resp.json() if reviews_resp.status_code == 200 else []
         comments = comments_resp.json() if comments_resp.status_code == 200 else []
+        files = files_resp.json() if files_resp.status_code == 200 else []
 
     return success_response(
         {
@@ -229,6 +235,20 @@ async def review_detail(
                 }
                 for c in comments
                 if c.get("body")
+            ],
+            # What the change touches at all, not only what the review remarked
+            # on. A file nobody expected to see is a finding in itself.
+            "files": [
+                {
+                    "filename": f.get("filename"),
+                    "previous_filename": f.get("previous_filename"),
+                    "status": f.get("status"),
+                    "additions": f.get("additions", 0),
+                    "deletions": f.get("deletions", 0),
+                    "changes": f.get("changes", 0),
+                    "patch": f.get("patch"),
+                }
+                for f in files
             ],
         }
     )

--- a/src/api/routes/reviews.py
+++ b/src/api/routes/reviews.py
@@ -164,12 +164,20 @@ async def review_detail(
             raise HTTPException(status_code=502, detail="GitHub API error")
         pr = pr_resp.json()
 
-        reviews_resp = await client.get(
-            f"{_GITHUB_API}/repos/{repo}/pulls/{number}/reviews",
-            headers=headers,
-            params={"per_page": 50},
+        reviews_resp, comments_resp = await asyncio.gather(
+            client.get(
+                f"{_GITHUB_API}/repos/{repo}/pulls/{number}/reviews",
+                headers=headers,
+                params={"per_page": 50},
+            ),
+            client.get(
+                f"{_GITHUB_API}/repos/{repo}/pulls/{number}/comments",
+                headers=headers,
+                params={"per_page": 100},
+            ),
         )
         reviews = reviews_resp.json() if reviews_resp.status_code == 200 else []
+        comments = comments_resp.json() if comments_resp.status_code == 200 else []
 
     return success_response(
         {
@@ -190,6 +198,25 @@ async def review_detail(
                 }
                 for r in reviews
                 if r.get("body")
+            ],
+            # The findings themselves are inline comments, not the review body,
+            # which carries only a pointer to the overview comment.
+            "comments": [
+                {
+                    "id": c.get("id"),
+                    "author": (c.get("user") or {}).get("login"),
+                    "body": c.get("body") or "",
+                    "path": c.get("path"),
+                    "line": c.get("line") or c.get("original_line"),
+                    "start_line": c.get("start_line") or c.get("original_start_line"),
+                    "side": c.get("side"),
+                    "diff_hunk": c.get("diff_hunk"),
+                    "in_reply_to_id": c.get("in_reply_to_id"),
+                    "url": c.get("html_url"),
+                    "created_at": c.get("created_at"),
+                }
+                for c in comments
+                if c.get("body")
             ],
         }
     )

--- a/src/api/routes/settings.py
+++ b/src/api/routes/settings.py
@@ -1,0 +1,118 @@
+"""Read and change what a repository or organisation has configured.
+
+Every response says where a value came from, so a screen can show whether it is
+set here, inherited from the organisation, or simply the shipped default, and
+can offer to go back to inheriting.
+"""
+
+from dataclasses import asdict
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from src.auth import get_current_user
+from src.core.responses import success_response
+from src.core.settings import (
+    ORGANIZATION,
+    REPOSITORY,
+    Resolved,
+    clear_value,
+    for_scope,
+    resolve_all,
+    set_value,
+)
+
+router = APIRouter()
+
+Scope = Literal["repository", "organization"]
+
+
+class SettingInput(BaseModel):
+    value: Any
+
+
+def _described(resolved: Resolved) -> dict:
+    setting = resolved.setting
+    return {
+        "key": resolved.key,
+        "value": resolved.value,
+        "source": resolved.source,
+        "source_id": resolved.source_id,
+        "label": setting.label if setting else resolved.key,
+        "description": setting.description if setting else "",
+        "type": setting.type if setting else "string",
+        "default": setting.default if setting else None,
+        "unit": setting.unit if setting else None,
+        "minimum": setting.minimum if setting else None,
+        "maximum": setting.maximum if setting else None,
+        "choices": list(setting.choices) if setting else [],
+        "group": setting.group if setting else "General",
+    }
+
+
+@router.get("/catalogue")
+async def catalogue(
+    scope: Scope = REPOSITORY,
+    user: dict = Depends(get_current_user),
+):
+    """Everything that can be configured at this scope, without any values."""
+    return success_response([asdict(setting) for setting in for_scope(scope)])
+
+
+@router.get("/{scope}/{scope_id:path}")
+async def read_settings(
+    scope: Scope,
+    scope_id: str,
+    user: dict = Depends(get_current_user),
+):
+    """Every setting that applies here, resolved, with where each came from."""
+    if scope == REPOSITORY:
+        resolved = resolve_all(repository=scope_id)
+    else:
+        resolved = resolve_all(organization=scope_id)
+    return success_response([_described(item) for item in resolved])
+
+
+@router.put("/{scope}/{scope_id:path}/{key}")
+async def write_setting(
+    scope: Scope,
+    scope_id: str,
+    key: str,
+    payload: SettingInput,
+    user: dict = Depends(get_current_user),
+):
+    """Give one setting a value here. Narrower scopes still win over this one."""
+    try:
+        resolved = set_value(scope, scope_id, key, payload.value)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Unknown setting: {key}")
+    except (ValueError, TypeError) as error:
+        raise HTTPException(status_code=422, detail=str(error))
+    return success_response(_described(resolved))
+
+
+@router.delete("/{scope}/{scope_id:path}/{key}")
+async def reset_setting(
+    scope: Scope,
+    scope_id: str,
+    key: str,
+    user: dict = Depends(get_current_user),
+):
+    """Stop setting this here, so it goes back to whatever it inherits."""
+    try:
+        clear_value(scope, scope_id, key)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Unknown setting: {key}")
+
+    if scope == REPOSITORY:
+        resolved = resolve_all(repository=scope_id)
+    else:
+        resolved = resolve_all(organization=scope_id)
+    current = next((item for item in resolved if item.key == key), None)
+    if current is None:
+        raise HTTPException(status_code=404, detail=f"Unknown setting: {key}")
+    return success_response(_described(current))
+
+
+__all__ = ["router", "ORGANIZATION", "REPOSITORY"]

--- a/src/core/settings/__init__.py
+++ b/src/core/settings/__init__.py
@@ -1,0 +1,35 @@
+from .definitions import (
+    ORGANIZATION,
+    REPOSITORY,
+    SCOPE_ORDER,
+    SETTINGS,
+    Resolved,
+    Setting,
+    for_scope,
+    get,
+)
+from .resolver import (
+    clear_value,
+    organization_of,
+    resolve,
+    resolve_all,
+    set_value,
+    value_of,
+)
+
+__all__ = [
+    "ORGANIZATION",
+    "REPOSITORY",
+    "SCOPE_ORDER",
+    "SETTINGS",
+    "Resolved",
+    "Setting",
+    "clear_value",
+    "for_scope",
+    "get",
+    "organization_of",
+    "resolve",
+    "resolve_all",
+    "set_value",
+    "value_of",
+]

--- a/src/core/settings/definitions.py
+++ b/src/core/settings/definitions.py
@@ -1,0 +1,111 @@
+"""What can be configured, declared once.
+
+A setting is described here rather than read straight out of the store, so that
+everything downstream, the resolver, the API, and the screen a person edits it
+on, works from the same declaration. Adding a setting is one entry, not a new
+endpoint and a new form field.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from src.models.config import ConfigType
+
+# Where a setting can be given a value. Order matters: the narrowest scope that
+# has a value wins, which is what lets a repository depart from its
+# organisation without detaching from it.
+REPOSITORY = "repository"
+ORGANIZATION = "organization"
+
+SCOPE_ORDER: tuple[str, ...] = (REPOSITORY, ORGANIZATION)
+
+
+@dataclass(frozen=True)
+class Setting:
+    key: str
+    label: str
+    description: str
+    type: str
+    default: Any
+    # The scopes this setting may be given a value at, narrowest first.
+    scopes: tuple[str, ...] = SCOPE_ORDER
+    # What the number means, so a screen can say "days" without hardcoding it.
+    unit: str | None = None
+    minimum: float | None = None
+    maximum: float | None = None
+    choices: tuple[str, ...] = ()
+    # Grouping for presentation, so related settings stay together.
+    group: str = "General"
+
+    def validate(self, value: Any) -> Any:
+        """Return the value coerced to this setting's type, or raise ValueError."""
+        coerced = _coerce(value, self.type)
+        if self.choices and str(coerced) not in self.choices:
+            raise ValueError(f"{self.key} must be one of {', '.join(self.choices)}")
+        if self.minimum is not None and coerced < self.minimum:
+            raise ValueError(f"{self.key} cannot be below {self.minimum}")
+        if self.maximum is not None and coerced > self.maximum:
+            raise ValueError(f"{self.key} cannot be above {self.maximum}")
+        return coerced
+
+
+def _coerce(value: Any, type_: str) -> Any:
+    if type_ == ConfigType.BOOL:
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() in ("true", "1", "yes", "on")
+    if type_ == ConfigType.INT:
+        return int(value)
+    if type_ == ConfigType.FLOAT:
+        return float(value)
+    if type_ == ConfigType.JSON:
+        return value
+    return str(value)
+
+
+SETTINGS: tuple[Setting, ...] = (
+    Setting(
+        key="review.reuse_days",
+        label="Reuse a review for",
+        description=(
+            "How long a generated review is served again for the same revision "
+            "before it is generated afresh. A new commit is reviewed again "
+            "regardless."
+        ),
+        type=ConfigType.INT,
+        default=7,
+        unit="days",
+        minimum=0,
+        maximum=90,
+        group="Review",
+    ),
+)
+
+BY_KEY: Mapping[str, Setting] = {setting.key: setting for setting in SETTINGS}
+
+
+def get(key: str) -> Setting:
+    setting = BY_KEY.get(key)
+    if setting is None:
+        raise KeyError(f"Unknown setting: {key}")
+    return setting
+
+
+def for_scope(scope: str) -> tuple[Setting, ...]:
+    """The settings that may be given a value at this scope."""
+    return tuple(setting for setting in SETTINGS if scope in setting.scopes)
+
+
+@dataclass(frozen=True)
+class Resolved:
+    """A value, and where it came from, so a screen can say which."""
+
+    key: str
+    value: Any
+    # "repository", "organization", or "default".
+    source: str
+    # The scope the value was read from, absent when it is the default.
+    source_id: str | None = None
+    setting: Setting | None = field(default=None, compare=False)

--- a/src/core/settings/resolver.py
+++ b/src/core/settings/resolver.py
@@ -1,0 +1,107 @@
+"""Resolve a setting for a repository, falling back the way a reader expects.
+
+A repository takes its organisation's answer unless it has given its own, and
+an organisation takes the shipped default unless it has given its own. The
+answer carries where it came from, so a screen can show whether a value is set
+here, inherited, or simply the default.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from src.core.settings.definitions import (
+    ORGANIZATION,
+    REPOSITORY,
+    Resolved,
+    Setting,
+    for_scope,
+    get,
+)
+from src.models.config import Config
+from src.utils.logger import logger
+
+
+def organization_of(repository: str) -> Optional[str]:
+    """The organisation a repository belongs to, from its full name."""
+    owner, separator, _ = repository.partition("/")
+    return owner if separator and owner else None
+
+
+def _stored(setting: Setting, scope: str, scope_id: str) -> Any:
+    if scope not in setting.scopes:
+        return None
+    try:
+        raw = Config.get_value(scope, scope_id, setting.key)
+    except Exception as error:
+        # A setting that cannot be read falls back rather than failing the
+        # request that needed it.
+        logger.warning(f"Could not read {setting.key} for {scope} {scope_id}: {error}")
+        return None
+    if raw is None:
+        return None
+    try:
+        return setting.validate(raw)
+    except ValueError as error:
+        logger.warning(
+            f"Ignoring invalid {setting.key} for {scope} {scope_id}: {error}"
+        )
+        return None
+
+
+def resolve(
+    key: str,
+    repository: Optional[str] = None,
+    organization: Optional[str] = None,
+) -> Resolved:
+    """Resolve one setting, narrowest scope first."""
+    setting = get(key)
+
+    if repository:
+        value = _stored(setting, REPOSITORY, repository)
+        if value is not None:
+            return Resolved(key, value, REPOSITORY, repository, setting)
+
+    owner = organization or (organization_of(repository) if repository else None)
+    if owner:
+        value = _stored(setting, ORGANIZATION, owner)
+        if value is not None:
+            return Resolved(key, value, ORGANIZATION, owner, setting)
+
+    return Resolved(key, setting.default, "default", None, setting)
+
+
+def value_of(
+    key: str,
+    repository: Optional[str] = None,
+    organization: Optional[str] = None,
+) -> Any:
+    """The resolved value alone, for callers that do not care where it came from."""
+    return resolve(key, repository, organization).value
+
+
+def resolve_all(
+    repository: Optional[str] = None,
+    organization: Optional[str] = None,
+) -> tuple[Resolved, ...]:
+    """Every setting that applies to this scope, resolved."""
+    scope = REPOSITORY if repository else ORGANIZATION
+    return tuple(
+        resolve(setting.key, repository, organization) for setting in for_scope(scope)
+    )
+
+
+def set_value(scope: str, scope_id: str, key: str, value: Any) -> Resolved:
+    """Give a setting a value at one scope. Raises ValueError if it is not valid."""
+    setting = get(key)
+    if scope not in setting.scopes:
+        raise ValueError(f"{key} cannot be set at the {scope} level")
+    coerced = setting.validate(value)
+    Config.set_value(scope, scope_id, key, coerced, setting.type)
+    return Resolved(key, coerced, scope, scope_id, setting)
+
+
+def clear_value(scope: str, scope_id: str, key: str) -> None:
+    """Remove a value so the scope goes back to inheriting."""
+    setting = get(key)
+    Config.delete_value(scope, scope_id, setting.key)

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -125,6 +125,25 @@ class Config(BaseModel, table=True):
             session.refresh(entry)
         return entry
 
+    @classmethod
+    def delete_value(
+        cls, configurable_type: str, configurable_id: str, key: str
+    ) -> bool:
+        """Remove a config entry so the entity falls back to what it inherits."""
+        with next(get_session()) as session:
+            entry = session.exec(
+                select(cls).where(
+                    cls.configurable_type == configurable_type,
+                    cls.configurable_id == configurable_id,
+                    cls.key == key,
+                )
+            ).first()
+            if entry is None:
+                return False
+            session.delete(entry)
+            session.commit()
+        return True
+
     @staticmethod
     def _serialize_value(value: Any, type: str) -> str:
         """Convert a Python value to its string representation for storage."""

--- a/src/plugins/builtin/code_reviewer/plugin.py
+++ b/src/plugins/builtin/code_reviewer/plugin.py
@@ -427,7 +427,9 @@ class CodeReviewerPlugin(BasePlugin):
             return {
                 "status": "success",
                 "review_posted": post_result,
-                "review": final_review.model_dump() if final_review else None,
+                "review": (
+                    final_review.model_dump(mode="json") if final_review else None
+                ),
                 "suggestions_count": (
                     len(final_review.code_suggestions)
                     if final_review.code_suggestions

--- a/src/tests/unit/test_code_reviewer_plugin.py
+++ b/src/tests/unit/test_code_reviewer_plugin.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -11,6 +13,7 @@ from src.models.code_review import (
 )
 from src.models.repository import Repository
 from src.models.pull_request import PullRequest
+from src.core.responses import success_response
 
 
 @pytest.fixture
@@ -399,3 +402,84 @@ class TestFilterDuplicateSuggestions:
 
         result = plugin._filter_duplicate_suggestions(suggestions, existing)
         assert len(result) == 0
+
+
+_DIFF = """diff --git a/test.py b/test.py
+index 1111111..2222222 100644
+--- a/test.py
++++ b/test.py
+@@ -7,7 +7,7 @@ def load(path):
+     if not path:
+         return None
+ 
+-    f = open(path)
+-    data = f.read()
+-    f.close()
++    f = open(path, "r")
++    data = f.read()
++    f.close()
+     return data
+"""
+
+
+class TestPreviewResponseIsSerializable:
+    @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
+    @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
+    @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
+    @patch("src.plugins.builtin.code_reviewer.plugin.llm")
+    def test_preview_run_renders_as_json(
+        self,
+        mock_llm,
+        mock_github_cls,
+        mock_get_sha,
+        mock_save_record,
+        plugin,
+        repository,
+        pull_request,
+    ):
+        mock_get_sha.return_value = None
+
+        mock_github = MagicMock()
+        mock_github_cls.return_value = mock_github
+        mock_github.get_diff.return_value = _DIFF
+        mock_github.get_existing_bot_review_comments.return_value = []
+
+        mock_llm_instance = MagicMock()
+        mock_llm.return_value = mock_llm_instance
+        mock_llm_instance.count_tokens.return_value = 100
+        mock_llm_instance.token_limit = 1000000
+        mock_llm_instance.generate_code_review.return_value = CodeReview(
+            verdict=Verdict.REQUEST_CHANGES,
+            code_suggestions=[
+                CodeSuggestion(
+                    file_name="test.py",
+                    start_line=10,
+                    end_line=12,
+                    side=Side.RIGHT,
+                    comment="Consider a context manager so the file is closed on failure.",
+                    category=SuggestionCategory.BUG,
+                    existing_code='    f = open(path, "r")\n    data = f.read()\n    f.close()',
+                    suggested_code="    with open(path) as f:\n        data = f.read()",
+                )
+            ],
+        )
+
+        import asyncio
+
+        result = asyncio.get_event_loop().run_until_complete(
+            plugin.generate_review(
+                repository,
+                pull_request,
+                repository_full_name="test_owner/test_repo",
+                post=False,
+            )
+        )
+
+        assert result["status"] == "success"
+        mock_github.post_review.assert_not_called()
+
+        body = json.loads(success_response(result).body)
+        suggestion = body["data"]["review"]["code_suggestions"][0]
+        assert suggestion["side"] == "RIGHT"
+        assert suggestion["category"] == "BUG"
+        assert body["data"]["review"]["verdict"] == "REQUEST_CHANGES"

--- a/src/tests/unit/test_core_settings.py
+++ b/src/tests/unit/test_core_settings.py
@@ -1,0 +1,130 @@
+import pytest
+
+from src.core.settings import definitions
+from src.core.settings.definitions import ORGANIZATION, REPOSITORY, Setting
+from src.core.settings.resolver import organization_of
+from src.models.config import ConfigType
+
+
+@pytest.fixture
+def store(monkeypatch):
+    """A configuration store held in memory, so resolution is tested on its own."""
+    entries: dict[tuple[str, str, str], object] = {}
+
+    class FakeConfig:
+        @staticmethod
+        def get_value(scope, scope_id, key, default=None):
+            return entries.get((scope, scope_id, key), default)
+
+        @staticmethod
+        def set_value(scope, scope_id, key, value, type=ConfigType.STRING):
+            entries[(scope, scope_id, key)] = value
+
+        @staticmethod
+        def delete_value(scope, scope_id, key):
+            return entries.pop((scope, scope_id, key), None) is not None
+
+    monkeypatch.setattr("src.core.settings.resolver.Config", FakeConfig)
+    return entries
+
+
+@pytest.fixture
+def reuse_days(monkeypatch):
+    setting = Setting(
+        key="review.reuse_days",
+        label="Reuse a review for",
+        description="",
+        type=ConfigType.INT,
+        default=7,
+        minimum=0,
+        maximum=90,
+    )
+    monkeypatch.setattr(definitions, "SETTINGS", (setting,))
+    monkeypatch.setattr(definitions, "BY_KEY", {setting.key: setting})
+    return setting
+
+
+class TestResolution:
+    def test_falls_back_to_the_shipped_default(self, store, reuse_days):
+        from src.core.settings.resolver import resolve
+
+        answer = resolve("review.reuse_days", repository="acme/web")
+
+        assert answer.value == 7
+        assert answer.source == "default"
+        assert answer.source_id is None
+
+    def test_a_repository_takes_what_its_organisation_says(self, store, reuse_days):
+        from src.core.settings.resolver import resolve, set_value
+
+        set_value(ORGANIZATION, "acme", "review.reuse_days", 14)
+        answer = resolve("review.reuse_days", repository="acme/web")
+
+        assert answer.value == 14
+        assert answer.source == ORGANIZATION
+        assert answer.source_id == "acme"
+
+    def test_a_repository_may_depart_from_its_organisation(self, store, reuse_days):
+        from src.core.settings.resolver import resolve, set_value
+
+        set_value(ORGANIZATION, "acme", "review.reuse_days", 14)
+        set_value(REPOSITORY, "acme/web", "review.reuse_days", 2)
+        answer = resolve("review.reuse_days", repository="acme/web")
+
+        assert answer.value == 2
+        assert answer.source == REPOSITORY
+
+    def test_clearing_a_repository_value_inherits_again(self, store, reuse_days):
+        from src.core.settings.resolver import clear_value, resolve, set_value
+
+        set_value(ORGANIZATION, "acme", "review.reuse_days", 14)
+        set_value(REPOSITORY, "acme/web", "review.reuse_days", 2)
+        clear_value(REPOSITORY, "acme/web", "review.reuse_days")
+
+        assert resolve("review.reuse_days", repository="acme/web").value == 14
+
+    def test_one_repository_does_not_answer_for_another(self, store, reuse_days):
+        from src.core.settings.resolver import resolve, set_value
+
+        set_value(REPOSITORY, "acme/web", "review.reuse_days", 2)
+
+        assert resolve("review.reuse_days", repository="acme/api").value == 7
+
+    def test_a_stored_value_that_is_no_longer_valid_is_ignored(self, store, reuse_days):
+        from src.core.settings.resolver import resolve
+
+        store[(REPOSITORY, "acme/web", "review.reuse_days")] = 5000
+
+        answer = resolve("review.reuse_days", repository="acme/web")
+
+        assert answer.value == 7
+        assert answer.source == "default"
+
+
+class TestWriting:
+    def test_refuses_a_value_outside_what_the_setting_allows(self, store, reuse_days):
+        from src.core.settings.resolver import set_value
+
+        with pytest.raises(ValueError):
+            set_value(REPOSITORY, "acme/web", "review.reuse_days", 500)
+
+    def test_refuses_a_setting_it_does_not_know(self, store, reuse_days):
+        from src.core.settings.resolver import set_value
+
+        with pytest.raises(KeyError):
+            set_value(REPOSITORY, "acme/web", "review.invented", 1)
+
+    def test_reads_a_value_written_as_text(self, store, reuse_days):
+        from src.core.settings.resolver import resolve, set_value
+
+        set_value(REPOSITORY, "acme/web", "review.reuse_days", "3")
+
+        assert resolve("review.reuse_days", repository="acme/web").value == 3
+
+
+class TestOrganizationOf:
+    def test_takes_the_owner_from_a_full_name(self):
+        assert organization_of("sourceant/dashboard") == "sourceant"
+
+    def test_has_no_organisation_without_one(self):
+        assert organization_of("dashboard") is None

--- a/src/utils/review_cache.py
+++ b/src/utils/review_cache.py
@@ -2,17 +2,19 @@
 
 Generating a review costs a model run, so one is kept per revision and served
 again until the change moves. The key carries the revision, so a new commit
-misses rather than needing invalidation.
+misses rather than needing invalidation. How long a review is worth reusing is
+a judgement about the repository, so it is asked of the repository rather than
+fixed here.
 """
 
 import json
 from typing import Any, Dict, Optional
 
 from src.config.settings import REDIS_HOST, REDIS_PORT
+from src.core.settings import value_of
 from src.utils.logger import logger
 
-# A review is only worth reusing while the pull request is still being worked on.
-TTL_SECONDS = 7 * 24 * 60 * 60
+SECONDS_PER_DAY = 24 * 60 * 60
 
 _client = None
 _unavailable = False
@@ -55,6 +57,12 @@ def get_review(
         return None
 
 
+def _ttl_seconds(repo_full_name: str) -> int:
+    """How long this repository reuses a review, as it or its organisation says."""
+    days = value_of("review.reuse_days", repository=repo_full_name)
+    return int(days) * SECONDS_PER_DAY
+
+
 def save_review(
     repo_full_name: str,
     pr_number: int,
@@ -66,9 +74,13 @@ def save_review(
     client = _redis()
     if client is None:
         return
+    ttl = _ttl_seconds(repo_full_name)
+    # Reuse turned off entirely means nothing is worth storing.
+    if ttl <= 0:
+        return
     try:
         client.setex(
-            _key(repo_full_name, pr_number, head_sha), TTL_SECONDS, json.dumps(payload)
+            _key(repo_full_name, pr_number, head_sha), ttl, json.dumps(payload)
         )
     except Exception as e:
         logger.warning(f"Could not write the review cache: {e}")

--- a/src/utils/review_cache.py
+++ b/src/utils/review_cache.py
@@ -1,0 +1,74 @@
+"""Reuse of generated reviews.
+
+Generating a review costs a model run, so one is kept per revision and served
+again until the change moves. The key carries the revision, so a new commit
+misses rather than needing invalidation.
+"""
+
+import json
+from typing import Any, Dict, Optional
+
+from src.config.settings import REDIS_HOST, REDIS_PORT
+from src.utils.logger import logger
+
+# A review is only worth reusing while the pull request is still being worked on.
+TTL_SECONDS = 7 * 24 * 60 * 60
+
+_client = None
+_unavailable = False
+
+
+def _redis():
+    """The cache is best effort: a review still generates when Redis is absent."""
+    global _client, _unavailable
+    if _client is not None or _unavailable:
+        return _client
+    try:
+        import redis
+
+        client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, db=1)
+        client.ping()
+        _client = client
+    except Exception as e:
+        logger.warning(f"Review cache unavailable, reviews will regenerate: {e}")
+        _unavailable = True
+    return _client
+
+
+def _key(repo_full_name: str, pr_number: int, head_sha: str) -> str:
+    return f"review:{repo_full_name}:{pr_number}:{head_sha}"
+
+
+def get_review(
+    repo_full_name: str, pr_number: int, head_sha: Optional[str]
+) -> Optional[Dict[str, Any]]:
+    if not head_sha:
+        return None
+    client = _redis()
+    if client is None:
+        return None
+    try:
+        cached = client.get(_key(repo_full_name, pr_number, head_sha))
+        return json.loads(cached) if cached else None
+    except Exception as e:
+        logger.warning(f"Could not read the review cache: {e}")
+        return None
+
+
+def save_review(
+    repo_full_name: str,
+    pr_number: int,
+    head_sha: Optional[str],
+    payload: Dict[str, Any],
+) -> None:
+    if not head_sha:
+        return
+    client = _redis()
+    if client is None:
+        return
+    try:
+        client.setex(
+            _key(repo_full_name, pr_number, head_sha), TTL_SECONDS, json.dumps(payload)
+        )
+    except Exception as e:
+        logger.warning(f"Could not write the review cache: {e}")


### PR DESCRIPTION
Dashboard #20 merged reading four things the core does not serve yet, so the file list, the conversation on a claim, and signature revisions are all inert on `main` right now. This is that side.

Asking for a review preview also failed outright whenever the reviewer produced a code suggestion, which made the feature unusable rather than merely incomplete. The enums in the generated review were handed to a JSON response that could not serialize them.

Beyond the fix, three things the detail endpoint was not saying:

- **What the change touches.** It described the review but never the change, so a reader could not see which files were involved. A file nobody expected to find in a change is a finding on its own, and it was invisible.
- **What the review actually said.** The reviewer writes a fixed pointer to the overview comment as the review body; the findings themselves are comments anchored to a file and line. A reader was shown the pointer and never the review.
- **Which revision a review belongs to**, so a decision taken on a claim can be tied to the commit it was taken against.

## Reusing a generated review

Asking for a preview always ran the model, so opening the same pull request again bought a second run that could only repeat the first, and every reader paid separately for the same answer. One is now kept per revision and served again to anyone who asks. A new commit misses naturally since the revision identifies the review, and a caller can still ask for a fresh one. Reviews posted to the provider are unaffected and always generate. The cache is best effort: if it cannot be reached, the review is generated as before.

## How long to reuse one is not a constant

A repository that ships all day wants a shorter answer than one that does not, so it is asked rather than fixed.

`Config` already stored per-entity settings and its docstring already promised resolution, but only single-entity lookup existed. The one consumer, `repo_manager`, hand-rolls its own fallback in a dict that nothing else can read. So settings are now declared in one place, with their meaning, type, unit and the bounds of a sensible answer, and resolved narrowest first:

```
nothing set                    7 days (from default)
org sets 14                   14 days (from organization sourceant)
repo overrides with 2          2 days (from repository sourceant/dashboard)
repo clears, inherits again   14 days (from organization sourceant)
org clears, back to default    7 days (from default)
```

The organisation is taken from the repository's full name, so nothing extra has to be wired to know which one applies.

Every answer carries where it came from, which is what makes a usable screen possible: a value can be shown as set here or inherited from the organisation, with an offer to go back to inheriting. `GET /api/settings/catalogue` says what exists, `GET /api/settings/{scope}/{id}` gives resolved values with their origin, `PUT` sets one, and `DELETE` stops setting it here and returns what it now inherits, so a screen updates without a second call.

Setting reuse to nothing turns it off for that repository. A stored value that has since fallen outside what the setting allows is ignored in favour of what it inherits, rather than failing the request that needed it.

## Not in this change

The screen itself, which belongs in the dashboard. The API is shaped so it is mechanical: group by `group`, render by `type` with `unit` and the bounds, show `source`, offer a reset.

`repo_manager` is not migrated onto this either. Its four settings are the obvious second customer and doing so would delete its hand-rolled resolver, but that is a behaviour change to a working plugin and belongs on its own.
