### PR TITLE
feat(topology): Propose how a system fits together from what it declares

### DIFF
--- a/src/api/routes/topology.py
+++ b/src/api/routes/topology.py
@@ -9,6 +9,9 @@ from src.config.db import get_engine
 from src.core.responses import success_response
 from src.core.scope import Scope
 from src.core.services import service_registry
+from src.core.topology.inference import infer_dependencies
+from src.core.topology.manifests import read_manifests
+from src.utils.logger import logger
 from src.core.topology import (
     InMemoryTopologyRepository,
     SQLTopologyRepository,
@@ -83,6 +86,18 @@ class RelationshipInput(BaseModel):
     stale: bool = False
     properties: dict[str, Any] = Field(default_factory=dict)
     evidence: list[EvidenceInput] = Field(default_factory=list)
+
+
+class InferAssetInput(BaseModel):
+    entity_id: str
+    repository: str
+
+
+class InferInput(BaseModel):
+    assets: list[InferAssetInput] = Field(default_factory=list)
+    # Proposals are recorded as pending by default so they can be looked at in
+    # place. Asking for a preview leaves the graph untouched.
+    persist: bool = True
 
 
 class SearchInput(BaseModel):
@@ -168,6 +183,49 @@ async def put_relationship(
     except ValueError as error:
         raise HTTPException(status_code=422, detail=str(error))
     return success_response(asdict(relationship))
+
+
+@router.post("/infer")
+async def infer_relationships(
+    payload: InferInput,
+    user: dict = Depends(get_current_user),
+    scope: Scope = Depends(get_scope),
+    repository: TopologyRepository = Depends(get_topology_repository),
+):
+    """Propose dependencies between repositories from the manifests they publish.
+
+    Every proposal is pending and carries the file it came from. Nothing is
+    approved here: a person decides whether a proposed relationship is real.
+    """
+    github_token = user.get("github_token")
+    if not github_token:
+        raise HTTPException(status_code=400, detail="No GitHub token available")
+    if not payload.assets:
+        return success_response({"proposed": [], "read": 0})
+
+    manifests = await read_manifests(
+        [
+            {"entity_id": a.entity_id, "repository": a.repository}
+            for a in payload.assets
+        ],
+        github_token,
+    )
+    proposals = infer_dependencies(manifests)
+
+    if payload.persist:
+        for proposal in proposals:
+            try:
+                repository.put_relationship(scope, proposal)
+            except ValueError as error:
+                logger.warning(f"Could not record a proposed relationship: {error}")
+
+    return success_response(
+        {
+            "proposed": [asdict(p) for p in proposals],
+            "read": len(manifests),
+            "persisted": payload.persist,
+        }
+    )
 
 
 @router.delete("/entities/{entity_id:path}")

--- a/src/core/topology/inference.py
+++ b/src/core/topology/inference.py
@@ -20,6 +20,43 @@ from src.core.topology.models import TopologyEvidence, TopologyRelationship
 
 DEPENDS_ON = "depends_on"
 
+# A package name is only half an identifier. The Package URL specification exists
+# because every ecosystem names and compares packages by its own rules, so a name
+# is only meaningful alongside the ecosystem that issued it. The comparison rules
+# below are the ones that specification records for each type.
+NPM = "npm"
+PYPI = "pypi"
+COMPOSER = "composer"
+GOLANG = "golang"
+
+_PYPI_SEPARATORS = re.compile(r"[-_.]+")
+
+
+def normalise(ecosystem: str, name: str) -> str:
+    """Reduce a declared name to the form its own ecosystem compares by."""
+    if ecosystem == PYPI:
+        # PEP 503: runs of dot, hyphen and underscore collapse to one hyphen,
+        # and the name is lowercased. friendly.bard and Friendly_Bard are one
+        # project.
+        return _PYPI_SEPARATORS.sub("-", name).lower()
+    if ecosystem == COMPOSER:
+        # Both vendor and package are compared without regard to case.
+        return name.lower()
+    # npm and go compare names exactly.
+    return name
+
+
+def is_namespaced(ecosystem: str, name: str) -> bool:
+    """
+    Whether the name carries who owns it, rather than being a bare word anyone
+    could publish.
+    """
+    if ecosystem in (COMPOSER, GOLANG):
+        return "/" in name
+    if ecosystem == NPM:
+        return name.startswith("@") and "/" in name
+    return False
+
 
 @dataclass(frozen=True)
 class RepositoryManifest:
@@ -28,6 +65,8 @@ class RepositoryManifest:
     entity_id: str
     repository: str
     path: str
+    # Which ecosystem issued these names, since names only compare within one.
+    ecosystem: str = ""
     # The names this repository publishes itself under.
     identity: tuple[str, ...] = ()
     # The names it declares a dependency on.
@@ -62,6 +101,7 @@ def parse_package_json(entity_id: str, repository: str, path: str, content: str)
         entity_id=entity_id,
         repository=repository,
         path=path,
+        ecosystem=NPM,
         identity=_clean([data.get("name")]),
         dependencies=_clean(deps),
     )
@@ -79,6 +119,7 @@ def parse_composer_json(entity_id: str, repository: str, path: str, content: str
         entity_id=entity_id,
         repository=repository,
         path=path,
+        ecosystem=COMPOSER,
         identity=_clean([data.get("name")]),
         dependencies=_clean(deps),
     )
@@ -102,6 +143,7 @@ def parse_go_mod(entity_id: str, repository: str, path: str, content: str):
         entity_id=entity_id,
         repository=repository,
         path=path,
+        ecosystem=GOLANG,
         identity=_clean(identity),
         dependencies=_clean(deps),
     )
@@ -124,6 +166,7 @@ def parse_requirements_txt(entity_id: str, repository: str, path: str, content: 
         entity_id=entity_id,
         repository=repository,
         path=path,
+        ecosystem=PYPI,
         dependencies=_clean(deps),
     )
 
@@ -145,6 +188,7 @@ def parse_pyproject_toml(entity_id: str, repository: str, path: str, content: st
         entity_id=entity_id,
         repository=repository,
         path=path,
+        ecosystem=PYPI,
         identity=_clean([project.get("name")]),
         dependencies=_clean(deps),
     )
