### PR TITLE
fix: Use a model client that can build a response

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ fastapi
 fastapi-pagination
 google-genai
 httpx
-litellm==1.97.0
+litellm==1.96.0
 Mako
 mcp==1.28.1
 psycopg2

--- a/src/tests/unit/test_model_client_contract.py
+++ b/src/tests/unit/test_model_client_contract.py
@@ -1,0 +1,23 @@
+"""The model client is mocked everywhere else, so nothing else would notice it break."""
+
+import pytest
+
+
+def test_a_response_can_be_constructed():
+    from litellm.types.utils import ModelResponse
+
+    # Raised PydanticUserError on litellm 1.97.0, which reached production and
+    # stopped every review before a request was ever sent.
+    ModelResponse()
+
+
+def test_a_completion_can_be_made_without_a_provider():
+    import litellm
+
+    answer = litellm.completion(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        mock_response="hello",
+    )
+
+    assert answer.choices[0].message.content == "hello"


### PR DESCRIPTION
Reviews stopped before any request was sent: constructing a response raised on the pinned version, which is broken for that regardless of environment. The versions either side of it are fine.

Nothing caught it because the model client is replaced by a stub in every test, so no test has ever exercised the real one. Two now do, and both fail on the version that reached production.