### PR TITLE
feat(api): Read whole lists upstream and serve them a page at a time

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ alembic
 click
 cryptography # Required by pyjwt
 fastapi
+fastapi-pagination
 google-genai
 httpx
 litellm

--- a/src/api/routes/repos.py
+++ b/src/api/routes/repos.py
@@ -64,8 +64,11 @@ async def list_repos(
     ).all()
     connected_ids = {row.repository_id for row in connected_rows}
 
-    all_repos = session.exec(select(Repository)).all()
-    repo_map = {r.full_name: r.id for r in all_repos}
+    # Only the repositories the provider just named, rather than every row in
+    # the table, which grows with every account on the platform.
+    seen = [gh_repo["full_name"] for gh_repo in github_repos]
+    known = session.exec(select(Repository).where(Repository.full_name.in_(seen))).all()
+    repo_map = {r.full_name: r.id for r in known}
 
     needle = q.strip().lower()
     results = []

--- a/src/api/routes/repos.py
+++ b/src/api/routes/repos.py
@@ -4,7 +4,7 @@ from typing import Optional
 import httpx
 
 from src.utils.provider_pages import fetch_all
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlmodel import Session, select
 
@@ -13,6 +13,7 @@ from src.config.db import get_session
 from src.core.responses import success_response
 from src.models.repository import Repository
 from src.models.connected_repository import ConnectedRepository
+from src.utils.pagination import Params, as_data, page_of, page_of_query
 
 router = APIRouter()
 
@@ -34,10 +35,12 @@ class ConnectRepoRequest(BaseModel):
 
 @router.get("")
 async def list_repos(
+    q: str = Query("", description="Match against the name or description"),
+    params: Params = Depends(),
     session: Session = Depends(get_session),
     user: dict = Depends(get_current_user),
 ):
-    """List repos the user has access to via their GitHub token, with connected status."""
+    """One page of the repos the user's GitHub token reaches, with connected status."""
     github_token = user.get("github_token")
     if not github_token:
         raise HTTPException(status_code=401, detail="No GitHub token available")
