### PR TITLE
fix: Reconnect before calling a dependency down

### DIFF
--- a/src/api/routes/health.py
+++ b/src/api/routes/health.py
@@ -116,11 +116,24 @@ _pool = ThreadPoolExecutor(max_workers=len(CHECKS) * 2, thread_name_prefix="heal
 
 def _run(name: str, probe: Callable[[], tuple[str, str | None]]) -> Check:
     started = perf_counter()
-    try:
-        status, detail = probe()
-    except Exception as error:
-        logger.warning(f"Readiness check '{name}' failed: {error}", exc_info=True)
-        status, detail = FAILED, str(error)
+    status, detail = FAILED, None
+
+    # After a redeploy the first call can fail on a pooled connection to the
+    # container that was just replaced, and the driver opens a new one for the
+    # call after it. Retry once so that is not reported as the dependency
+    # being down.
+    for remaining in (True, False):
+        try:
+            status, detail = probe()
+            break
+        except Exception as error:
+            detail = str(error)
+            if remaining:
+                logger.debug(f"Readiness check '{name}' failed, retrying: {error}")
+                continue
+            logger.warning(f"Readiness check '{name}' failed: {error}", exc_info=True)
+            status = FAILED
+
     elapsed = int((perf_counter() - started) * 1000)
     return Check(name=name, status=status, duration_ms=elapsed, detail=detail)
 

--- a/src/tests/test_health.py
+++ b/src/tests/test_health.py
@@ -45,6 +45,38 @@ class TestReadiness:
         assert response.json()["status"] == "failed"
         assert response.json()["checks"]["queue"]["status"] == "failed"
 
+    def test_a_connection_replaced_under_it_is_not_a_failure(self, client, monkeypatch):
+        attempts = []
+
+        def stale_once():
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise OSError("No data")
+            return health.OK, "reconnected"
+
+        monkeypatch.setitem(health.CHECKS, "graph", stale_once)
+
+        response = client.get("/health/ready")
+
+        assert attempts == [1, 1]
+        assert response.status_code == 200
+        assert response.json()["checks"]["graph"]["status"] == "ok"
+
+    def test_a_dependency_that_stays_down_is_still_a_failure(self, client, monkeypatch):
+        attempts = []
+
+        def always_down():
+            attempts.append(1)
+            raise ConnectionError("Error 111 connecting to memgraph:7687")
+
+        monkeypatch.setitem(health.CHECKS, "graph", always_down)
+
+        response = client.get("/health/ready")
+
+        assert attempts == [1, 1]
+        assert response.status_code == 503
+        assert response.json()["checks"]["graph"]["status"] == "failed"
+
     def test_a_failure_does_not_hide_the_checks_that_passed(self, client, monkeypatch):
         monkeypatch.setitem(
             health.CHECKS, "graph", lambda: (_ for _ in ()).throw(ValueError("down"))


### PR DESCRIPTION
A redeploy replaces Memgraph underneath a driver that is still holding a
connection to it, so the first readiness probe afterwards fails on a socket the
driver then quietly replaces:

```
neo4j.io ERROR <CONNECTION> error: Failed to read from defunct connection
  IPv4Address(('memgraph', 7687)): OSError('No data')
GET /health/ready HTTP/1.1" 503 Service Unavailable
```

The endpoint reported that as the graph store being down, and the next probe
seconds later returned 200. A caller reading readiness during that window is
told a dependency is unavailable when it is reachable.

A probe now gets a second attempt before its answer counts, which is the right
number for this failure: a stale pooled connection fails once and the driver
opens a new one for the call after it. A dependency that is genuinely gone
fails both attempts and is still reported down.

Retrying more times, with waits between them, would work against the five
second budget the whole probe runs under, and turn a slow but reachable
dependency into a timeout. Tolerance for a dependency that is simply slow to
come up belongs in the container health check's start period and retry count,
not inside a single probe.
