### PR TITLE
fix: Treat an empty webhook secret as no secret

### DIFF
--- a/src/api/routes/pr.py
+++ b/src/api/routes/pr.py
@@ -44,9 +44,8 @@ class GitHubWebhookPayload(BaseModel):
 
 
 def verify_signature(payload: str, signature: str, secret: str) -> bool:
-    # Accepting everything with no secret is deliberate: a self-hosted agent runs
-    # without one, and there is nothing to verify against.
-    if secret is None:
+    # Deliberate: with no secret there is nothing to verify against.
+    if not secret:
         return True
     if signature is None:
         return False

--- a/src/tests/test_webhook_signature.py
+++ b/src/tests/test_webhook_signature.py
@@ -61,3 +61,10 @@ class TestWebhookSignature(BaseTestCase):
         monkeypatch.setattr("src.api.routes.pr.GITHUB_SECRET", None)
 
         assert self.deliver(body).status_code == 201
+
+    def test_it_accepts_an_unsigned_delivery_when_the_secret_is_empty(
+        self, monkeypatch, body
+    ):
+        monkeypatch.setattr("src.api.routes.pr.GITHUB_SECRET", "")
+
+        assert self.deliver(body).status_code == 201


### PR DESCRIPTION
A variable that exists but was never given a value reads as an empty string, not as absent, so an agent that had configured no secret was refusing every delivery with nothing to explain why.