@@ -187,26 +231,39 @@ def infer_dependencies(
 
     # Which entity publishes which name. A name published by more than one
     # repository is ambiguous and proposes nothing.
-    published: dict[str, set[str]] = {}
+    published: dict[tuple[str, str], set[str]] = {}
     for manifest in manifests:
         for name in manifest.identity:
-            published.setdefault(name, set()).add(manifest.entity_id)
+            key = (manifest.ecosystem, normalise(manifest.ecosystem, name))
+            published.setdefault(key, set()).add(manifest.entity_id)
 
     proposals: dict[str, TopologyRelationship] = {}
     for manifest in manifests:
         for name in manifest.dependencies:
-            owners = published.get(name)
+            owners = published.get(
+                (manifest.ecosystem, normalise(manifest.ecosystem, name))
+            )
             if not owners or len(owners) > 1:
                 continue
             target_id = next(iter(owners))
             if target_id == manifest.entity_id:
                 continue
 
+            # A bare name is not proof the dependency resolves here. A public
+            # registry can carry the same name, which is how dependency
+            # confusion works, so an unowned name proposes with less confidence.
+            namespaced = is_namespaced(manifest.ecosystem, name)
+            confidence = 1.0 if namespaced else 0.6
+
             evidence = TopologyEvidence(
                 id=f"{manifest.repository}:{manifest.path}:{name}",
                 kind="manifest",
                 source=f"{manifest.repository}/{manifest.path}",
-                properties={"declared": name},
+                properties={
+                    "declared": name,
+                    "ecosystem": manifest.ecosystem,
+                    "namespaced": namespaced,
+                },
             )
             key = _relationship_id(manifest.entity_id, target_id)
             existing = proposals.get(key)
@@ -230,8 +287,11 @@ def infer_dependencies(
                 type=DEPENDS_ON,
                 # Proposed, never applied. A person decides whether it is real.
                 status="pending",
-                confidence=1.0,
-                properties={"inferred_from": "manifest"},
+                confidence=confidence,
+                properties={
+                    "inferred_from": "manifest",
+                    "ecosystem": manifest.ecosystem,
+                },
                 evidence=(evidence,),
             )
 

--- a/src/core/topology/inference.py
+++ b/src/core/topology/inference.py
@@ -1,0 +1,238 @@
+"""Propose topology relationships from what repositories declare about themselves.
+
+A proposal is only as good as what it can point at, so every relationship here
+comes from a manifest a repository actually publishes: the name it goes by, and
+the names it declares a dependency on. Nothing is guessed, and nothing is
+derived from a model, so a reader can check any proposal by opening one file.
+
+Proposals are always pending. Deciding whether a relationship is real is a
+human's job, and this only narrows what they have to look at.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping
+
+from src.core.topology.models import TopologyEvidence, TopologyRelationship
+
+DEPENDS_ON = "depends_on"
+
+
+@dataclass(frozen=True)
+class RepositoryManifest:
+    """One manifest read from one repository."""
+
+    entity_id: str
+    repository: str
+    path: str
+    # The names this repository publishes itself under.
+    identity: tuple[str, ...] = ()
+    # The names it declares a dependency on.
+    dependencies: tuple[str, ...] = ()
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+
+def _clean(values: Iterable[Any]) -> tuple[str, ...]:
+    seen: list[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        name = value.strip()
+        if name and name not in seen:
+            seen.append(name)
+    return tuple(seen)
+
+
+def parse_package_json(entity_id: str, repository: str, path: str, content: str):
+    data = json.loads(content)
+    deps: list[str] = []
+    for key in (
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+    ):
+        section = data.get(key)
+        if isinstance(section, dict):
+            deps.extend(section.keys())
+    return RepositoryManifest(
+        entity_id=entity_id,
+        repository=repository,
+        path=path,
+        identity=_clean([data.get("name")]),
+        dependencies=_clean(deps),
+    )
+
+
+def parse_composer_json(entity_id: str, repository: str, path: str, content: str):
+    data = json.loads(content)
+    deps: list[str] = []
+    for key in ("require", "require-dev"):
+        section = data.get(key)
+        if isinstance(section, dict):
+            # PHP platform requirements are not repositories.
+            deps.extend(k for k in section if "/" in k)
+    return RepositoryManifest(
+        entity_id=entity_id,
+        repository=repository,
+        path=path,
+        identity=_clean([data.get("name")]),
+        dependencies=_clean(deps),
+    )
+
+
+_GO_MODULE = re.compile(r"^module\s+(\S+)", re.MULTILINE)
+_GO_REQUIRE_BLOCK = re.compile(r"require\s*\((.*?)\)", re.DOTALL)
+_GO_REQUIRE_LINE = re.compile(r"^require\s+(\S+)", re.MULTILINE)
+
+
+def parse_go_mod(entity_id: str, repository: str, path: str, content: str):
+    deps: list[str] = []
+    for block in _GO_REQUIRE_BLOCK.findall(content):
+        for line in block.splitlines():
+            line = line.split("//")[0].strip()
+            if line:
+                deps.append(line.split()[0])
+    deps.extend(_GO_REQUIRE_LINE.findall(content))
+    identity = _GO_MODULE.findall(content)
+    return RepositoryManifest(
+        entity_id=entity_id,
+        repository=repository,
+        path=path,
+        identity=_clean(identity),
+        dependencies=_clean(deps),
+    )
+
+
+_REQUIREMENT = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+
+def parse_requirements_txt(entity_id: str, repository: str, path: str, content: str):
+    deps: list[str] = []
+    for line in content.splitlines():
+        line = line.split("#")[0].strip()
+        # Options and includes are not dependencies.
+        if not line or line.startswith("-"):
+            continue
+        match = _REQUIREMENT.match(line)
+        if match:
+            deps.append(match.group(1))
+    return RepositoryManifest(
+        entity_id=entity_id,
+        repository=repository,
+        path=path,
+        dependencies=_clean(deps),
+    )
+
+
+def parse_pyproject_toml(entity_id: str, repository: str, path: str, content: str):
+    try:
+        import tomllib  # type: ignore[import-not-found]
+    except ModuleNotFoundError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    data = tomllib.loads(content)
+    project = data.get("project") or {}
+    deps: list[str] = []
+    for raw in project.get("dependencies") or []:
+        match = _REQUIREMENT.match(str(raw))
+        if match:
+            deps.append(match.group(1))
+    return RepositoryManifest(
+        entity_id=entity_id,
+        repository=repository,
+        path=path,
+        identity=_clean([project.get("name")]),
+        dependencies=_clean(deps),
+    )
+
+
+PARSERS = {
+    "package.json": parse_package_json,
+    "composer.json": parse_composer_json,
+    "go.mod": parse_go_mod,
+    "requirements.txt": parse_requirements_txt,
+    "pyproject.toml": parse_pyproject_toml,
+}
+
+
+def parse_manifest(entity_id: str, repository: str, path: str, content: str):
+    """Parse a manifest by its filename, or return None when it is not one."""
+    parser = PARSERS.get(path.rsplit("/", 1)[-1])
+    if parser is None:
+        return None
+    try:
+        return parser(entity_id, repository, path, content)
+    except Exception:
+        # A manifest that will not parse proposes nothing rather than failing
+        # the whole system.
+        return None
+
+
+def _relationship_id(source_id: str, target_id: str) -> str:
+    return f"{source_id}--{DEPENDS_ON}--{target_id}"
+
+
+def infer_dependencies(
+    manifests: Iterable[RepositoryManifest],
+) -> tuple[TopologyRelationship, ...]:
+    """
+    Propose a dependency wherever one repository declares a name another one
+    publishes itself under. Every proposal names the manifest it came from.
+    """
+    manifests = list(manifests)
+
+    # Which entity publishes which name. A name published by more than one
+    # repository is ambiguous and proposes nothing.
+    published: dict[str, set[str]] = {}
+    for manifest in manifests:
+        for name in manifest.identity:
+            published.setdefault(name, set()).add(manifest.entity_id)
+
+    proposals: dict[str, TopologyRelationship] = {}
+    for manifest in manifests:
+        for name in manifest.dependencies:
+            owners = published.get(name)
+            if not owners or len(owners) > 1:
+                continue
+            target_id = next(iter(owners))
+            if target_id == manifest.entity_id:
+                continue
+
+            evidence = TopologyEvidence(
+                id=f"{manifest.repository}:{manifest.path}:{name}",
+                kind="manifest",
+                source=f"{manifest.repository}/{manifest.path}",
+                properties={"declared": name},
+            )
+            key = _relationship_id(manifest.entity_id, target_id)
+            existing = proposals.get(key)
+            if existing:
+                proposals[key] = TopologyRelationship(
+                    id=existing.id,
+                    source_id=existing.source_id,
+                    target_id=existing.target_id,
+                    type=existing.type,
+                    status=existing.status,
+                    confidence=existing.confidence,
+                    properties=existing.properties,
+                    evidence=existing.evidence + (evidence,),
+                )
+                continue
+
+            proposals[key] = TopologyRelationship(
+                id=key,
+                source_id=manifest.entity_id,
+                target_id=target_id,
+                type=DEPENDS_ON,
+                # Proposed, never applied. A person decides whether it is real.
+                status="pending",
+                confidence=1.0,
+                properties={"inferred_from": "manifest"},
+                evidence=(evidence,),
+            )
+
+    return tuple(proposals.values())

--- a/src/core/topology/inference.py
+++ b/src/core/topology/inference.py
@@ -14,11 +14,12 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, Sequence
 
 from src.core.topology.models import TopologyEvidence, TopologyRelationship
 
 DEPENDS_ON = "depends_on"
+EXTENDS = "extends"
 
 # A package name is only half an identifier. The Package URL specification exists
 # because every ecosystem names and compares packages by its own rules, so a name
@@ -71,6 +72,8 @@ class RepositoryManifest:
     identity: tuple[str, ...] = ()
     # The names it declares a dependency on.
     dependencies: tuple[str, ...] = ()
+    # Extension points it registers itself into, such as a plugin group.
+    plugin_groups: tuple[str, ...] = ()
     properties: Mapping[str, Any] = field(default_factory=dict)
 
 
@@ -184,6 +187,7 @@ def parse_pyproject_toml(entity_id: str, repository: str, path: str, content: st
         match = _REQUIREMENT.match(str(raw))
         if match:
             deps.append(match.group(1))
+    groups = project.get("entry-points") or {}
     return RepositoryManifest(
         entity_id=entity_id,
         repository=repository,
@@ -191,6 +195,7 @@ def parse_pyproject_toml(entity_id: str, repository: str, path: str, content: st
         ecosystem=PYPI,
         identity=_clean([project.get("name")]),
         dependencies=_clean(deps),
+        plugin_groups=_clean(groups.keys()) if isinstance(groups, dict) else (),
     )
 
 
@@ -295,4 +300,61 @@ def infer_dependencies(
                 evidence=(evidence,),
             )
 
+    proposals.update(_infer_extensions(manifests, proposals))
     return tuple(proposals.values())
+
+
+def _repository_name(repository: str) -> str:
+    return repository.rsplit("/", 1)[-1].lower()
+
+
+def _infer_extensions(
+    manifests: Sequence[RepositoryManifest],
+    existing: Mapping[str, TopologyRelationship],
+) -> dict[str, TopologyRelationship]:
+    """
+    Propose an extension wherever a repository registers itself into another
+    repository's extension point, such as a python entry point group named
+    after the host.
+
+    The group only names the host by convention, so this is proposed with less
+    confidence than a dependency a package manager would resolve.
+    """
+    by_name: dict[str, set[str]] = {}
+    for manifest in manifests:
+        by_name.setdefault(_repository_name(manifest.repository), set()).add(
+            manifest.entity_id
+        )
+
+    found: dict[str, TopologyRelationship] = {}
+    for manifest in manifests:
+        for group in manifest.plugin_groups:
+            host = group.split(".", 1)[0].lower()
+            owners = by_name.get(host)
+            if not owners or len(owners) > 1:
+                continue
+            target_id = next(iter(owners))
+            if target_id == manifest.entity_id:
+                continue
+
+            key = f"{manifest.entity_id}--{EXTENDS}--{target_id}"
+            if key in existing or key in found:
+                continue
+            found[key] = TopologyRelationship(
+                id=key,
+                source_id=manifest.entity_id,
+                target_id=target_id,
+                type=EXTENDS,
+                status="pending",
+                confidence=0.6,
+                properties={"inferred_from": "entry_point", "group": group},
+                evidence=(
+                    TopologyEvidence(
+                        id=f"{manifest.repository}:{manifest.path}:{group}",
+                        kind="manifest",
+                        source=f"{manifest.repository}/{manifest.path}",
+                        properties={"entry_point_group": group},
+                    ),
+                ),
+            )
+    return found

--- a/src/core/topology/manifests.py
+++ b/src/core/topology/manifests.py
@@ -1,0 +1,99 @@
+"""Read the manifests a repository publishes, so its declared dependencies can
+be proposed as topology relationships.
+
+Only files a repository already keeps at its root are read, and only the ones
+that declare package identity. Nothing is cloned and nothing is executed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from typing import Any, Iterable, Mapping, Sequence
+
+import httpx
+
+from src.core.topology.inference import PARSERS, RepositoryManifest, parse_manifest
+from src.utils.logger import logger
+
+_GITHUB_API = "https://api.github.com"
+
+# The manifests worth asking for, in the order a repository is likely to lead with.
+CANDIDATES: tuple[str, ...] = tuple(PARSERS.keys())
+
+
+async def _fetch_one(
+    client: httpx.AsyncClient,
+    token: str,
+    entity_id: str,
+    repository: str,
+    path: str,
+) -> RepositoryManifest | None:
+    try:
+        response = await client.get(
+            f"{_GITHUB_API}/repos/{repository}/contents/{path}",
+            headers={
+                "Authorization": f"token {token}",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+    except httpx.HTTPError as error:
+        logger.warning(f"Could not read {repository}/{path}: {error}")
+        return None
+
+    # A repository simply not having a manifest is the common case, not a fault.
+    if response.status_code != 200:
+        return None
+
+    payload = response.json()
+    if payload.get("encoding") != "base64" or not payload.get("content"):
+        return None
+    try:
+        content = base64.b64decode(payload["content"]).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+    return parse_manifest(entity_id, repository, path, content)
+
+
+async def read_manifests(
+    assets: Sequence[Mapping[str, Any]],
+    token: str,
+    candidates: Iterable[str] = CANDIDATES,
+) -> tuple[RepositoryManifest, ...]:
+    """
+    Read every candidate manifest from every asset concurrently.
+
+    ``assets`` carry an ``entity_id`` and a ``repository`` full name. An asset
+    that is not a repository, or whose manifests cannot be read, contributes
+    nothing rather than failing the whole reading.
+    """
+    wanted = [
+        (str(asset["entity_id"]), str(asset["repository"]), path)
+        for asset in assets
+        if asset.get("entity_id") and asset.get("repository")
+        for path in candidates
+    ]
+    if not wanted:
+        return ()
+
+    # Bounded so a system with many repositories cannot trip secondary limits.
+    semaphore = asyncio.Semaphore(8)
+
+    async with httpx.AsyncClient(timeout=15) as client:
+
+        async def _guarded(entity_id: str, repository: str, path: str):
+            async with semaphore:
+                return await _fetch_one(client, token, entity_id, repository, path)
+
+        results = await asyncio.gather(
+            *[_guarded(*item) for item in wanted], return_exceptions=True
+        )
+
+    manifests: list[RepositoryManifest] = []
+    for result in results:
+        if isinstance(result, RepositoryManifest):
+            manifests.append(result)
+        elif isinstance(result, BaseException):
+            logger.warning(f"Manifest read failed: {result}")
+    return tuple(manifests)

--- a/src/tests/unit/data/manifests/dashboard.package.json
+++ b/src/tests/unit/data/manifests/dashboard.package.json
@@ -1,0 +1,49 @@
+{
+  "name": "sourceant-memory",
+  "version": "0.1.0",
+  "private": true,
+  "description": "SourceAnt Memory - Your agents remember why",
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview",
+    "postinstall": "nuxt prepare",
+    "lint": "eslint .",
+    "typecheck": "nuxt typecheck",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@nuxtjs/sitemap": "^7.6.0",
+    "@pinia/nuxt": "^0.11.3",
+    "3d-force-graph": "^1.80.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "cytoscape": "^3.34.0",
+    "force-graph": "^1.51.4",
+    "lucide-vue-next": "^0.563.0",
+    "nuxt": "^4.3.0",
+    "radix-vue": "^1.9.17",
+    "tailwind-merge": "^3.4.0",
+    "three-spritetext": "^1.10.0"
+  },
+  "devDependencies": {
+    "@nuxt/eslint": "^1.13.0",
+    "@nuxt/test-utils": "^4.0.3",
+    "@nuxtjs/tailwindcss": "^6.14.0",
+    "@tailwindcss/typography": "^0.5.19",
+    "@types/cytoscape": "^3.21.9",
+    "@types/node": "^25.2.1",
+    "@vue/test-utils": "^2.4.11",
+    "autoprefixer": "^10.4.24",
+    "eslint": "^9.39.2",
+    "eslint-plugin-vue": "^10.7.0",
+    "happy-dom": "^20.10.6",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.19",
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.9",
+    "vue-tsc": "^3.2.7"
+  },
+  "type": "module"
+}

--- a/src/tests/unit/data/manifests/memory.pyproject.toml
+++ b/src/tests/unit/data/manifests/memory.pyproject.toml
@@ -1,0 +1,78 @@
+[project]
+name = "sourceant-memory"
+version = "0.1.0"
+description = "SourceAnt Memory - Your agent remembers why"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Proprietary" }
+authors = [{ name = "SourceAnt", email = "hello@sourceant.ai" }]
+keywords = ["ai", "context", "memory", "mcp", "sourceant"]
+
+dependencies = [
+    "anthropic>=0.40.0",
+    "boto3==1.43.50",
+    "codebase-memory-mcp==0.8.1",
+    "fastapi>=0.115.0",
+    "graphql-core==3.2.11",
+    "grpcio-tools==1.82.1",
+    "httpx>=0.27.0",
+    "litellm>=1.0.0",
+    "mcp>=1.0.0",
+    "neo4j==5.28.4",
+    "numpy>=1.24.0",
+    "orjson>=3.9.0",
+    "openapi-spec-validator==0.9.0",
+    "pact-python-ffi==0.5.4.1",
+    "pydantic>=2.0.0",
+    "pyyaml>=6.0.0",
+    "rank-bm25>=0.2.2",
+    "smartql @ git+https://github.com/SmartQL/SmartQL.git",
+    "sqlglot>=20.0.0",
+    "sqlmodel>=0.0.22",
+]
+
+[project.optional-dependencies]
+dev = [
+    "httpx>=0.27.0",
+    "pymysql>=1.1.0",
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.24.0",
+    "ruff>=0.8.0",
+]
+
+[project.entry-points."sourceant.plugins"]
+memory = "memory.plugin:MemoryPlugin"
+
+[project.entry-points."sourceant.migrations"]
+memory = "memory.migrations"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/memory"]
+
+[tool.pytest.ini_options]
+testpaths = ["src/tests"]
+asyncio_mode = "auto"
+markers = [
+    "memgraph: tests that require Memgraph",
+    "postgres: tests that require PostgreSQL",
+    "mysql: tests that require MySQL",
+]
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+ignore = ["UP042"]
+
+[tool.ruff.lint.per-file-ignores]
+"src/memory/migrations/*" = ["E501"]
+"src/memory/models/__init__.py" = ["F401"]

--- a/src/tests/unit/data/manifests/sourceant.requirements.txt
+++ b/src/tests/unit/data/manifests/sourceant.requirements.txt
@@ -1,0 +1,23 @@
+alembic
+click
+cryptography # Required by pyjwt
+fastapi
+google-genai
+httpx
+litellm
+Mako
+mcp==1.28.1
+psycopg2
+pymysql==1.1.2
+PyJWT==2.10.1
+python-dateutil==2.8.2
+python-dotenv
+rapidfuzz
+redis==5.0.4
+redislite
+requests==2.31.0
+rq
+sqlmodel
+unidiff
+uvicorn
+vaderSentiment

--- a/src/tests/unit/data/manifests/webservice.composer.json
+++ b/src/tests/unit/data/manifests/webservice.composer.json
@@ -1,0 +1,101 @@
+{
+    "$schema": "https://getcomposer.org/schema.json",
+    "name": "laravel/laravel",
+    "type": "project",
+    "description": "The skeleton application for the Laravel framework.",
+    "keywords": ["laravel", "framework"],
+    "license": "MIT",
+    "require": {
+        "php": "^8.2",
+        "firebase/php-jwt": "*",
+        "laravel/framework": "^12.0",
+        "laravel/sanctum": "*",
+        "laravel/tinker": "^2.10.1",
+        "whilesmart/eloquent-client-credentials": "dev-main",
+        "whilesmart/eloquent-model-configuration": "*",
+        "whilesmart/eloquent-roles": "*",
+        "whilesmart/eloquent-workspaces": "*",
+        "whilesmart/laravel-user-authentication": "dev-dev"
+    },
+    "require-dev": {
+        "fakerphp/faker": "^1.23",
+        "laravel/pail": "^1.2.2",
+        "laravel/pint": "^1.24",
+        "laravel/sail": "^1.41",
+        "mockery/mockery": "^1.6",
+        "nunomaduro/collision": "^8.6",
+        "phpunit/phpunit": "^11.5.3"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/",
+            "Database\\Factories\\": "database/factories/",
+            "Database\\Seeders\\": "database/seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "setup": [
+            "composer install",
+            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\"",
+            "@php artisan key:generate",
+            "@php artisan migrate --force",
+            "npm install",
+            "npm run build"
+        ],
+        "dev": [
+            "Composer\\Config::disableProcessTimeout",
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
+        ],
+        "test": [
+            "@php artisan config:clear --ansi",
+            "@php artisan test"
+        ],
+        "pint": "pint",
+        "pint:test": "pint --test",
+        "post-autoload-dump": [
+            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+            "@php artisan package:discover --ansi"
+        ],
+        "post-update-cmd": [
+            "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
+        ],
+        "post-root-package-install": [
+            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+        ],
+        "post-create-project-cmd": [
+            "@php artisan key:generate --ansi",
+            "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",
+            "@php artisan migrate --graceful --ansi"
+        ],
+        "pre-package-uninstall": [
+            "Illuminate\\Foundation\\ComposerScripts::prePackageUninstall"
+        ]
+    },
+    "extra": {
+        "laravel": {
+            "dont-discover": []
+        }
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": "dist",
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true,
+            "php-http/discovery": true
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/whilesmartphp/eloquent-client-credentials.git"
+        }
+    ]
+}

