### PR TITLE
fix(migrations): Let the migration command finish

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ fastapi
 fastapi-pagination
 google-genai
 httpx
-litellm
+litellm==1.97.0
 Mako
 mcp==1.28.1
 psycopg2

--- a/sourceant
+++ b/sourceant
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import click
+import os
 import sys
 import subprocess
 from src.config.settings import DATABASE_URL, STATELESS_MODE
@@ -34,7 +35,12 @@ def db_command(ctx):
     cfg.set_main_option("version_locations", " ".join(resolve_version_locations()))
     fn, positional, kwarg = options.cmd
     fn(cfg, *[getattr(options, k) for k in positional], **{k: getattr(options, k) for k in kwarg})
-    sys.exit(0)
+    # Leave immediately rather than waiting on whatever the migration environment
+    # started. A plugin that keeps a thread alive would otherwise hold this command
+    # open forever, and everything that waits for migrations to finish with it.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)
 
 
 @click.group(name='code')

--- a/src/utils/migration_paths.py
+++ b/src/utils/migration_paths.py
@@ -10,12 +10,16 @@ def resolve_version_locations() -> List[str]:
     dirs += globmod.glob("src/plugins/*/migrations")
     try:
         from importlib.metadata import entry_points
-        import importlib.resources
+        import importlib.util
 
         for ep in entry_points(group="sourceant.migrations"):
-            mod = ep.load()
-            path = str(importlib.resources.files(mod.__name__))
-            if os.path.isdir(path):
+            # Locate the module rather than loading it. Importing a plugin to read
+            # its migrations directory also starts it, and a plugin that leaves a
+            # thread running keeps the migration process alive after it is done.
+            spec = importlib.util.find_spec(ep.value.split(":")[0])
+            locations = list(getattr(spec, "submodule_search_locations", None) or [])
+            path = locations[0] if locations else os.path.dirname(spec.origin or "")
+            if path and os.path.isdir(path):
                 dirs.append(path)
     except Exception as e:
         logger.warning(f"Could not discover entrypoint migrations: {e}")


### PR DESCRIPTION
Discovering a plugin's migrations imported the plugin to read its location, which also started it. A plugin that leaves a thread running then held the migration command open after the schema was already written.

The location is now resolved without running the plugin, and the command leaves as soon as the work is done rather than waiting on whatever the migration environment happened to start.

A deployment that waits for migrations to finish before serving was waiting forever, so nothing behind them ever started.