### PR TITLE
fix: Leave the transaction to the caller, and narrow before sorting

### DIFF
--- a/src/api/routes/repos.py
+++ b/src/api/routes/repos.py
@@ -196,7 +196,7 @@ async def connect_repo(
     session.add(connection)
     session.commit()
 
-    _sync_repository(session, data)
+    _sync_repository(session, repo, data)
 
     return success_response(
         data={"id": repo.id}, message="Repository connected", status_code=201
@@ -223,15 +223,10 @@ async def disconnect_repo(
     return success_response(data=None, message="Repository disconnected")
 
 
-def _sync_repository(session: Session, data: ConnectRepoRequest) -> None:
+def _sync_repository(
+    session: Session, repo: Repository, data: ConnectRepoRequest
+) -> None:
     """Sync repository metadata from the connect request."""
-    repo = session.exec(
-        select(Repository).where(Repository.full_name == data.full_name)
-    ).first()
-
-    if not repo:
-        return
-
     repo.description = data.description
     repo.private = data.private
     repo.language = data.language

--- a/src/core/code_index/memory.py
+++ b/src/core/code_index/memory.py
@@ -141,16 +141,18 @@ class InMemoryCodeIndex:
         kept = wanted[: query.node_limit]
         included = {node.id for node in kept}
 
-        edges = tuple(
-            edge
-            for (edge_scope, _), edge in sorted(
-                self._edges.items(), key=lambda i: i[0][1]
-            )
+        # Narrowed before it is ordered. Sorting every edge in the store to
+        # answer about one scope costs the whole store on every call.
+        wanted_edges = [
+            (edge_id, edge)
+            for (edge_scope, edge_id), edge in self._edges.items()
             if edge_scope == scope
             and edge.source_id in included
             and edge.target_id in included
             and (not query.edge_types or edge.type in query.edge_types)
-        )
+        ]
+        wanted_edges.sort(key=lambda pair: pair[0])
+        edges = tuple(edge for _, edge in wanted_edges)
         return CodeGraphResult(nodes=tuple(kept), edges=edges, truncated=truncated)
 
 

--- a/src/core/workspace.py
+++ b/src/core/workspace.py
@@ -55,7 +55,10 @@ def remember(session: Session, workspace: str) -> Workspace:
 
     known = Workspace(external_id=workspace)
     session.add(known)
-    session.commit()
+    # Flushed rather than committed: the row gets its id, and whatever the
+    # caller is doing stays one transaction. Committing here would settle a
+    # workspace whose reason for existing had not been written yet.
+    session.flush()
     session.refresh(known)
     return known
 

--- a/src/tests/unit/test_core_workspace.py
+++ b/src/tests/unit/test_core_workspace.py
@@ -170,3 +170,36 @@ class TestWhatAWorkspaceHasTakenOn:
 
             held = session.exec(select(ConnectedRepository)).one()
             assert held.workspace_id == mine.id
+
+
+class TestLeavingTheTransactionToTheCaller:
+    def test_a_workspace_it_records_is_not_settled_on_its_own(self, tmp_path):
+        """Recording one is half of connecting a repository to it. Committing
+        here settles a workspace whose reason for existing has not been written
+        yet, and leaves it behind if the rest fails."""
+        engine = store(tmp_path)
+        with Session(engine) as session:
+            remember(session, "w42")
+            session.rollback()
+
+        with Session(engine) as session:
+            assert session.exec(select(Workspace)).all() == []
+
+    def test_it_still_hands_back_an_id_to_point_at(self, tmp_path):
+        with Session(store(tmp_path)) as session:
+            assert remember(session, "w42").id is not None
+
+    def test_what_the_caller_commits_arrives_together(self, tmp_path):
+        engine = store(tmp_path)
+        with Session(engine) as session:
+            repository_id = a_repository(session, "acme/ours").id
+            session.add(
+                ConnectedRepository(
+                    workspace_id=remember(session, "w42").id,
+                    repository_id=repository_id,
+                )
+            )
+            session.commit()
+
+        with Session(engine) as session:
+            assert repositories_of(session, "w42") == [repository_id]


### PR DESCRIPTION
Three things the review on #119 found, which went in before they were fixed.

Recording a workspace committed the caller's session. Connecting a repository is
one act: the workspace and the connection that justifies it settle together, or
a failure part way through leaves a workspace behind whose reason for existing
was never written. It flushes now, and still hands back the id to point at.

Reading a whole scope sorted every edge in the store before filtering to the one
asked for, so answering about one scope cost the size of the store.

Syncing a repository's details looked it up again, having been called from the
one place that had just fetched it.