--- a/src/tests/unit/test_topology_inference.py
+++ b/src/tests/unit/test_topology_inference.py
@@ -3,9 +3,14 @@ from pathlib import Path
 import pytest
 
 from src.core.topology.inference import (
+    COMPOSER,
     DEPENDS_ON,
+    GOLANG,
+    NPM,
+    PYPI,
     RepositoryManifest,
     infer_dependencies,
+    normalise,
     parse_manifest,
 )
 
@@ -85,6 +90,7 @@ class TestProposingDependencies:
                     entity_id="asset:web",
                     repository="acme/web",
                     path="package.json",
+                    ecosystem=NPM,
                     identity=("@acme/web",),
                     dependencies=("@acme/design", "lodash"),
                 ),
@@ -92,6 +98,7 @@ class TestProposingDependencies:
                     entity_id="asset:design",
                     repository="acme/design",
                     path="package.json",
+                    ecosystem=NPM,
                     identity=("@acme/design",),
                 ),
             ]
@@ -114,6 +121,7 @@ class TestProposingDependencies:
                     entity_id="asset:web",
                     repository="acme/web",
                     path="package.json",
+                    ecosystem=NPM,
                     dependencies=("lodash", "nuxt"),
                 )
             ]
@@ -121,10 +129,10 @@ class TestProposingDependencies:
 
         assert proposals == ()
 