@@ -64,8 +67,11 @@ async def list_repos(
     all_repos = session.exec(select(Repository)).all()
     repo_map = {r.full_name: r.id for r in all_repos}
 
+    needle = q.strip().lower()
     results = []
     for gh_repo in github_repos:
+        if needle and not _matches(gh_repo, needle):
+            continue
         repo_id = repo_map.get(gh_repo["full_name"])
         results.append(
             {
@@ -75,47 +81,67 @@ async def list_repos(
             }
         )
 
-    return results
+    # The whole list is read, and searched, before the page is cut: connected
+    # status comes from here rather than from the provider, and a search that
+    # only covered the page in hand would miss most of what it was asked about.
+    return success_response(page_of(results, params))
+
+
+def _matches(repo: dict, needle: str) -> bool:
+    haystack = f"{repo.get('full_name') or ''} {repo.get('description') or ''}"
+    return needle in haystack.lower()
 
 
 @router.get("/connected")
 async def list_connected_repos(
+    params: Params = Depends(),
     session: Session = Depends(get_session),
     user: dict = Depends(get_current_user),
 ):
-    """List only the user's connected repositories from the DB cache."""
+    """One page of the user's connected repositories, from the DB cache."""
     user_id = user["user_id"]
     connected_rows = session.exec(
         select(ConnectedRepository).where(ConnectedRepository.user_id == user_id)
     ).all()
 
     if not connected_rows:
-        return []
+        return success_response(page_of([], params))
 
     repo_ids = [row.repository_id for row in connected_rows]
     connected_at_map = {row.repository_id: row.connected_at for row in connected_rows}
 
-    repos = session.exec(select(Repository).where(Repository.id.in_(repo_ids))).all()
+    page = page_of_query(
+        session,
+        select(Repository)
+        .where(Repository.id.in_(repo_ids))
+        .order_by(Repository.full_name),
+        params,
+    )
 
-    return [
-        {
-            "id": repo.id,
-            "name": repo.full_name,
-            "full_name": repo.full_name,
-            "description": repo.description,
-            "private": repo.private,
-            "language": repo.language,
-            "default_branch": repo.default_branch,
-            "visibility": repo.visibility,
-            "archived": repo.archived,
-            "owner": repo.owner,
-            "url": repo.url,
-            "contexts": 0,
-            "connected_at": connected_at_map[repo.id].isoformat(),
-            "status": "active",
-        }
-        for repo in repos
-    ]
+    return success_response(
+        as_data(
+            page,
+            [
+                {
+                    "id": repo.id,
+                    "name": repo.full_name,
+                    "full_name": repo.full_name,
+                    "description": repo.description,
+                    "private": repo.private,
+                    "language": repo.language,
+                    "default_branch": repo.default_branch,
+                    "visibility": repo.visibility,
+                    "archived": repo.archived,
+                    "owner": repo.owner,
+                    "url": repo.url,
+                    "contexts": 0,
+                    "connected_at": connected_at_map[repo.id].isoformat(),
+                    "status": "active",
+                }
+                for repo in page.items
+            ],
+        )
+    )
 
 
 @router.post("/connect")

--- a/src/api/routes/repos.py
+++ b/src/api/routes/repos.py
@@ -2,6 +2,8 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import httpx
+
+from src.utils.provider_pages import fetch_all
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlmodel import Session, select
@@ -40,18 +42,18 @@ async def list_repos(
     if not github_token:
         raise HTTPException(status_code=401, detail="No GitHub token available")
 
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(
+    async with httpx.AsyncClient(timeout=30) as client:
+        github_repos, truncated = await fetch_all(
+            client,
             "https://api.github.com/user/repos",
-            headers={
+            {
                 "Authorization": f"token {github_token}",
                 "Accept": "application/vnd.github+json",
             },
-            params={"per_page": 100, "sort": "updated"},
+            params={"sort": "updated"},
         )
-        if resp.status_code != 200:
-            raise HTTPException(status_code=502, detail="GitHub API error")
-        github_repos = resp.json()
+    if not github_repos and truncated:
+        raise HTTPException(status_code=502, detail="GitHub API error")
 
     user_id = user["user_id"]
     connected_rows = session.exec(

--- a/src/api/routes/reviews.py
+++ b/src/api/routes/reviews.py
@@ -9,6 +9,8 @@ from src.auth import get_current_user
 from src.config.db import get_session
 from src.core.responses import success_response
 from src.models.review_record import ReviewRecord
+from src.utils.concurrency import gather_bounded
+from src.utils.pagination import Params, as_data, page_of, page_of_query
 from src.utils.provider_pages import fetch_all
 from src.utils.review_cache import get_review as get_cached_review
 from src.utils.review_cache import save_review as save_cached_review
@@ -117,42 +119,59 @@ async def _fetch_pull_request(
 
 @router.get("/pulls")
 async def list_pulls(
-    repo: str = Query(..., description="Repository full name, e.g. owner/name"),
+    repo: list[str] = Query(
+        ..., description="Repository full name, e.g. owner/name. May repeat."
+    ),
+    params: Params = Depends(),
     user: dict = Depends(get_current_user),
 ):
-    """Open pull requests for a repository, from live GitHub."""
+    """One page of open pull requests across the given repositories."""
     github_token = user.get("github_token")
     if not github_token:
-        return success_response([])
+        return success_response(page_of([], params))
 
-    async with httpx.AsyncClient(timeout=30) as client:
+    headers = {
+        "Authorization": f"token {github_token}",
+        "Accept": "application/vnd.github+json",
+    }
+
+    async def _pulls_of(client: httpx.AsyncClient, full_name: str):
         pulls, truncated = await fetch_all(
             client,
-            f"{_GITHUB_API}/repos/{repo}/pulls",
-            {
-                "Authorization": f"token {github_token}",
-                "Accept": "application/vnd.github+json",
-            },
+            f"{_GITHUB_API}/repos/{full_name}/pulls",
+            headers,
             params={"state": "open", "sort": "updated"},
         )
-    if not pulls and truncated:
-        raise HTTPException(status_code=502, detail="GitHub API error")
+        return full_name, pulls, truncated
 
-    results = []
-    for pr in pulls:
-        results.append(
-            {
-                "number": pr["number"],
-                "title": pr["title"],
-                "state": pr["state"],
-                "draft": pr.get("draft", False),
-                "author": (pr.get("user") or {}).get("login"),
-                "url": pr.get("html_url"),
-                "updated_at": pr.get("updated_at"),
-            }
+    async with httpx.AsyncClient(timeout=30) as client:
+        gathered = await gather_bounded(
+            [
+                lambda c=client, name=name: _pulls_of(c, name)
+                for name in dict.fromkeys(repo)
+            ]
         )
 
-    return success_response(results)
+    if all(truncated and not pulls for _, pulls, truncated in gathered):
+        raise HTTPException(status_code=502, detail="GitHub API error")
+
+    results = [
+        {
+            "repo": full_name,
+            "number": pr["number"],
+            "title": pr["title"],
+            "state": pr["state"],
+            "draft": pr.get("draft", False),
+            "author": (pr.get("user") or {}).get("login"),
+            "url": pr.get("html_url"),
+            "updated_at": pr.get("updated_at"),
+        }
+        for full_name, pulls, _ in gathered
+        for pr in pulls
+    ]
+    results.sort(key=lambda item: item["updated_at"] or "", reverse=True)
+
+    return success_response(page_of(results, params))
 
 
 @router.get("/detail")
@@ -258,42 +277,52 @@ async def review_detail(
 
 @router.get("")
 async def list_reviews(
-    repo: str = Query(..., description="Repository full name, e.g. owner/name"),
+    repo: list[str] = Query(
+        ..., description="Repository full name, e.g. owner/name. May repeat."
+    ),
+    params: Params = Depends(),
     session: Session = Depends(get_session),
     user: dict = Depends(get_current_user),
 ):
-    """List SourceAnt's reviews for a repository, enriched with live GitHub PR state."""
+    """One page of SourceAnt's reviews, enriched with live GitHub state."""
     github_token = user.get("github_token")
 
-    records = session.exec(
+    page = page_of_query(
+        session,
         select(ReviewRecord)
-        .where(ReviewRecord.repository_full_name == repo)
-        .order_by(ReviewRecord.id.desc())
-    ).all()
+        .where(ReviewRecord.repository_full_name.in_(repo))
+        .order_by(ReviewRecord.id.desc()),
+        params,
+    )
 
-    # Fetch each distinct pull request once, concurrently but bounded so a
-    # repository with many reviewed PRs does not open a flood of requests that
-    # trips GitHub's secondary rate limits.
-    pr_numbers = list({record.pr_number for record in records})
-    semaphore = asyncio.Semaphore(8)
+    # Only the page is enriched, so the number of provider calls follows the
+    # page size rather than the whole review history.
+    wanted = {(record.repository_full_name, record.pr_number) for record in page.items}
 
     async with httpx.AsyncClient(timeout=10) as client:
 
-        async def _fetch(number: int):
-            async with semaphore:
-                return number, await _fetch_pull_request(
-                    client, repo, number, github_token
-                )
+        async def _fetch(full_name: str, number: int):
+            return (full_name, number), await _fetch_pull_request(
+                client, full_name, number, github_token
+            )
 
-        pr_cache = dict(await asyncio.gather(*[_fetch(n) for n in pr_numbers]))
+        pr_cache = dict(
+            await gather_bounded(
+                [
+                    lambda name=name, number=number: _fetch(name, number)
+                    for name, number in wanted
+                ]
+            )
+        )
 
     results = []
-    for record in records:
-        pr = pr_cache.get(record.pr_number)
+    for record in page.items:
+        pr = pr_cache.get((record.repository_full_name, record.pr_number))
         results.append(
             {
                 "id": record.id,
                 "repository_full_name": record.repository_full_name,
+                "repo": record.repository_full_name,
                 "pr_number": record.pr_number,
                 "status": record.status,
                 "reviewed_head_sha": record.reviewed_head_sha,
@@ -305,4 +334,4 @@ async def list_reviews(
             }
         )
 
-    return success_response(results)
+    return success_response(as_data(page, results))

--- a/src/api/routes/reviews.py
+++ b/src/api/routes/reviews.py
@@ -9,6 +9,7 @@ from src.auth import get_current_user
 from src.config.db import get_session
 from src.core.responses import success_response
 from src.models.review_record import ReviewRecord
+from src.utils.provider_pages import fetch_all
 from src.utils.review_cache import get_review as get_cached_review
 from src.utils.review_cache import save_review as save_cached_review
 
@@ -124,20 +125,21 @@ async def list_pulls(
     if not github_token:
         return success_response([])
 
-    async with httpx.AsyncClient(timeout=10) as client:
-        resp = await client.get(
+    async with httpx.AsyncClient(timeout=30) as client:
+        pulls, truncated = await fetch_all(
+            client,
             f"{_GITHUB_API}/repos/{repo}/pulls",
-            headers={
+            {
                 "Authorization": f"token {github_token}",
                 "Accept": "application/vnd.github+json",
             },
-            params={"state": "open", "per_page": 50, "sort": "updated"},
+            params={"state": "open", "sort": "updated"},
         )
-    if resp.status_code != 200:
+    if not pulls and truncated:
         raise HTTPException(status_code=502, detail="GitHub API error")
 
     results = []
-    for pr in resp.json():
+    for pr in pulls:
         results.append(
             {
                 "number": pr["number"],

--- a/src/api/routes/triage.py
+++ b/src/api/routes/triage.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel
 
 from src.auth import get_current_user
 from src.core.responses import success_response
+from src.utils.concurrency import gather_bounded
+from src.utils.pagination import Params, page_of
 from src.utils.provider_pages import fetch_all
 
 router = APIRouter()
@@ -30,42 +32,57 @@ class TriageAction(BaseModel):
 
 @router.get("")
 async def list_triage(
-    repo: str = Query(..., description="Repository full name, e.g. owner/name"),
+    repo: list[str] = Query(
+        ..., description="Repository full name, e.g. owner/name. May repeat."
+    ),
+    params: Params = Depends(),
     user: dict = Depends(get_current_user),
 ):
-    """The open-issue triage queue for a repository, from live GitHub state."""
+    """One page of the open-issue triage queue across the given repositories."""
     github_token = user.get("github_token")
     if not github_token:
-        return success_response([])
+        return success_response(page_of([], params))
 
-    async with httpx.AsyncClient(timeout=30) as client:
+    async def _issues_of(client: httpx.AsyncClient, full_name: str):
         issues, truncated = await fetch_all(
             client,
-            f"{_GITHUB_API}/repos/{repo}/issues",
+            f"{_GITHUB_API}/repos/{full_name}/issues",
             _headers(github_token),
             params={"state": "open", "sort": "updated"},
         )
-    if not issues and truncated:
-        raise HTTPException(status_code=502, detail="GitHub API error")
+        return full_name, issues, truncated
 
-    results = []
-    for issue in issues:
-        if "pull_request" in issue:
-            continue
-        results.append(
-            {
-                "number": issue["number"],
-                "title": issue["title"],
-                "state": issue["state"],
-                "author": (issue.get("user") or {}).get("login"),
-                "labels": [label["name"] for label in issue.get("labels", [])],
-                "comments": issue.get("comments", 0),
-                "url": issue.get("html_url"),
-                "updated_at": issue.get("updated_at"),
-            }
+    async with httpx.AsyncClient(timeout=30) as client:
+        gathered = await gather_bounded(
+            [
+                lambda c=client, name=name: _issues_of(c, name)
+                for name in dict.fromkeys(repo)
+            ]
         )
 
-    return success_response(results)
+    if all(truncated and not issues for _, issues, truncated in gathered):
+        raise HTTPException(status_code=502, detail="GitHub API error")
+
+    results = [
+        {
+            "repo": full_name,
+            "number": issue["number"],
+            "title": issue["title"],
+            "state": issue["state"],
+            "author": (issue.get("user") or {}).get("login"),
+            "labels": [label["name"] for label in issue.get("labels", [])],
+            "comments": issue.get("comments", 0),
+            "url": issue.get("html_url"),
+            "updated_at": issue.get("updated_at"),
+        }
+        for full_name, issues, _ in gathered
+        for issue in issues
+        # The provider answers pull requests from the issues endpoint too.
+        if "pull_request" not in issue
+    ]
+    results.sort(key=lambda item: item["updated_at"] or "", reverse=True)
+
+    return success_response(page_of(results, params))
 
 
 @router.get("/detail")

--- a/src/api/routes/triage.py
+++ b/src/api/routes/triage.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 from src.auth import get_current_user
 from src.core.responses import success_response
+from src.utils.provider_pages import fetch_all
 
 router = APIRouter()
 
@@ -37,17 +38,18 @@ async def list_triage(
     if not github_token:
         return success_response([])
 
-    async with httpx.AsyncClient(timeout=10) as client:
-        resp = await client.get(
+    async with httpx.AsyncClient(timeout=30) as client:
+        issues, truncated = await fetch_all(
+            client,
             f"{_GITHUB_API}/repos/{repo}/issues",
-            headers=_headers(github_token),
-            params={"state": "open", "per_page": 50, "sort": "updated"},
+            _headers(github_token),
+            params={"state": "open", "sort": "updated"},
         )
-    if resp.status_code != 200:
+    if not issues and truncated:
         raise HTTPException(status_code=502, detail="GitHub API error")
 
     results = []
-    for issue in resp.json():
+    for issue in issues:
         if "pull_request" in issue:
             continue
         results.append(

--- a/src/tests/test_pagination_api.py
+++ b/src/tests/test_pagination_api.py
@@ -252,6 +252,25 @@ class TestPagedEndpoints:
         assert body["total"] == 1
         assert body["items"][0]["full_name"] == "acme/repo-90"
 
+    def test_connected_status_still_answers_for_the_repositories_named(
+        self, monkeypatch
+    ):
+        self.connect(["acme/api"])
+        self.answer_github(
+            monkeypatch,
+            lambda request: [
+                {"id": 1, "name": "api", "full_name": "acme/api"},
+                {"id": 2, "name": "web", "full_name": "acme/web"},
+            ],
+        )
+
+        body = self.client.get(
+            "/api/repos", params={"size": 10}, headers=self.headers
+        ).json()["data"]
+
+        connected = {item["full_name"]: item["connected"] for item in body["items"]}
+        assert connected == {"acme/api": True, "acme/web": False}
+
     def test_only_the_reviews_on_the_page_are_looked_up_upstream(self, monkeypatch):
         for number in range(1, 21):
             self.session.add(

--- a/src/tests/test_pagination_api.py
+++ b/src/tests/test_pagination_api.py
@@ -1,0 +1,288 @@
+"""Drives the paged list endpoints over HTTP, the way the gateway calls them."""
+
+import os
+import time
+
+import httpx
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+from src.api.main import app
+from src.config.db import get_session
+from src.models.connected_repository import ConnectedRepository
+from src.models.repository import Repository
+from src.models.review_record import ReviewRecord
+
+TEST_JWT_SECRET = "pagination-api-test-secret"
+GITHUB_TOKEN = "gho_test-token"
+
+
+def _token() -> str:
+    return jwt.encode(
+        {
+            "sub": "1",
+            "username": "octocat",
+            "github_token": GITHUB_TOKEN,
+            "scope": {"workspace_id": "w1", "repository_ids": []},
+            "exp": int(time.time()) + 300,
+        },
+        os.environ["JWT_SECRET"],
+        algorithm="HS256",
+    )
+
+
+def _issue(number: int, repo: str) -> dict:
+    """An issue shaped the way GitHub sends one, trimmed to what the route reads."""
+    return {
+        "number": number,
+        "title": f"{repo} issue {number}",
+        "state": "open",
+        "user": {"login": "octocat"},
+        "labels": [{"name": "bug"}],
+        "comments": 0,
+        "html_url": f"https://github.com/{repo}/issues/{number}",
+        # Descending, so the newest issue is the lowest number.
+        "updated_at": f"2026-07-{31 - number:02d}T00:00:00Z",
+    }
+
+
+def _pull(number: int, repo: str) -> dict:
+    return {
+        "number": number,
+        "title": f"{repo} pull {number}",
+        "state": "open",
+        "draft": False,
+        "user": {"login": "octocat"},
+        "html_url": f"https://github.com/{repo}/pull/{number}",
+        "updated_at": f"2026-07-{31 - number:02d}T00:00:00Z",
+    }
+
+
+class TestPagedEndpoints:
+    @pytest.fixture(autouse=True)
+    def environment(self, monkeypatch):
+        monkeypatch.setenv("JWT_SECRET", TEST_JWT_SECRET)
+        self.headers = {"Authorization": f"Bearer {_token()}"}
+        self.requests: list[str] = []
+
+        engine = create_engine(
+            "sqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        SQLModel.metadata.create_all(engine)
+        self.session = Session(engine)
+        app.dependency_overrides[get_session] = lambda: self.session
+        self.client = TestClient(app)
+        yield
+        app.dependency_overrides.pop(get_session, None)
+        self.session.close()
+
+    def answer_github(self, monkeypatch, body_for):
+        """Answer every provider call from a fixture instead of the network."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            self.requests.append(str(request.url))
+            return httpx.Response(200, json=body_for(request))
+
+        real_client = httpx.AsyncClient
+
+        def factory(*args, **kwargs):
+            return real_client(transport=httpx.MockTransport(handler))
+
+        monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+    def connect(self, full_names: list[str]) -> None:
+        for full_name in full_names:
+            owner, _, name = full_name.partition("/")
+            repo = Repository(
+                provider="github",
+                name=name,
+                full_name=full_name,
+                url=f"https://github.com/{full_name}",
+                owner=owner,
+                owner_type="Organization",
+                private=False,
+                archived=False,
+                visibility="public",
+                default_branch="main",
+            )
+            self.session.add(repo)
+            self.session.commit()
+            self.session.refresh(repo)
+            self.session.add(ConnectedRepository(user_id=1, repository_id=repo.id))
+        self.session.commit()
+
+    def triage(self, **params) -> dict:
+        return self.client.get(
+            "/api/triage", params=params, headers=self.headers
+        ).json()["data"]
+
+    def test_a_page_carries_the_totals_with_it(self, monkeypatch):
+        self.answer_github(
+            monkeypatch, lambda request: [_issue(n, "acme/api") for n in range(1, 26)]
+        )
+
+        body = self.triage(repo="acme/api", page=1, size=10)
+
+        assert len(body["items"]) == 10
+        assert body["total"] == 25
+        assert body["pages"] == 3
+        assert body["page"] == 1
+        assert body["size"] == 10
+
+    def test_the_second_page_continues_where_the_first_stopped(self, monkeypatch):
+        self.answer_github(
+            monkeypatch, lambda request: [_issue(n, "acme/api") for n in range(1, 26)]
+        )
+
+        first = self.triage(repo="acme/api", page=1, size=10)["items"]
+        second = self.triage(repo="acme/api", page=2, size=10)["items"]
+
+        numbers = [item["number"] for item in first + second]
+        assert numbers == list(range(1, 21))
+
+    def test_a_scope_of_several_repositories_is_one_merged_page(self, monkeypatch):
+        def body_for(request: httpx.Request):
+            if "acme/api" in str(request.url):
+                return [_issue(n, "acme/api") for n in (1, 3)]
+            return [_issue(n, "acme/web") for n in (2, 4)]
+
+        self.answer_github(monkeypatch, body_for)
+
+        body = self.client.get(
+            "/api/triage",
+            params=[("repo", "acme/api"), ("repo", "acme/web"), ("size", 3)],
+            headers=self.headers,
+        ).json()["data"]
+
+        assert body["total"] == 4
+        # Ordered across both repositories, newest first, rather than one
+        # repository's list appended to the other's.
+        assert [item["number"] for item in body["items"]] == [1, 2, 3]
+        assert [item["repo"] for item in body["items"]] == [
+            "acme/api",
+            "acme/web",
+            "acme/api",
+        ]
+
+    def test_pull_requests_are_paged_the_same_way(self, monkeypatch):
+        self.answer_github(
+            monkeypatch, lambda request: [_pull(n, "acme/api") for n in range(1, 8)]
+        )
+
+        body = self.client.get(
+            "/api/reviews/pulls",
+            params={"repo": "acme/api", "page": 2, "size": 5},
+            headers=self.headers,
+        ).json()["data"]
+
+        assert body["total"] == 7
+        assert len(body["items"]) == 2
+        assert body["pages"] == 2
+
+    def test_a_page_beyond_the_last_one_is_empty_rather_than_an_error(
+        self, monkeypatch
+    ):
+        self.answer_github(
+            monkeypatch, lambda request: [_issue(n, "acme/api") for n in range(1, 4)]
+        )
+
+        response = self.client.get(
+            "/api/triage",
+            params={"repo": "acme/api", "page": 9, "size": 10},
+            headers=self.headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["data"]["items"] == []
+        assert response.json()["data"]["total"] == 3
+
+    def test_a_page_larger_than_the_ceiling_is_refused(self, monkeypatch):
+        self.answer_github(monkeypatch, lambda request: [])
+
+        response = self.client.get(
+            "/api/triage",
+            params={"repo": "acme/api", "size": 500},
+            headers=self.headers,
+        )
+
+        assert response.status_code == 422
+
+    def test_connected_repositories_are_read_a_page_at_a_time(self):
+        self.connect([f"acme/repo-{n:02d}" for n in range(1, 8)])
+
+        body = self.client.get(
+            "/api/repos/connected",
+            params={"page": 2, "size": 5},
+            headers=self.headers,
+        ).json()["data"]
+
+        assert body["total"] == 7
+        assert [item["full_name"] for item in body["items"]] == [
+            "acme/repo-06",
+            "acme/repo-07",
+        ]
+
+    def test_the_repository_search_covers_more_than_the_page_in_hand(self, monkeypatch):
+        self.answer_github(
+            monkeypatch,
+            lambda request: [
+                {
+                    "id": n,
+                    "name": f"repo-{n:02d}",
+                    "full_name": f"acme/repo-{n:02d}",
+                    "description": "the ledger" if n == 90 else "something else",
+                }
+                for n in range(1, 101)
+            ],
+        )
+
+        body = self.client.get(
+            "/api/repos",
+            params={"q": "ledger", "size": 10},
+            headers=self.headers,
+        ).json()["data"]
+
+        # The match sits on what would be the ninth page, so a search that only
+        # looked at the page in hand would find nothing.
+        assert body["total"] == 1
+        assert body["items"][0]["full_name"] == "acme/repo-90"
+
+    def test_only_the_reviews_on_the_page_are_looked_up_upstream(self, monkeypatch):
+        for number in range(1, 21):
+            self.session.add(
+                ReviewRecord(
+                    repository_full_name="acme/api",
+                    pr_number=number,
+                    reviewed_head_sha=f"head{number}",
+                    reviewed_base_sha=f"base{number}",
+                )
+            )
+        self.session.commit()
+        self.answer_github(
+            monkeypatch,
+            lambda request: {
+                "number": 1,
+                "title": "A change",
+                "state": "open",
+                "user": {"login": "octocat"},
+                "html_url": "https://github.com/acme/api/pull/1",
+                "updated_at": "2026-07-30T00:00:00Z",
+            },
+        )
+
+        body = self.client.get(
+            "/api/reviews",
+            params={"repo": "acme/api", "size": 5},
+            headers=self.headers,
+        ).json()["data"]
+
+        assert body["total"] == 20
+        assert len(body["items"]) == 5
+        # The provider is asked about the five reviews on the page, not all
+        # twenty in the history.
+        assert len(self.requests) == 5

--- a/src/tests/unit/test_provider_pages.py
+++ b/src/tests/unit/test_provider_pages.py
@@ -105,6 +105,43 @@ class TestFetchAll:
         assert truncated is True
 
     @pytest.mark.asyncio
+    async def test_keeps_what_it_read_when_a_page_is_not_json(self):
+        def handler(request):
+            if "page=2" in str(request.url):
+                # What a proxy in front of the provider answers with.
+                return httpx.Response(200, text="<html>Gateway Time-out</html>")
+            return httpx.Response(
+                200,
+                json=[{"id": 1}],
+                headers={"Link": '<https://api.github.com/x?page=2>; rel="next"'},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            items, truncated = await fetch_all(client, "https://api.github.com/x", {})
+
+        assert [item["id"] for item in items] == [1]
+        assert truncated is True
+
+    @pytest.mark.asyncio
+    async def test_keeps_what_it_read_when_a_page_is_not_a_list(self):
+        def handler(request):
+            if "page=2" in str(request.url):
+                return httpx.Response(200, json={"message": "Bad credentials"})
+            return httpx.Response(
+                200,
+                json=[{"id": 1}],
+                headers={"Link": '<https://api.github.com/x?page=2>; rel="next"'},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            items, truncated = await fetch_all(client, "https://api.github.com/x", {})
+
+        # The caller iterates what comes back, so handing it the object would
+        # walk the keys of an error message and call them repositories.
+        assert [item["id"] for item in items] == [1]
+        assert truncated is True
+
+    @pytest.mark.asyncio
     async def test_asks_for_the_largest_page_the_provider_allows(self):
         client, calls = _client([[{"id": 1}]], lambda i: None)
         async with client:

--- a/src/tests/unit/test_provider_pages.py
+++ b/src/tests/unit/test_provider_pages.py
@@ -1,0 +1,116 @@
+import httpx
+import pytest
+
+from src.utils.provider_pages import fetch_all, next_page_url
+
+# A Link header exactly as GitHub sends one.
+GITHUB_LINK = (
+    '<https://api.github.com/user/repos?per_page=100&page=2>; rel="next", '
+    '<https://api.github.com/user/repos?per_page=100&page=10>; rel="last"'
+)
+
+
+class TestNextPageUrl:
+    def test_takes_the_next_page_from_a_real_header(self):
+        assert next_page_url(GITHUB_LINK) == (
+            "https://api.github.com/user/repos?per_page=100&page=2"
+        )
+
+    def test_has_no_next_page_on_the_last_one(self):
+        last = '<https://api.github.com/user/repos?page=1>; rel="prev"'
+        assert next_page_url(last) is None
+
+    def test_has_no_next_page_without_a_header(self):
+        assert next_page_url(None) is None
+
+
+def _client(pages, link_for):
+    """A client answering a fixed set of pages, each pointing at the next."""
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(str(request.url))
+        index = len(calls) - 1
+        headers = {}
+        link = link_for(index)
+        if link:
+            headers["Link"] = link
+        return httpx.Response(200, json=pages[index], headers=headers)
+
+    transport = httpx.MockTransport(handler)
+    return httpx.AsyncClient(transport=transport), calls
+
+
+class TestFetchAll:
+    @pytest.mark.asyncio
+    async def test_reads_every_page_the_provider_offers(self):
+        pages = [[{"id": 1}, {"id": 2}], [{"id": 3}]]
+        client, calls = _client(
+            pages,
+            lambda i: (
+                '<https://api.github.com/user/repos?page=2>; rel="next"'
+                if i == 0
+                else None
+            ),
+        )
+        async with client:
+            items, truncated = await fetch_all(
+                client, "https://api.github.com/user/repos", {}
+            )
+
+        assert [item["id"] for item in items] == [1, 2, 3]
+        assert truncated is False
+        assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_stops_at_the_ceiling_and_says_it_did(self):
+        pages = [[{"id": i}] for i in range(5)]
+        client, _ = _client(
+            pages, lambda i: '<https://api.github.com/x?page=9>; rel="next"'
+        )
+        async with client:
+            items, truncated = await fetch_all(
+                client, "https://api.github.com/x", {}, max_pages=2
+            )
+
+        assert len(items) == 2
+        # The caller can say the list is short rather than implying it is whole.
+        assert truncated is True
+
+    @pytest.mark.asyncio
+    async def test_a_single_page_is_not_truncated(self):
+        client, calls = _client([[{"id": 1}]], lambda i: None)
+        async with client:
+            items, truncated = await fetch_all(client, "https://api.github.com/x", {})
+
+        assert len(items) == 1
+        assert truncated is False
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_keeps_what_it_read_when_a_later_page_fails(self):
+        def handler(request):
+            if "page=2" in str(request.url):
+                return httpx.Response(502)
+            return httpx.Response(
+                200,
+                json=[{"id": 1}],
+                headers={"Link": '<https://api.github.com/x?page=2>; rel="next"'},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            items, truncated = await fetch_all(client, "https://api.github.com/x", {})
+
+        assert len(items) == 1
+        assert truncated is True
+
+    @pytest.mark.asyncio
+    async def test_asks_for_the_largest_page_the_provider_allows(self):
+        client, calls = _client([[{"id": 1}]], lambda i: None)
+        async with client:
+            await fetch_all(
+                client, "https://api.github.com/x", {}, params={"sort": "updated"}
+            )
+
+        assert "per_page=100" in calls[0]
+        assert "sort=updated" in calls[0]

--- a/src/utils/concurrency.py
+++ b/src/utils/concurrency.py
@@ -1,0 +1,27 @@
+"""Run several provider calls at once without opening a flood of them.
+
+Asking the provider for one repository at a time is slow when a scope covers a
+dozen; asking for all of them at once trips the provider's secondary rate
+limits. This keeps a few in flight and no more.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, Sequence
+
+DEFAULT_LIMIT = 8
+
+
+async def gather_bounded(
+    calls: Sequence[Callable[[], Awaitable[Any]]],
+    limit: int = DEFAULT_LIMIT,
+) -> list[Any]:
+    """Await every call, at most `limit` of them at a time, keeping their order."""
+    semaphore = asyncio.Semaphore(limit)
+
+    async def _run(call: Callable[[], Awaitable[Any]]):
+        async with semaphore:
+            return await call()
+
+    return list(await asyncio.gather(*[_run(call) for call in calls]))

--- a/src/utils/concurrency.py
+++ b/src/utils/concurrency.py
@@ -24,4 +24,4 @@ async def gather_bounded(
         async with semaphore:
             return await call()
 
-    return list(await asyncio.gather(*[_run(call) for call in calls]))
+    return await asyncio.gather(*[_run(call) for call in calls])

--- a/src/utils/pagination.py
+++ b/src/utils/pagination.py
@@ -1,0 +1,52 @@
+"""One page of a list, in the shape every list endpoint answers with.
+
+Returning a whole list works until the account grows, at which point the
+response gets slower every week and the screen showing it has no way to ask for
+less. A page carries the totals with it, so a reader can tell how much they are
+looking at and ask for the rest.
+
+The paging itself is fastapi-pagination's; these helpers only place its page
+inside the response envelope the rest of the API uses.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from fastapi_pagination import Page, Params
+from fastapi_pagination import paginate as _paginate_sequence
+from fastapi_pagination.ext.sqlmodel import paginate as _paginate_query
+from fastapi_pagination.utils import disable_installed_extensions_check
+from sqlmodel import Session
+
+# The database pages go through the sqlmodel extension below; without this the
+# library warns about that on every in-memory page too.
+disable_installed_extensions_check()
+
+__all__ = ["Params", "page_of", "page_of_query", "as_data"]
+
+
+def page_of(items: Sequence[Any], params: Params) -> dict:
+    """A page of an already-gathered list."""
+    return as_data(_paginate_sequence(items, params))
+
+
+def page_of_query(session: Session, query: Any, params: Params) -> Page:
+    """A page read straight from the database, so only the page is loaded."""
+    return _paginate_query(session, query, params)
+
+
+def as_data(page: Page, items: Sequence[Any] | None = None) -> dict:
+    """
+    A page as the envelope's data.
+
+    Pass `items` to answer with something other than what came out of the query,
+    which is what a route does when it enriches the rows it just read.
+    """
+    return {
+        "items": list(page.items if items is None else items),
+        "total": page.total,
+        "page": page.page,
+        "size": page.size,
+        "pages": page.pages,
+    }

--- a/src/utils/provider_pages.py
+++ b/src/utils/provider_pages.py
@@ -1,0 +1,76 @@
+"""Read a whole list from the provider, not just its first page.
+
+The provider answers a list one page at a time and says in a header whether
+there is another. Asking once and stopping returns a prefix that looks exactly
+like a complete answer, so a reader cannot tell a short list from a truncated
+one. These helpers follow the pages, and say plainly when they stopped early.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Optional
+
+import httpx
+
+from src.utils.logger import logger
+
+# What the provider allows per request.
+PAGE_SIZE = 100
+
+# Enough to hold any real repository or pull request, while keeping a runaway
+# list from becoming an unbounded number of requests.
+DEFAULT_MAX_PAGES = 20
+
+_NEXT_LINK = re.compile(r'<([^>]+)>;\s*rel="next"')
+
+
+def next_page_url(link_header: Optional[str]) -> Optional[str]:
+    """The next page's URL from a Link header, or None when this is the last."""
+    if not link_header:
+        return None
+    match = _NEXT_LINK.search(link_header)
+    return match.group(1) if match else None
+
+
+async def fetch_all(
+    client: httpx.AsyncClient,
+    url: str,
+    headers: Mapping[str, str],
+    params: Optional[Mapping[str, Any]] = None,
+    max_pages: int = DEFAULT_MAX_PAGES,
+) -> tuple[list[Any], bool]:
+    """
+    Read every page the provider offers, up to a ceiling.
+
+    Returns the items and whether more were left unread, so a caller can say so
+    rather than presenting a prefix as the whole answer.
+    """
+    query: Optional[dict] = {"per_page": PAGE_SIZE, **(params or {})}
+    items: list[Any] = []
+    pages = 0
+
+    while url and pages < max_pages:
+        response = await client.get(url, headers=dict(headers), params=query)
+        if response.status_code != 200:
+            # A failure part way through returns what was read rather than
+            # nothing, and reports that it is incomplete.
+            logger.warning(f"{url} answered {response.status_code} while paging")
+            return items, True
+
+        page = response.json()
+        if not isinstance(page, list):
+            return page, False
+
+        items.extend(page)
+        pages += 1
+
+        url = next_page_url(response.headers.get("link"))
+        # The next URL already carries its own query, and passing an empty set
+        # of parameters would replace it rather than leave it alone.
+        query = None
+
+    truncated = bool(url)
+    if truncated:
+        logger.info(f"Stopped after {pages} pages; more were available")
+    return items, truncated

--- a/src/utils/provider_pages.py
+++ b/src/utils/provider_pages.py
@@ -58,9 +58,20 @@ async def fetch_all(
             logger.warning(f"{url} answered {response.status_code} while paging")
             return items, True
 
-        page = response.json()
+        try:
+            page = response.json()
+        except ValueError:
+            # A proxy error page, or a body cut off part way through. Keeping
+            # what was read and saying the list is short beats handing back a
+            # prefix that looks whole.
+            logger.warning(f"{url} answered something other than JSON while paging")
+            return items, True
+
         if not isinstance(page, list):
-            return page, False
+            logger.warning(
+                f"{url} answered a {type(page).__name__} where a list was expected"
+            )
+            return items, True
 
         items.extend(page)
         pages += 1


### PR DESCRIPTION
Lists were read one page deep and served as if that were all of them, so a truncated list and a short one looked the same. On this account the repository picker showed 100 of several hundred and the rest could not be connected at all. Reading the same endpoint now returns 157.

| Endpoint | Was | Now |
| --- | --- | --- |
| `/api/repos` | first 100 | every page |
| `/api/reviews/pulls` | first 50 | every page |
| `/api/triage` | first 50 | every page |

Reading stops after 20 pages rather than running unbounded, and a list cut short there says so. A page that fails part way returns what was read, marked incomplete.

Serving those lists whole only moved the problem, so they now answer a page at a time. The paging is `fastapi-pagination`: `page` and `size` are its `Params`, the body is its `Page` inside the usual envelope, and a `size` above 100 is refused.

| Endpoint | Takes |
| --- | --- |
| `/api/repos` | `q`, `page`, `size` |
| `/api/repos/connected` | `page`, `size` |
| `/api/reviews` | repeated `repo`, `page`, `size` |
| `/api/reviews/pulls` | repeated `repo`, `page`, `size` |
| `/api/triage` | repeated `repo`, `page`, `size` |

A scope of several repositories is merged and ordered here rather than by the caller. Fetching each repository separately and stitching the answers together can only order what has already been fetched, so page 2 of a stitched list is not page 2 of anything.

Reviews are enriched only for the page in hand. A repository with 200 reviews made 200 provider calls to answer one screen; it now makes as many as the page holds.

Repository search runs over everything the token reaches before the page is cut. Filtering the page in hand would search 20 of 157.

## Breaking

`/api/repos` and `/api/repos/connected` answered with a bare array and now answer with the envelope every other endpoint uses.

## Still capped

Comments and files on a pull request, 100 each. Files matter for Lens, which shows its file list as everything a change touches, and #18 asks that surface to work on a change too large for the provider to render.

## Goes with

- webservice: forwards `page`, `size`, `q`, and the repeated `repo`
- dashboard: requests pages instead of slicing an array it already holds
- memory: a scope-wide proposals endpoint, so the inbox queue can be paged
