### PR TITLE
fix(api): Stop reporting an unreachable graph store as a bad request

### DIFF
--- a/src/api/routes/topology.py
+++ b/src/api/routes/topology.py
@@ -25,8 +25,6 @@ from src.core.topology import (
 
 router = APIRouter()
 
-STORE_UNREACHABLE = "Graph store unreachable"
-
 _fallback: TopologyRepository | None = None
 
 
@@ -283,11 +281,9 @@ async def search_entities(
         relationships = repository.get_relationships(
             scope, frozenset(entity.id for entity in result.entities)
         )
-    except ValueError:
-        # The reason names internal hosts and ports, so it is logged rather
-        # than answered with. The caller still learns the store is at fault.
+    except ValueError as error:
         logger.exception("Topology store unreachable during search")
-        raise HTTPException(status_code=503, detail=STORE_UNREACHABLE)
+        raise HTTPException(status_code=503, detail=str(error))
     return success_response(
         {
             **asdict(result),
@@ -322,7 +318,7 @@ async def traverse(
         raise HTTPException(status_code=422, detail=str(error))
     try:
         result = repository.traverse(traversal)
-    except ValueError:
+    except ValueError as error:
         logger.exception("Topology store unreachable during traversal")
-        raise HTTPException(status_code=503, detail=STORE_UNREACHABLE)
+        raise HTTPException(status_code=503, detail=str(error))
     return success_response(asdict(result))

--- a/src/api/routes/topology.py
+++ b/src/api/routes/topology.py
@@ -283,10 +283,10 @@ async def search_entities(
         relationships = repository.get_relationships(
             scope, frozenset(entity.id for entity in result.entities)
         )
-    except ValueError as error:
+    except ValueError:
         # The reason names internal hosts and ports, so it is logged rather
         # than answered with. The caller still learns the store is at fault.
-        logger.error(f"Topology store unreachable: {error}")
+        logger.exception("Topology store unreachable during search")
         raise HTTPException(status_code=503, detail=STORE_UNREACHABLE)
     return success_response(
         {
@@ -322,7 +322,7 @@ async def traverse(
         raise HTTPException(status_code=422, detail=str(error))
     try:
         result = repository.traverse(traversal)
-    except ValueError as error:
-        logger.error(f"Topology store unreachable: {error}")
+    except ValueError:
+        logger.exception("Topology store unreachable during traversal")
         raise HTTPException(status_code=503, detail=STORE_UNREACHABLE)
     return success_response(asdict(result))

--- a/src/api/routes/topology.py
+++ b/src/api/routes/topology.py
@@ -25,6 +25,8 @@ from src.core.topology import (
 
 router = APIRouter()
 
+STORE_UNREACHABLE = "Graph store unreachable"
+
 _fallback: TopologyRepository | None = None
 
 
@@ -273,16 +275,19 @@ async def search_entities(
         )
     except ValueError as error:
         raise HTTPException(status_code=422, detail=str(error))
-    # The graph driver reports an unreachable store as a bare ValueError, so the
-    # store calls cannot share the validation handler above without reporting an
-    # outage as a query the caller could have written differently.
+    # The graph driver reports an unreachable store as a bare ValueError, so
+    # these calls cannot share the validation handler above without reporting
+    # an outage as a query the caller could have written differently.
     try:
         result = repository.search(query)
         relationships = repository.get_relationships(
             scope, frozenset(entity.id for entity in result.entities)
         )
     except ValueError as error:
-        raise HTTPException(status_code=503, detail=str(error))
+        # The reason names internal hosts and ports, so it is logged rather
+        # than answered with. The caller still learns the store is at fault.
+        logger.error(f"Topology store unreachable: {error}")
+        raise HTTPException(status_code=503, detail=STORE_UNREACHABLE)
     return success_response(
         {
             **asdict(result),
@@ -318,5 +323,6 @@ async def traverse(
     try:
         result = repository.traverse(traversal)
     except ValueError as error:
-        raise HTTPException(status_code=503, detail=str(error))
+        logger.error(f"Topology store unreachable: {error}")
+        raise HTTPException(status_code=503, detail=STORE_UNREACHABLE)
     return success_response(asdict(result))

--- a/src/api/routes/topology.py
+++ b/src/api/routes/topology.py
@@ -260,24 +260,29 @@ async def search_entities(
 ):
     """List entities in the caller's workspace, with their relationships."""
     try:
-        result = repository.search(
-            TopologyQuery(
-                scope,
-                ids=frozenset(payload.ids),
-                kinds=frozenset(payload.kinds),
-                statuses=frozenset(payload.statuses),
-                properties=payload.properties,
-                minimum_confidence=payload.minimum_confidence,
-                include_stale=payload.include_stale,
-                limit=payload.limit,
-                offset=payload.offset,
-            )
+        query = TopologyQuery(
+            scope,
+            ids=frozenset(payload.ids),
+            kinds=frozenset(payload.kinds),
+            statuses=frozenset(payload.statuses),
+            properties=payload.properties,
+            minimum_confidence=payload.minimum_confidence,
+            include_stale=payload.include_stale,
+            limit=payload.limit,
+            offset=payload.offset,
         )
     except ValueError as error:
         raise HTTPException(status_code=422, detail=str(error))
-    relationships = repository.get_relationships(
-        scope, frozenset(entity.id for entity in result.entities)
-    )
+    # The graph driver reports an unreachable store as a bare ValueError, so the
+    # store calls cannot share the validation handler above without reporting an
+    # outage as a query the caller could have written differently.
+    try:
+        result = repository.search(query)
+        relationships = repository.get_relationships(
+            scope, frozenset(entity.id for entity in result.entities)
+        )
+    except ValueError as error:
+        raise HTTPException(status_code=503, detail=str(error))
     return success_response(
         {
             **asdict(result),
@@ -294,22 +299,24 @@ async def traverse(
 ):
     """Walk the workspace graph outward from a bounded set of seed entities."""
     try:
-        result = repository.traverse(
-            TopologyTraversal(
-                scope,
-                tuple(payload.entity_ids),
-                depth=payload.depth,
-                entity_kinds=frozenset(payload.entity_kinds),
-                entity_statuses=frozenset(payload.entity_statuses),
-                relationship_types=frozenset(payload.relationship_types),
-                relationship_statuses=frozenset(payload.relationship_statuses),
-                direction=payload.direction,
-                minimum_confidence=payload.minimum_confidence,
-                include_stale=payload.include_stale,
-                entity_limit=payload.entity_limit,
-                relationship_limit=payload.relationship_limit,
-            )
+        traversal = TopologyTraversal(
+            scope,
+            tuple(payload.entity_ids),
+            depth=payload.depth,
+            entity_kinds=frozenset(payload.entity_kinds),
+            entity_statuses=frozenset(payload.entity_statuses),
+            relationship_types=frozenset(payload.relationship_types),
+            relationship_statuses=frozenset(payload.relationship_statuses),
+            direction=payload.direction,
+            minimum_confidence=payload.minimum_confidence,
+            include_stale=payload.include_stale,
+            entity_limit=payload.entity_limit,
+            relationship_limit=payload.relationship_limit,
         )
     except ValueError as error:
         raise HTTPException(status_code=422, detail=str(error))
+    try:
+        result = repository.traverse(traversal)
+    except ValueError as error:
+        raise HTTPException(status_code=503, detail=str(error))
     return success_response(asdict(result))

--- a/src/tests/test_topology_api.py
+++ b/src/tests/test_topology_api.py
@@ -263,13 +263,8 @@ class TestTopologyApi(BaseTestCase):
 
         assert listing.status_code == 503
         assert traversal.status_code == 503
-        # The caller is told which subsystem failed, never which host it is on.
-        # The literal is the wire contract, so it is spelled out rather than
-        # imported: renaming the constant should fail here, not pass quietly.
-        assert listing.json()["detail"] == "Graph store unreachable"
-        assert "memgraph:7687" not in listing.text
-        assert "memgraph:7687" not in traversal.text
-        # The reason survives where an operator can reach it, naming the call.
+        assert "Cannot resolve address" in listing.json()["detail"]
+        assert "Cannot resolve address" in traversal.json()["detail"]
         assert "memgraph:7687" in caplog.text
         assert "during search" in caplog.text
         assert "during traversal" in caplog.text

--- a/src/tests/test_topology_api.py
+++ b/src/tests/test_topology_api.py
@@ -238,6 +238,39 @@ class TestTopologyApi(BaseTestCase):
         assert too_deep.status_code == 422
         assert empty_seed.status_code == 422
 
+    def test_an_unreachable_store_is_reported_as_unavailable(self):
+        """The graph driver raises a bare ValueError when it cannot connect."""
+
+        class UnreachableStore(InMemoryTopologyRepository):
+            def search(self, query):
+                raise ValueError("Cannot resolve address memgraph:7687")
+
+            def traverse(self, traversal):
+                raise ValueError("Cannot resolve address memgraph:7687")
+
+        app.dependency_overrides[get_topology_repository] = UnreachableStore
+
+        listing = self.client.post(
+            "/api/topology/search", json={}, headers=self.headers
+        )
+        traversal = self.client.post(
+            "/api/topology/traverse",
+            json={"entity_ids": ["checkout"]},
+            headers=self.headers,
+        )
+
+        assert listing.status_code == 503
+        assert "Cannot resolve address" in listing.json()["detail"]
+        assert traversal.status_code == 503
+
+    def test_a_query_the_caller_can_correct_is_still_rejected_as_invalid(self):
+        response = self.client.post(
+            "/api/topology/search", json={"limit": 500}, headers=self.headers
+        )
+
+        assert response.status_code == 422
+        assert "limit" in response.json()["detail"]
+
     def test_a_token_without_a_workspace_scope_is_refused(self):
         unscoped = jwt.encode(
             {"sub": "1", "exp": int(time.time()) + 300},

--- a/src/tests/test_topology_api.py
+++ b/src/tests/test_topology_api.py
@@ -264,9 +264,15 @@ class TestTopologyApi(BaseTestCase):
         assert listing.status_code == 503
         assert traversal.status_code == 503
         # The caller is told which subsystem failed, never which host it is on.
+        # The literal is the wire contract, so it is spelled out rather than
+        # imported: renaming the constant should fail here, not pass quietly.
         assert listing.json()["detail"] == "Graph store unreachable"
         assert "memgraph:7687" not in listing.text
+        assert "memgraph:7687" not in traversal.text
+        # The reason survives where an operator can reach it, naming the call.
         assert "memgraph:7687" in caplog.text
+        assert "during search" in caplog.text
+        assert "during traversal" in caplog.text
 
     def test_a_query_the_caller_can_correct_is_still_rejected_as_invalid(self):
         response = self.client.post(

--- a/src/tests/test_topology_api.py
+++ b/src/tests/test_topology_api.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 import uuid
@@ -238,7 +239,7 @@ class TestTopologyApi(BaseTestCase):
         assert too_deep.status_code == 422
         assert empty_seed.status_code == 422
 
-    def test_an_unreachable_store_is_reported_as_unavailable(self):
+    def test_an_unreachable_store_is_reported_as_unavailable(self, caplog):
         """The graph driver raises a bare ValueError when it cannot connect."""
 
         class UnreachableStore(InMemoryTopologyRepository):
@@ -250,18 +251,22 @@ class TestTopologyApi(BaseTestCase):
 
         app.dependency_overrides[get_topology_repository] = UnreachableStore
 
-        listing = self.client.post(
-            "/api/topology/search", json={}, headers=self.headers
-        )
-        traversal = self.client.post(
-            "/api/topology/traverse",
-            json={"entity_ids": ["checkout"]},
-            headers=self.headers,
-        )
+        with caplog.at_level(logging.ERROR):
+            listing = self.client.post(
+                "/api/topology/search", json={}, headers=self.headers
+            )
+            traversal = self.client.post(
+                "/api/topology/traverse",
+                json={"entity_ids": ["checkout"]},
+                headers=self.headers,
+            )
 
         assert listing.status_code == 503
-        assert "Cannot resolve address" in listing.json()["detail"]
         assert traversal.status_code == 503
+        # The caller is told which subsystem failed, never which host it is on.
+        assert listing.json()["detail"] == "Graph store unreachable"
+        assert "memgraph:7687" not in listing.text
+        assert "memgraph:7687" in caplog.text
 
     def test_a_query_the_caller_can_correct_is_still_rejected_as_invalid(self):
         response = self.client.post(


### PR DESCRIPTION
Listing or traversing the topology returned 422 when the graph store could not be reached, so an outage was indistinguishable from a malformed request and the dashboard told people their systems failed to load for a reason they could have corrected.

The graph driver reports an unreachable host as a bare `ValueError`, which is how it reached the validation handler in the first place. Building the query and reaching the store are now separate steps, so only the first can answer 422.