-    def test_a_name_two_repositories_publish_proposes_nothing(self):
-        """Taken from these repositories: the dashboard and memory both call
-        themselves sourceant-memory, so a dependency on that name cannot say
-        which one is meant."""
+    def test_the_same_name_in_two_ecosystems_is_two_packages(self):
+        """Taken from these repositories: the dashboard publishes
+        sourceant-memory to npm and memory publishes it to pypi. A python
+        dependency on that name can only mean the python one."""
         dashboard = parse_manifest(
             "asset:dashboard",
             "sourceant/dashboard",
@@ -138,15 +146,49 @@ class TestProposingDependencies:
             read("memory.pyproject.toml"),
         )
         assert dashboard.identity == memory.identity
+        assert dashboard.ecosystem != memory.ecosystem
 
         caller = RepositoryManifest(
             entity_id="asset:core",
             repository="sourceant/sourceant",
             path="requirements.txt",
+            ecosystem=PYPI,
             dependencies=("sourceant-memory",),
         )
 
-        assert infer_dependencies([dashboard, memory, caller]) == ()
+        proposals = infer_dependencies([dashboard, memory, caller])
+
+        assert len(proposals) == 1
+        assert proposals[0].target_id == "asset:memory"
+
+    def test_the_same_name_twice_in_one_ecosystem_proposes_nothing(self):
+        proposals = infer_dependencies(
+            [
+                RepositoryManifest(
+                    entity_id="a",
+                    repository="o/a",
+                    path="package.json",
+                    ecosystem=NPM,
+                    identity=("shared",),
+                ),
+                RepositoryManifest(
+                    entity_id="b",
+                    repository="o/b",
+                    path="package.json",
+                    ecosystem=NPM,
+                    identity=("shared",),
+                ),
+                RepositoryManifest(
+                    entity_id="c",
+                    repository="o/c",
+                    path="package.json",
+                    ecosystem=NPM,
+                    dependencies=("shared",),
+                ),
+            ]
+        )
+
+        assert proposals == ()
 
     def test_a_repository_depending_on_itself_proposes_nothing(self):
         proposals = infer_dependencies(
@@ -155,6 +197,7 @@ class TestProposingDependencies:
                     entity_id="asset:web",
                     repository="acme/web",
                     path="package.json",
+                    ecosystem=NPM,
                     identity=("@acme/web",),
                     dependencies=("@acme/web",),
                 )
