### PR TITLE
feat(settings): Let a repository say what to leave out of its drawings

### DIFF
--- a/src/core/code_index/__init__.py
+++ b/src/core/code_index/__init__.py
@@ -15,6 +15,7 @@ from .models import (
     CodeSearchResult,
     CodeTraversal,
     CodeTraversalResult,
+    is_excluded_path,
     is_test_path,
 )
 from .resolving import ResolvingCodeIndexReader
@@ -23,6 +24,7 @@ from .scip import ScipImportLimits, ScipImportResult, ScipJsonImporter
 __all__ = [
     "MAX_GRAPH_NODES",
     "CodeEdge",
+    "is_excluded_path",
     "is_test_path",
     "CodeGraphQuery",
     "CodeGraphReader",

--- a/src/core/code_index/memory.py
+++ b/src/core/code_index/memory.py
@@ -9,6 +9,7 @@ from .models import (
     CodeGraphQuery,
     CodeGraphResult,
     CodeNode,
+    is_excluded_path,
     is_test_path,
     CodeSearch,
     CodeSearchResult,
@@ -166,5 +167,7 @@ def _drawable(node: CodeNode, query: CodeGraphQuery) -> bool:
     ):
         return False
     if not query.include_tests and (properties.get("is_test") or is_test_path(path)):
+        return False
+    if query.excluded_paths and is_excluded_path(path, query.excluded_paths):
         return False
     return True

--- a/src/core/code_index/models.py
+++ b/src/core/code_index/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 
 from src.core.scope import Scope
 
@@ -91,6 +91,7 @@ class CodeGraphQuery:
     edge_types: frozenset[str] = field(default_factory=frozenset)
     path_prefix: str = ""
     include_tests: bool = False
+    excluded_paths: frozenset[str] = field(default_factory=frozenset)
     node_limit: int = MAX_GRAPH_NODES
 
     def __post_init__(self) -> None:
@@ -107,6 +108,20 @@ class CodeGraphResult:
 
 TEST_DIRECTORIES = ("/tests/", "/test/", "/spec/", "__tests__")
 TEST_PREFIXES = ("tests/", "test/", "spec/")
+
+
+def is_excluded_path(path: object, excluded: Iterable[str]) -> bool:
+    """Whether a file sits under a path somebody asked to be left out.
+
+    Matching is by whole segment, so ".github" leaves that directory and
+    everything under it out without also taking ".github-actions-notes". Every
+    index has to answer this the same way, for the same reason is_test_path
+    lives here.
+    """
+    if not isinstance(path, str) or not path:
+        return False
+    segments = [segment for segment in path.replace("\\", "/").split("/") if segment]
+    return any(pattern and pattern in segments for pattern in excluded)
 
 
 def is_test_path(path: object) -> bool:

--- a/src/core/settings/definitions.py
+++ b/src/core/settings/definitions.py
@@ -135,7 +135,7 @@ SETTINGS: tuple[Setting, ...] = (
         key="initialization.community_limit",
         label="Maximum parts read separately",
         description=(
-            "How many clusters of related code a large repository is read in. "
+            "How many parts of related code a large repository is read in. "
             "Each is given the whole evidence budget and read on its own, so "
             "raising this reads more of the repository and costs proportionally "
             "more. One reads the repository as a single piece."

--- a/src/core/settings/definitions.py
+++ b/src/core/settings/definitions.py
@@ -148,6 +148,19 @@ SETTINGS: tuple[Setting, ...] = (
         group="Knowledge initialization",
     ),
     Setting(
+        key="initialization.excluded_paths",
+        label="Paths left out of the index",
+        description=(
+            "Path patterns the index does not report. A pattern matches a whole "
+            "path segment, so \".github\" also leaves everything under it out. "
+            "The index still holds them; what reads the index stops seeing them."
+        ),
+        type=ConfigType.JSON,
+        default=(".github", ".codebase-memory"),
+        scopes=(REPOSITORY, ORGANIZATION),
+        group="Knowledge initialization",
+    ),
+    Setting(
         key="initialization.investigation_limit",
         label="Maximum follow-up investigations",
         description="Maximum graph identities investigated after initial retrieval.",

--- a/src/core/settings/definitions.py
+++ b/src/core/settings/definitions.py
@@ -152,7 +152,7 @@ SETTINGS: tuple[Setting, ...] = (
         label="Paths left out of the index",
         description=(
             "Path patterns the index does not report. A pattern matches a whole "
-            "path segment, so \".github\" also leaves everything under it out. "
+            'path segment, so ".github" also leaves everything under it out. '
             "The index still holds them; what reads the index stops seeing them."
         ),
         type=ConfigType.JSON,

--- a/src/core/settings/definitions.py
+++ b/src/core/settings/definitions.py
@@ -124,7 +124,7 @@ SETTINGS: tuple[Setting, ...] = (
         label="Evidence character budget",
         description="Maximum evidence characters supplied in one initialization stage.",
         type=ConfigType.INT,
-        default=20_000,
+        default=60_000,
         unit="characters",
         minimum=1_000,
         maximum=100_000,
@@ -141,7 +141,7 @@ SETTINGS: tuple[Setting, ...] = (
             "more. One reads the repository as a single piece."
         ),
         type=ConfigType.INT,
-        default=10,
+        default=25,
         minimum=1,
         maximum=100,
         scopes=(REPOSITORY, ORGANIZATION),

--- a/src/tests/unit/test_core_initialization.py
+++ b/src/tests/unit/test_core_initialization.py
@@ -254,5 +254,5 @@ def test_initialization_limits_are_exposed_as_settings():
     assert candidate_limit.default == 20
     assert candidate_limit.scopes == ("repository", "organization")
     assert get("initialization.evidence_limit").maximum == 100
-    assert get("initialization.evidence_character_limit").default == 20_000
+    assert get("initialization.evidence_character_limit").default == 60_000
     assert get("initialization.investigation_limit").minimum == 0


### PR DESCRIPTION
Adds a setting naming the path segments a repository leaves out of what its index reports, defaulting to `.github` and `.codebase-memory`. Drawings of a repository were carrying its workflow files and the indexer's own artefact directory alongside its code.

Matching is by whole segment, so `.github` does not also take `.github-notes`. The rule sits beside the existing test-path rule, because every index has to answer it the same way or two of them draw two different repositories.

This is the first setting whose value is a list, and so the first to use the JSON type.

Two defaults move with it. A run read a repository in ten parts on twenty thousand characters each, which covered a fraction of a large codebase and gave each part about a third of the evidence a model of this size is usually given. It now reads twenty-five parts on sixty thousand characters. How many proposals and evidence items a stage considers stays at twenty, which is where retrieval practice puts it. Every repository that has not set its own values gets the larger run, so the cost of a run rises with this.

Also settles a third word. The setting for how many pieces a repository is read in described them as clusters, while its own label and every screen that draws them said parts. The reader now sees one word, and `community` stays where the data uses it.
