### PR TITLE
feat(webhooks): Accept the gateway's authorization on deliveries

### DIFF
--- a/src/api/routes/pr.py
+++ b/src/api/routes/pr.py
@@ -9,7 +9,8 @@ from fastapi import (
 )
 from src.controllers.repository_event_controller import RepositoryEventController
 from src.events.dispatcher import bg_tasks_cv
-from src.config.settings import GITHUB_SECRET, GITHUB_OAUTH_SECRET
+from src.auth import read_gateway_scope
+from src.config.settings import GITHUB_SECRET, GITHUB_OAUTH_SECRET, REQUIRE_GATEWAY
 from typing import Optional
 from pydantic import BaseModel, ConfigDict
 import hmac
@@ -54,6 +55,15 @@ def get_event(event: str = Header(None, alias="X-GitHub-Event")):
     return event
 
 
+def get_gateway_scope(authorization: str = Header(None)) -> dict:
+    scope = read_gateway_scope(authorization)
+
+    if scope is None and REQUIRE_GATEWAY:
+        raise HTTPException(status_code=401, detail="Gateway authorization required")
+
+    return scope or {}
+
+
 def get_provider_from_headers(headers: dict) -> Optional[str]:
     for header_name in headers:
         if header_name.lower().startswith("x-github-"):
