### PR TITLE
feat: Let a repository be read in more than one part

### DIFF
--- a/src/core/settings/definitions.py
+++ b/src/core/settings/definitions.py
@@ -132,6 +132,22 @@ SETTINGS: tuple[Setting, ...] = (
         group="Knowledge initialization",
     ),
     Setting(
+        key="initialization.community_limit",
+        label="Maximum parts read separately",
+        description=(
+            "How many clusters of related code a large repository is read in. "
+            "Each is given the whole evidence budget and read on its own, so "
+            "raising this reads more of the repository and costs proportionally "
+            "more. One reads the repository as a single piece."
+        ),
+        type=ConfigType.INT,
+        default=10,
+        minimum=1,
+        maximum=100,
+        scopes=(REPOSITORY, ORGANIZATION),
+        group="Knowledge initialization",
+    ),
+    Setting(
         key="initialization.investigation_limit",
         label="Maximum follow-up investigations",
         description="Maximum graph identities investigated after initial retrieval.",


### PR DESCRIPTION
Adds a setting for how many clusters of related code a repository is read in during initialization, each cluster given its own evidence budget.

One budget spent across a whole repository reaches its busiest twenty symbols and nothing else, so a repository of a thousand files and one of a hundred thousand yield the same amount.

The default of 10 changes what a deployment does on the first read after it ships. Each part is read on its own, and a part that asks to look closer costs a second call, so ten parts is up to twenty model calls where there was one. Initialization runs once per repository. The setting resolves per repository and per organization, and 1 gives the single-piece reading.