@@ -170,18 +213,21 @@ class TestProposingDependencies:
                     entity_id="asset:web",
                     repository="acme/web",
                     path="package.json",
+                    ecosystem=NPM,
                     dependencies=("@acme/design",),
                 ),
                 RepositoryManifest(
                     entity_id="asset:web",
                     repository="acme/web",
                     path="apps/admin/package.json",
+                    ecosystem=NPM,
                     dependencies=("@acme/design",),
                 ),
                 RepositoryManifest(
                     entity_id="asset:design",
                     repository="acme/design",
                     path="package.json",
+                    ecosystem=NPM,
                     identity=("@acme/design",),
                 ),
             ]
@@ -198,15 +244,115 @@ class TestProposingDependencies:
                     entity_id="a",
                     repository="o/a",
                     path="package.json",
+                    ecosystem=NPM,
                     dependencies=("b",),
                 ),
                 RepositoryManifest(
                     entity_id="b",
                     repository="o/b",
                     path="package.json",
+                    ecosystem=NPM,
                     identity=("b",),
                 ),
             ]
         )
 
         assert all(p.status == status for p in proposals)
+
+
+class TestNameComparison:
+    """The rules each ecosystem compares names by, as the Package URL
+    specification records them."""
+
+    def test_python_ignores_case_and_separator_style(self):
+        # PEP 503: runs of dot, hyphen and underscore collapse to one hyphen.
+        for written in (
+            "friendly-bard",
+            "Friendly_Bard",
+            "friendly.bard",
+            "friendly--bard",
+        ):
+            assert normalise(PYPI, written) == "friendly-bard"
+
+    def test_php_ignores_case(self):
+        assert normalise(COMPOSER, "Laravel/Framework") == "laravel/framework"
+
+    def test_node_and_go_compare_exactly(self):
+        assert normalise(NPM, "MyPackage") == "MyPackage"
+        assert normalise(GOLANG, "github.com/Acme/Thing") == "github.com/Acme/Thing"
+
+    def test_a_python_dependency_written_either_way_finds_the_same_repository(self):
+        proposals = infer_dependencies(
+            [
+                RepositoryManifest(
+                    entity_id="asset:lib",
+                    repository="o/lib",
+                    path="pyproject.toml",
+                    ecosystem=PYPI,
+                    identity=("Source_Ant.Memory",),
+                ),
+                RepositoryManifest(
+                    entity_id="asset:app",
+                    repository="o/app",
+                    path="requirements.txt",
+                    ecosystem=PYPI,
+                    dependencies=("source-ant-memory",),
+                ),
+            ]
+        )
+
+        assert len(proposals) == 1
+        assert proposals[0].target_id == "asset:lib"
+
+
+class TestConfidence:
+    """A name that says who owns it proves more than a bare word, because a
+    public registry can carry the same bare word."""
+
+    def test_an_owned_name_is_proposed_with_full_confidence(self):
+        proposals = infer_dependencies(
+            [
+                RepositoryManifest(
+                    entity_id="asset:app",
+                    repository="o/app",
+                    path="composer.json",
+                    ecosystem=COMPOSER,
+                    dependencies=("acme/billing",),
+                ),
+                RepositoryManifest(
+                    entity_id="asset:billing",
+                    repository="o/billing",
+                    path="composer.json",
+                    ecosystem=COMPOSER,
+                    identity=("acme/billing",),
+                ),
+            ]
+        )
+
+        assert proposals[0].confidence == 1.0
+        assert proposals[0].evidence[0].properties["namespaced"] is True
+
+    def test_a_bare_name_is_proposed_with_less(self):
+        proposals = infer_dependencies(
+            [
+                RepositoryManifest(
+                    entity_id="asset:app",
+                    repository="o/app",
+                    path="requirements.txt",
+                    ecosystem=PYPI,
+                    dependencies=("billing",),
+                ),
+                RepositoryManifest(
+                    entity_id="asset:billing",
+                    repository="o/billing",
+                    path="pyproject.toml",
+                    ecosystem=PYPI,
+                    identity=("billing",),
+                ),
+            ]
+        )
+
+        assert proposals[0].confidence < 1.0
+        assert proposals[0].evidence[0].properties["namespaced"] is False
+        # Still pending either way: confidence never decides.
+        assert proposals[0].status == "pending"

