### PR TITLE
fix: Carry the reason a model call failed

### DIFF
--- a/src/llms/errors.py
+++ b/src/llms/errors.py
@@ -1,0 +1,15 @@
+class LLMError(Exception):
+    """A call to the model provider failed.
+
+    Carries the provider's own exception rather than replacing it, because the
+    caller cannot tell an expired key from an exhausted quota from a prompt that
+    overran the context window, and each of those needs a different response.
+    """
+
+    def __init__(self, message: str, cause: BaseException | None = None):
+        super().__init__(message)
+        self.cause = cause
+
+    @classmethod
+    def wrapping(cls, action: str, cause: BaseException) -> "LLMError":
+        return cls(f"{action} failed: {type(cause).__name__}: {cause}", cause)

--- a/src/llms/litellm_provider.py
+++ b/src/llms/litellm_provider.py
@@ -2,6 +2,7 @@ from typing import Optional, List, Union
 
 import litellm
 
+from src.llms.errors import LLMError
 from src.llms.llm_interface import LLMInterface
 from src.prompts.prompts import Prompts
 from src.utils.diff_parser import ParsedDiff
@@ -167,7 +168,7 @@ class LiteLLMProvider(LLMInterface):
             return response.choices[0].message.content
         except Exception as e:
             logger.error(f"An error occurred during text generation: {e}")
-            return ""
+            raise LLMError.wrapping("Text generation", e) from e
 
     def is_summary_different(self, summary_a: str, summary_b: str) -> bool:
         prompt = Prompts.COMPARE_SUMMARIES_PROMPT.format(

--- a/src/tests/unit/test_litellm_provider.py
+++ b/src/tests/unit/test_litellm_provider.py
@@ -1,4 +1,6 @@
 import pytest
+
+from src.llms.errors import LLMError
 from unittest.mock import patch, MagicMock
 
 from src.llms.litellm_provider import LiteLLMProvider
@@ -180,10 +182,27 @@ def test_generate_text_success(provider, mock_completion):
     assert result == "Hello there"
 
 
-def test_generate_text_error(provider, mock_completion):
+def test_generate_text_names_the_provider_failure(provider, mock_completion):
+    class AuthenticationError(Exception):
+        pass
+
+    mock_completion.completion.side_effect = AuthenticationError(
+        "API key not valid. Please pass a valid API key."
+    )
+
+    with pytest.raises(LLMError) as raised:
+        provider.generate_text("Say hello")
+
+    assert "AuthenticationError" in str(raised.value)
+    assert "API key not valid" in str(raised.value)
+    assert isinstance(raised.value.cause, AuthenticationError)
+
+
+def test_generate_text_does_not_answer_with_an_empty_string(provider, mock_completion):
     mock_completion.completion.side_effect = Exception("fail")
-    result = provider.generate_text("Say hello")
-    assert result == ""
+
+    with pytest.raises(LLMError):
+        provider.generate_text("Say hello")
 
 
 def test_is_summary_different_returns_true(provider, mock_completion):


### PR DESCRIPTION
`generate_text` returned an empty string for every failure, so an expired key, a
model name that does not exist, a prompt past the context window, a timeout and a
real quota limit all reached the caller as the same value. The caller could only
guess at the cause, and the guess it shipped named quota.

This is not hypothetical. An expired Gemini key took down repository initialization
on staging and the failure was reported as a rate limit, which sent the reading in
the wrong direction entirely.

The call now fails with the provider's own exception attached, so the reason travels
with the error. The three existing callers already wrap it in `try/except Exception`
and are unaffected.