@@ -66,6 +76,7 @@ def process_github_webhook(
     event: str,
     request: Request,
     auth_type: str = "github_app",
+    scope: dict | None = None,
 ):
     url = (
         payload.pull_request["url"]
@@ -84,6 +95,7 @@ def process_github_webhook(
 
     enhanced_payload = payload.model_dump()
     enhanced_payload["sourceant_auth_type"] = auth_type
+    enhanced_payload["sourceant_workspace_id"] = (scope or {}).get("workspace_id")
 
     return RepositoryEventController.create(
         action=payload.action,
@@ -103,6 +115,7 @@ async def github_webhook(
     background_tasks: BackgroundTasks,
     signature: str = Header(None, alias="X-Hub-Signature-256"),
     event: str = Depends(get_event),
+    scope: dict = Depends(get_gateway_scope),
     payload: GitHubWebhookPayload = Body(...),
 ):
     payload_data = await request.body()
@@ -111,7 +124,9 @@ async def github_webhook(
 
     bg_tasks_cv.set(background_tasks)
 
-    return process_github_webhook(payload, event, request, auth_type="github_app")
+    return process_github_webhook(
+        payload, event, request, auth_type="github_app", scope=scope
+    )
 
 
 @router.post("/github-webhook-oauth")
@@ -120,6 +135,7 @@ async def github_oauth_webhook(
     background_tasks: BackgroundTasks,
     signature: str = Header(None, alias="X-Hub-Signature-256"),
     event: str = Depends(get_event),
+    scope: dict = Depends(get_gateway_scope),
     payload: GitHubWebhookPayload = Body(...),
 ):
     if GITHUB_OAUTH_SECRET is None:
@@ -131,4 +147,6 @@ async def github_oauth_webhook(
 
     bg_tasks_cv.set(background_tasks)
 
-    return process_github_webhook(payload, event, request, auth_type="oauth")
+    return process_github_webhook(
+        payload, event, request, auth_type="oauth", scope=scope
+    )

--- a/src/auth.py
+++ b/src/auth.py
@@ -15,6 +15,29 @@ def _get_jwt_secret() -> str:
     return secret
 
 
+def read_gateway_scope(authorization: str | None) -> dict | None:
+    """The workspace a gateway signed this call for, or None if it did not sign one.
+
+    Deliveries reach the agent through the gateway, which decides who is asking
+    and whether they may be reviewed. The scope is that decision, carried across.
+    """
+    if not authorization:
+        return None
+
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid authorization header")
+
+    try:
+        payload = decode_access_token(authorization[7:])
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token has expired")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    scope = payload.get("scope")
+    return scope if isinstance(scope, dict) else {}
+
+
 async def get_current_user(authorization: str = Header(...)) -> dict:
     try:
         if not authorization.startswith("Bearer "):

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -6,6 +6,7 @@ load_dotenv()
 APP_ENV = os.getenv("APP_ENV", "production").lower()
 DEBUG_MODE = os.getenv("DEBUG_MODE", "false").lower() == "true"
 STATELESS_MODE = os.getenv("STATELESS_MODE", "false").lower() == "true"
+REQUIRE_GATEWAY = os.getenv("REQUIRE_GATEWAY", "false").lower() == "true"
 QUEUE_MODE = os.getenv("QUEUE_MODE", "redis")
 VALID_QUEUE_MODES = ["redis", "request", "redislite"]
 if QUEUE_MODE not in VALID_QUEUE_MODES:

--- a/src/tests/test_gateway_authenticated_webhooks.py
+++ b/src/tests/test_gateway_authenticated_webhooks.py
@@ -1,0 +1,83 @@
+import time
+
+import jwt
+import pytest
+
+from src.tests.base_test import BaseTestCase
+
+SECRET = "a-jwt-secret-of-at-least-32-bytes-long"
+
+
+def token(workspace_id="7", expires_in=60):
+    return jwt.encode(
+        {
+            "sub": "installation:1",
+            "scope": {"workspace_id": workspace_id, "repository_ids": []},
+            "exp": int(time.time()) + expires_in,
+        },
+        SECRET,
+        algorithm="HS256",
+    )
+
+
+class TestGatewayAuthenticatedWebhooks(BaseTestCase):
+    @pytest.fixture(autouse=True)
+    def _secret(self, monkeypatch):
+        monkeypatch.setenv("JWT_SECRET", SECRET)
+
+    def payload(self):
+        return {
+            "action": "opened",
+            "pull_request": {
+                "url": "https://api.github.com/repos/sourceant/sourceant/pulls/1",
+                "title": "Fix bug",
+                "number": 1,
+            },
+            "repository": {"full_name": "sourceant/sourceant"},
+            "sender": {"login": "octocat"},
+        }
+
+    def deliver(self, headers=None):
+        return self.client.post(
+            "/api/prs/github-webhook",
+            headers={"X-GitHub-Event": "pull_request", **(headers or {})},
+            json=self.payload(),
+        )
+
+    def test_it_accepts_a_delivery_the_gateway_signed(self):
+        assert self.deliver({"Authorization": f"Bearer {token()}"}).status_code == 201
+
+    def test_it_rejects_a_token_signed_with_another_secret(self):
+        forged = jwt.encode(
+            {"sub": "installation:1", "exp": int(time.time()) + 60},
+            "not-the-secret-at-all-but-long-enough",
+            algorithm="HS256",
+        )
+
+        assert self.deliver({"Authorization": f"Bearer {forged}"}).status_code == 401
+
+    def test_it_rejects_an_expired_token(self):
+        assert (
+            self.deliver(
+                {"Authorization": f"Bearer {token(expires_in=-10)}"}
+            ).status_code
+            == 401
+        )
+
+    def test_it_rejects_a_header_that_is_not_a_bearer_token(self):
+        assert self.deliver({"Authorization": "Basic abc"}).status_code == 401
+
+    def test_it_still_accepts_a_delivery_with_no_gateway_in_front(self):
+        assert self.deliver().status_code == 201
+
+    def test_it_refuses_an_unsigned_delivery_when_a_gateway_is_required(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr("src.api.routes.pr.REQUIRE_GATEWAY", True)
+
+        assert self.deliver().status_code == 401
+
+    def test_it_accepts_a_signed_delivery_when_a_gateway_is_required(self, monkeypatch):
+        monkeypatch.setattr("src.api.routes.pr.REQUIRE_GATEWAY", True)
+
+        assert self.deliver({"Authorization": f"Bearer {token()}"}).status_code == 201


### PR DESCRIPTION
The agent accepts a signed scope from the gateway and records the workspace it names on each delivery, which is what ties a review to the account that was charged for it.

A deployment with nothing in front of the agent is unaffected. With no Authorization header a delivery is handled as it was before, so a self-hosted agent needs no gateway. `REQUIRE_GATEWAY=true` makes the header mandatory, which closes the path around the decision where the gateway is the only intended way in.