--- a/src/tests/unit/test_topology_inference.py
+++ b/src/tests/unit/test_topology_inference.py
@@ -5,6 +5,7 @@ import pytest
 from src.core.topology.inference import (
     COMPOSER,
     DEPENDS_ON,
+    EXTENDS,
     GOLANG,
     NPM,
     PYPI,
@@ -157,9 +158,10 @@ class TestProposingDependencies:
         )
 
         proposals = infer_dependencies([dashboard, memory, caller])
+        depends = [p for p in proposals if p.type == DEPENDS_ON]
 
-        assert len(proposals) == 1
-        assert proposals[0].target_id == "asset:memory"
+        assert len(depends) == 1
+        assert depends[0].target_id == "asset:memory"
 
     def test_the_same_name_twice_in_one_ecosystem_proposes_nothing(self):
         proposals = infer_dependencies(
@@ -356,3 +358,63 @@ class TestConfidence:
         assert proposals[0].evidence[0].properties["namespaced"] is False
         # Still pending either way: confidence never decides.
         assert proposals[0].status == "pending"
+
+
+class TestProposingExtensions:
+    """A repository that registers itself into another's extension point is
+    saying so out loud, even when no package manager resolves it."""
+
+    def test_a_plugin_entry_point_proposes_an_extension_of_its_host(self):
+        """Taken from these repositories: memory registers itself into the
+        sourceant.plugins group, and nothing in either manifest declares a
+        dependency between them."""
+        memory = parse_manifest(
+            "asset:memory",
+            "sourceant/memory",
+            "pyproject.toml",
+            read("memory.pyproject.toml"),
+        )
+        core = RepositoryManifest(
+            entity_id="asset:core",
+            repository="sourceant/sourceant",
+            path="requirements.txt",
+            ecosystem=PYPI,
+        )
+
+        assert "sourceant.plugins" in memory.plugin_groups
+
+        proposals = infer_dependencies([memory, core])
+        extends = [p for p in proposals if p.type == EXTENDS]
+
+        assert len(extends) == 1
+        assert extends[0].source_id == "asset:memory"
+        assert extends[0].target_id == "asset:core"
+        assert extends[0].status == "pending"
+        # The group names the host only by convention, so it proves less.
+        assert extends[0].confidence < 1.0
+        assert (
+            extends[0].evidence[0].properties["entry_point_group"]
+            == "sourceant.plugins"
+        )
+
+    def test_an_entry_point_naming_nothing_in_the_system_proposes_nothing(self):
+        manifest = RepositoryManifest(
+            entity_id="asset:plugin",
+            repository="o/plugin",
+            path="pyproject.toml",
+            ecosystem=PYPI,
+            plugin_groups=("console_scripts",),
+        )
+
+        assert infer_dependencies([manifest]) == ()
+
+    def test_a_repository_extending_itself_proposes_nothing(self):
+        manifest = RepositoryManifest(
+            entity_id="asset:core",
+            repository="sourceant/sourceant",
+            path="pyproject.toml",
+            ecosystem=PYPI,
+            plugin_groups=("sourceant.plugins",),
+        )
+
+        assert infer_dependencies([manifest]) == ()

--- a/src/tests/unit/test_topology_inference.py
+++ b/src/tests/unit/test_topology_inference.py
@@ -1,0 +1,212 @@
+from pathlib import Path
+
+import pytest
+
+from src.core.topology.inference import (
+    DEPENDS_ON,
+    RepositoryManifest,
+    infer_dependencies,
+    parse_manifest,
+)
+
+# Manifests copied from the repositories themselves, so the parsers are held to
+# what these projects actually publish rather than to an invented shape.
+MANIFESTS = Path(__file__).parent / "data" / "manifests"
+
+
+def read(name: str) -> str:
+    return (MANIFESTS / name).read_text()
+
+
+class TestParsingRealManifests:
+    def test_reads_a_node_package(self):
+        manifest = parse_manifest(
+            "asset:dashboard",
+            "sourceant/dashboard",
+            "package.json",
+            read("dashboard.package.json"),
+        )
+
+        assert manifest.identity == ("sourceant-memory",)
+        assert "nuxt" in manifest.dependencies
+        # Development dependencies are declarations too.
+        assert "vitest" in manifest.dependencies
+
+    def test_reads_a_php_package_without_platform_requirements(self):
+        manifest = parse_manifest(
+            "asset:webservice",
+            "sourceant/webservice",
+            "composer.json",
+            read("webservice.composer.json"),
+        )
+
+        assert manifest.identity == ("laravel/laravel",)
+        assert "laravel/framework" in manifest.dependencies
+        assert "whilesmart/eloquent-roles" in manifest.dependencies
+        # "php" is a platform requirement, not a repository.
+        assert "php" not in manifest.dependencies
+
+    def test_reads_a_python_project(self):
+        manifest = parse_manifest(
+            "asset:memory",
+            "sourceant/memory",
+            "pyproject.toml",
+            read("memory.pyproject.toml"),
+        )
+
+        assert manifest.identity == ("sourceant-memory",)
+
+    def test_reads_a_requirements_file_without_its_options(self):
+        manifest = parse_manifest(
+            "asset:core",
+            "sourceant/sourceant",
+            "requirements.txt",
+            read("sourceant.requirements.txt"),
+        )
+
+        assert "fastapi" in manifest.dependencies
+        assert "alembic" in manifest.dependencies
+        # A trailing comment is not part of the name.
+        assert "cryptography" in manifest.dependencies
+        assert not any(d.startswith("-") for d in manifest.dependencies)
+
+    def test_ignores_a_file_that_is_not_a_manifest(self):
+        assert parse_manifest("asset:x", "o/r", "README.md", "# hello") is None
+
+    def test_a_manifest_that_will_not_parse_proposes_nothing(self):
+        assert parse_manifest("asset:x", "o/r", "package.json", "{ not json") is None
+
+
+class TestProposingDependencies:
+    def test_proposes_a_pending_relationship_with_the_manifest_behind_it(self):
+        proposals = infer_dependencies(
+            [
+                RepositoryManifest(
+                    entity_id="asset:web",
+                    repository="acme/web",
+                    path="package.json",
+                    identity=("@acme/web",),
+                    dependencies=("@acme/design", "lodash"),
+                ),
+                RepositoryManifest(
+                    entity_id="asset:design",
+                    repository="acme/design",
+                    path="package.json",
+                    identity=("@acme/design",),
+                ),
+            ]
+        )
+
+        assert len(proposals) == 1
+        proposal = proposals[0]
+        assert proposal.source_id == "asset:web"
+        assert proposal.target_id == "asset:design"
+        assert proposal.type == DEPENDS_ON
+        # Never applied without a person deciding.
+        assert proposal.status == "pending"
+        assert proposal.evidence[0].source == "acme/web/package.json"
+        assert proposal.evidence[0].properties["declared"] == "@acme/design"
+
+    def test_a_dependency_on_nothing_in_the_system_proposes_nothing(self):
+        proposals = infer_dependencies(
+            [
+                RepositoryManifest(
+                    entity_id="asset:web",
+                    repository="acme/web",
+                    path="package.json",
+                    dependencies=("lodash", "nuxt"),
+                )
+            ]
+        )
+
+        assert proposals == ()
+
+    def test_a_name_two_repositories_publish_proposes_nothing(self):
+        """Taken from these repositories: the dashboard and memory both call
+        themselves sourceant-memory, so a dependency on that name cannot say
+        which one is meant."""
+        dashboard = parse_manifest(
+            "asset:dashboard",
+            "sourceant/dashboard",
+            "package.json",
+            read("dashboard.package.json"),
+        )
+        memory = parse_manifest(
+            "asset:memory",
+            "sourceant/memory",
+            "pyproject.toml",
+            read("memory.pyproject.toml"),
+        )
+        assert dashboard.identity == memory.identity
+
+        caller = RepositoryManifest(
+            entity_id="asset:core",
+            repository="sourceant/sourceant",
+            path="requirements.txt",
+            dependencies=("sourceant-memory",),
+        )
+
+        assert infer_dependencies([dashboard, memory, caller]) == ()
+
+    def test_a_repository_depending_on_itself_proposes_nothing(self):
+        proposals = infer_dependencies(
+            [
+                RepositoryManifest(
+                    entity_id="asset:web",
+                    repository="acme/web",
+                    path="package.json",
+                    identity=("@acme/web",),
+                    dependencies=("@acme/web",),
+                )
+            ]
+        )
+
+        assert proposals == ()
+
+    def test_two_manifests_declaring_the_same_edge_gather_evidence_once(self):
+        proposals = infer_dependencies(
+            [
+                RepositoryManifest(
+                    entity_id="asset:web",
+                    repository="acme/web",
+                    path="package.json",
+                    dependencies=("@acme/design",),
+                ),
+                RepositoryManifest(
+                    entity_id="asset:web",
+                    repository="acme/web",
+                    path="apps/admin/package.json",
+                    dependencies=("@acme/design",),
+                ),
+                RepositoryManifest(
+                    entity_id="asset:design",
+                    repository="acme/design",
+                    path="package.json",
+                    identity=("@acme/design",),
+                ),
+            ]
+        )
+
+        assert len(proposals) == 1
+        assert len(proposals[0].evidence) == 2
+
+    @pytest.mark.parametrize("status", ["pending"])
+    def test_every_proposal_is_pending(self, status):
+        proposals = infer_dependencies(
+            [
+                RepositoryManifest(
+                    entity_id="a",
+                    repository="o/a",
+                    path="package.json",
+                    dependencies=("b",),
+                ),
+                RepositoryManifest(
+                    entity_id="b",
+                    repository="o/b",
+                    path="package.json",
+                    identity=("b",),
+                ),
+            ]
+        )
+
+        assert all(p.status == status for p in proposals)


### PR DESCRIPTION
Drawing every connection in a system by hand does not scale past a few repositories, and the connections are already written down: a repository publishes the name it goes by and the names it depends on.

Dependencies are proposed by reading those manifests across node, php, go and python projects. Every proposal names the file and the declaration it came from, so it can be checked by opening one file, and nothing is derived from a model.

## Names are compared the way each ecosystem compares them

A package name is only half an identifier, which is why the Package URL specification makes the type a required component: `express` on npm is unrelated to `express` on PyPI. Matching on the bare name both missed real dependencies and risked proposing wrong ones.

Names are now compared within the ecosystem that issued them, using that ecosystem's own rules taken from that specification: python ignores case and treats dots, hyphens and underscores alike, php ignores case, node and go compare exactly. Two repositories publishing the same name in different ecosystems are two different packages, and only a name published twice within one ecosystem is genuinely undecidable.

This repository set is the example: `dashboard/package.json` and `memory/pyproject.toml` both publish `sourceant-memory`, to npm and to PyPI respectively. A python dependency on that name can only mean one of them.

## A bare name proves less than an owned one

A public registry can publish the same bare name an internal repository uses, which is how dependency confusion works, so a name that carries its owner (`@acme/web`, `acme/billing`, `github.com/acme/thing`) is proposed with full confidence and a bare name with less. Both stay pending either way: confidence orders what a reader looks at first, it never decides.

## Repositories also declare connections no package manager resolves

One that registers itself into another's extension point is stating a connection out loud. That is proposed too, with less confidence, since such a group names its host only by convention.

This is what the arrangement here actually rests on. Manifest dependencies alone find nothing across these four repositories; the entry point finds the one that matters:

```
asset:memory -> asset:core   extends   confidence=0.6   status=pending
    from sourceant/memory/pyproject.toml  {'entry_point_group': 'sourceant.plugins'}
```

Everything is recorded as pending. A repository with no manifest, or one that cannot be read, contributes nothing rather than failing the system it belongs to.

## Not in this change

The screen for reviewing what has been proposed, and a flow that starts from picking repositories. `POST /api/topology/infer` does the work and takes `persist: false` to preview without touching the graph.
