### PR TITLE
build: Publish an image when a version is released

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,6 +3,8 @@ name: Build Image
 on:
   push:
     branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -34,6 +36,7 @@ jobs:
           tags: |
             type=sha
             type=ref,event=branch
+            type=ref,event=tag
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push


### PR DESCRIPTION
Releasing produced a tag, a release page and a changelog entry, and nothing
anything could pull. The image was only ever built on a push to main and stamped
with a commit, so a version existed by name everywhere except the one place a
deployment reads from, and pinning one meant naming a commit instead.

A release now stamps its own name onto the image, matching what the gateway
already does with its own. `latest` is left alone: it follows main, and a
prerelease sorts before the version it leads to.