### PR TITLE
fix(mcp): Check what a caller may reach instead of partitioning by who they are

### DIFF
--- a/src/mcp_server/application.py
+++ b/src/mcp_server/application.py
@@ -20,7 +20,11 @@ from src.core.review_state import InMemoryReviewStateRepository
 from src.core.services import service_registry
 from src.core.topology import InMemoryTopologyRepository, SQLTopologyRepository
 
-from .auth import PrincipalScopeResolver, SourceAntTokenVerifier
+from .auth import (
+    EntitledScopeResolver,
+    SourceAntTokenVerifier,
+    connected_repository_entitlement,
+)
 from .server import create_mcp_server
 
 
@@ -96,7 +100,7 @@ def create_http_mcp_server():
         code=code,
         knowledge=knowledge,
         topology=topology,
-        scope_resolver=PrincipalScopeResolver(),
+        scope_resolver=EntitledScopeResolver(connected_repository_entitlement(engine)),
         auth=AuthSettings(
             issuer_url=values["issuer"],
             resource_server_url=values["resource"],

--- a/src/mcp_server/auth.py
+++ b/src/mcp_server/auth.py
@@ -111,9 +111,17 @@ def connected_repository_entitlement(engine) -> Callable[[str, str], str | None]
         # the answer is no rather than an unchecked yes.
         if engine is None:
             return None
-        user_id = principal.split(":")[-1]
-        if not user_id.isdigit():
+
+        # Subjects are written either bare or as kind:id, and the kinds share a
+        # numbering. Reading the id off the end would let installation 7 be
+        # answered as though it were user 7, so anything that is not a person is
+        # refused rather than reinterpreted.
+        kind, _, identity = principal.rpartition(":")
+        if kind not in ("", "user"):
             return None
+        if not identity.isdigit():
+            return None
+        user_id = identity
         with Session(engine) as session:
             row = session.exec(
                 select(Repository)

--- a/src/mcp_server/auth.py
+++ b/src/mcp_server/auth.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Callable, Protocol
+
 import jwt
 from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.auth.provider import AccessToken
@@ -52,9 +54,78 @@ class SourceAntTokenVerifier:
         return frozenset()
 
 
-class PrincipalScopeResolver:
+class RepositoryEntitlement(Protocol):
+    """Answers whether a principal may reach a repository, and who hosts it.
+
+    Returning the provider is what lets the resolver name the repository the way
+    the writers name it, from a request that gave only its full name.
+    """
+
+    def __call__(self, principal: str, repository: str) -> str | None: ...
+
+
+class EntitledScopeResolver:
+    """Check the caller against what they may reach, and leave the scope alone.
+
+    The principal used to be added to the scope, and the scope is the key the
+    graph is partitioned by, so a caller could only ever read back what that same
+    caller had written through this server. Everything SourceAnt captures for
+    itself is written without a principal, which put all of it in a partition no
+    token could name.
+
+    Isolation is now the entitlement rather than the partition, which is where it
+    belongs: the tenant is read from a verified claim on the token and enforced
+    on every call, and the data stays under the repository it is about.
+    """
+
+    def __init__(self, entitlement: RepositoryEntitlement) -> None:
+        self._entitlement = entitlement
+
     def __call__(self, scope: Scope) -> Scope:
         token = get_access_token()
         if token is None or token.subject is None:
             raise ValueError("authenticated principal is required")
-        return scope.extend({"principal": token.subject})
+
+        repository = scope.get("repository")
+        if not repository:
+            raise ValueError("scope must name a repository")
+
+        provider = self._entitlement(token.subject, repository)
+        if provider is None:
+            raise ValueError(f"not entitled to {repository}")
+
+        # A caller who named only the repository is asking about the same thing
+        # as the writers, which name the provider too.
+        return scope if scope.get("provider") else scope.extend({"provider": provider})
+
+
+def connected_repository_entitlement(engine) -> Callable[[str, str], str | None]:
+    """Entitlement as the rest of the API already means it: what you connected."""
+    from sqlmodel import Session, select
+
+    from src.models.connected_repository import ConnectedRepository
+    from src.models.repository import Repository
+
+    def entitled(principal: str, repository: str) -> str | None:
+        # Without a database there is nothing to check an entitlement against, so
+        # the answer is no rather than an unchecked yes.
+        if engine is None:
+            return None
+        user_id = principal.split(":")[-1]
+        if not user_id.isdigit():
+            return None
+        with Session(engine) as session:
+            row = session.exec(
+                select(Repository)
+                .join(
+                    ConnectedRepository,
+                    ConnectedRepository.repository_id == Repository.id,
+                )
+                .where(
+                    Repository.full_name == repository,
+                    ConnectedRepository.user_id == int(user_id),
+                )
+            ).first()
+        return row.provider if row else None
+
+    return entitled

--- a/src/tests/unit/test_mcp_entitlement.py
+++ b/src/tests/unit/test_mcp_entitlement.py
@@ -55,10 +55,14 @@ def test_a_repository_nobody_connected_is_not_reachable(tmp_path):
     assert entitled("7", "acme/other") is None
 
 
-def test_a_subject_that_is_not_a_user_is_refused(tmp_path):
+def test_a_subject_that_is_not_a_user_cannot_borrow_that_number(tmp_path):
+    """User 7 connected this repository. Installation 7 is a different thing."""
     entitled = connected_repository_entitlement(store(tmp_path))
 
-    assert entitled("installation:42", "acme/shop") is None
+    assert entitled("7", "acme/shop") == "github"
+    assert entitled("installation:7", "acme/shop") is None
+    assert entitled("workspace:7", "acme/shop") is None
+    assert entitled("client:7", "acme/shop") is None
 
 
 def test_without_a_database_nothing_is_reachable():

--- a/src/tests/unit/test_mcp_entitlement.py
+++ b/src/tests/unit/test_mcp_entitlement.py
@@ -1,0 +1,67 @@
+"""What a token may reach, resolved the way the rest of the API means it."""
+
+from sqlmodel import Session, SQLModel, create_engine
+
+from src.mcp_server.auth import connected_repository_entitlement
+from src.models.connected_repository import ConnectedRepository
+from src.models.repository import Repository
+
+
+def store(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'entitlement.db'}")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        repository = Repository(
+            provider="github",
+            name="shop",
+            full_name="acme/shop",
+            url="https://github.com/acme/shop",
+            private=False,
+            archived=False,
+            visibility="public",
+            owner="acme",
+            owner_type="Organization",
+            default_branch="main",
+        )
+        session.add(repository)
+        session.commit()
+        session.refresh(repository)
+        session.add(ConnectedRepository(user_id=7, repository_id=repository.id))
+        session.commit()
+    return engine
+
+
+def test_a_connected_repository_is_reachable_and_names_its_provider(tmp_path):
+    entitled = connected_repository_entitlement(store(tmp_path))
+
+    assert entitled("7", "acme/shop") == "github"
+
+
+def test_a_subject_written_as_a_pair_is_read_as_the_user(tmp_path):
+    entitled = connected_repository_entitlement(store(tmp_path))
+
+    assert entitled("user:7", "acme/shop") == "github"
+
+
+def test_somebody_else_cannot_reach_it(tmp_path):
+    entitled = connected_repository_entitlement(store(tmp_path))
+
+    assert entitled("8", "acme/shop") is None
+
+
+def test_a_repository_nobody_connected_is_not_reachable(tmp_path):
+    entitled = connected_repository_entitlement(store(tmp_path))
+
+    assert entitled("7", "acme/other") is None
+
+
+def test_a_subject_that_is_not_a_user_is_refused(tmp_path):
+    entitled = connected_repository_entitlement(store(tmp_path))
+
+    assert entitled("installation:42", "acme/shop") is None
+
+
+def test_without_a_database_nothing_is_reachable():
+    entitled = connected_repository_entitlement(None)
+
+    assert entitled("7", "acme/shop") is None

--- a/src/tests/unit/test_mcp_server.py
+++ b/src/tests/unit/test_mcp_server.py
@@ -28,7 +28,7 @@ from src.core.scope import Scope
 from src.core.topology import SQLTopologyRepository
 from src.mcp_server import create_mcp_server
 from src.mcp_server.application import create_http_mcp_server
-from src.mcp_server.auth import PrincipalScopeResolver, SourceAntTokenVerifier
+from src.mcp_server.auth import EntitledScopeResolver, SourceAntTokenVerifier
 
 PROJECT = Scope.from_mapping({"project": "one"})
 OTHER_PROJECT = Scope.from_mapping({"project": "two"})
@@ -350,7 +350,7 @@ async def test_mcp_topology_tools_are_unavailable_without_a_repository():
 
 
 @pytest.mark.asyncio
-async def test_streamable_http_authenticates_and_isolates_principals(
+async def test_streamable_http_serves_what_the_caller_is_entitled_to(
     tmp_path, monkeypatch
 ):
     monkeypatch.setenv("JWT_SECRET", "test-secret-value-with-at-least-32-bytes")
@@ -358,10 +358,26 @@ async def test_streamable_http_authenticates_and_isolates_principals(
         create_engine(f"sqlite:///{tmp_path / 'knowledge.db'}"),
         create_schema=True,
     )
+
+    # Written the way a review or an initialization writes it: under the
+    # repository, with no idea who will read it back.
+    knowledge.put(
+        Scope.from_mapping({"provider": "github", "repository": "acme/shop"}),
+        Knowledge(
+            id="signed-requests",
+            kind="decision",
+            status="approved",
+            summary="Use signed requests",
+        ),
+    )
+
+    entitlements = {("one", "acme/shop"): "github"}
     server = create_mcp_server(
         DefaultContextProvider(knowledge=knowledge),
         knowledge=knowledge,
-        scope_resolver=PrincipalScopeResolver(),
+        scope_resolver=EntitledScopeResolver(
+            lambda principal, repository: entitlements.get((principal, repository))
+        ),
         auth=AuthSettings(
             issuer_url="https://issuer.example.com",
             resource_server_url="https://sourceant.example.com/mcp",
@@ -407,29 +423,38 @@ async def test_streamable_http_authenticates_and_isolates_principals(
                     await session.initialize()
                     return await action(session)
 
-    async def put(session):
-        return await session.call_tool(
-            "put_knowledge",
-            {
-                "scope": {"repository": "shop"},
-                "id": "decision",
-                "kind": "decision",
-                "status": "approved",
-                "summary": "Use signed requests",
-            },
-        )
-
     async def search(session):
         return await session.call_tool(
             "search_knowledge",
-            {"scope": {"repository": "shop"}},
+            {"scope": {"repository": "acme/shop"}},
+        )
+
+    async def search_elsewhere(session):
+        return await session.call_tool(
+            "search_knowledge",
+            {"scope": {"repository": "someone/else"}},
+        )
+
+    async def search_without_a_repository(session):
+        return await session.call_tool(
+            "search_knowledge",
+            {"scope": {"workspace": "acme"}},
         )
 
     async with app.router.lifespan_context(app):
-        stored = await use_client("one", put)
-        owner_result = await use_client("one", search)
-        other_result = await use_client("two", search)
+        entitled = await use_client("one", search)
+        elsewhere = await use_client("one", search_elsewhere)
+        unscoped = await use_client("one", search_without_a_repository)
+        stranger = await use_client("two", search)
 
-    assert stored.isError is False
-    assert owner_result.structuredContent["total"] == 1
-    assert other_result.structuredContent["total"] == 0
+    # The whole point: knowledge captured by SourceAnt is readable over MCP.
+    assert entitled.structuredContent["total"] == 1
+
+    assert elsewhere.isError is True
+    assert "not entitled to someone/else" in elsewhere.content[0].text
+
+    assert unscoped.isError is True
+    assert "scope must name a repository" in unscoped.content[0].text
+
+    assert stranger.isError is True
+    assert "not entitled to acme/shop" in stranger.content[0].text


### PR DESCRIPTION
The caller was added to the scope, and the scope is the key the graph is partitioned by, so a token could only ever read back what that same token had written through this server. Everything captured from a review or an initialization is written under the repository with no caller attached, which left all of it in a partition no token could name. Measured, with the row present in the store: a search returned 0 while the store held 1.

Isolation is now the entitlement rather than the partition, which is where the current guidance puts it too: tenant identity comes from a verified token claim and is enforced on every call, and the data stays where it is about. A caller is checked against the repositories they connected, which is the rule the rest of the API already applies.

This changes a contract deliberately. Two callers reading the same repository now see the same knowledge, where before each saw only its own writes. That is the point: knowledge a team captured is worth having because it is shared. The test that asserted the old behaviour is replaced by one that asserts the new one, plus refusal by name for a repository the caller did not connect and refusal of a scope that names no repository at all.

A request naming only the repository is completed with its provider, so a caller does not have to guess the exact scope shape the writers used.