### PR TITLE
fix(settings): Stop reading settings when there is no database

### DIFF
--- a/src/core/settings/resolver.py
+++ b/src/core/settings/resolver.py
@@ -18,6 +18,7 @@ from src.core.settings.definitions import (
     for_scope,
     get,
 )
+from src.config.settings import STATELESS_MODE
 from src.models.config import Config
 from src.utils.logger import logger
 
@@ -30,6 +31,10 @@ def organization_of(repository: str) -> Optional[str]:
 
 def _stored(setting: Setting, scope: str, scope_id: str) -> Any:
     if scope not in setting.scopes:
+        return None
+    # Nothing is stored without a database, and attempting the read logs an
+    # error for a condition that is normal in a stateless deployment.
+    if STATELESS_MODE:
         return None
     try:
         raw = Config.get_value(scope, scope_id, setting.key)

--- a/src/tests/test_settings_resolver.py
+++ b/src/tests/test_settings_resolver.py
@@ -1,0 +1,33 @@
+from src.core.settings import resolver
+
+
+class TestStatelessSettings:
+    """A deployment with no database has nothing stored, so nothing is read."""
+
+    def test_a_setting_falls_back_without_reading_the_database(self, monkeypatch):
+        reads = []
+
+        def record(*args, **kwargs):
+            reads.append(args)
+            return None
+
+        monkeypatch.setattr(resolver, "STATELESS_MODE", True)
+        monkeypatch.setattr("src.models.config.Config.get_value", record)
+
+        answer = resolver.resolve("model.name", repository="sourceant/sourceant")
+
+        assert reads == []
+        assert answer.source == "default"
+        assert answer.value == ""
+
+    def test_a_stored_value_still_wins_when_there_is_a_database(self, monkeypatch):
+        monkeypatch.setattr(resolver, "STATELESS_MODE", False)
+        monkeypatch.setattr(
+            "src.models.config.Config.get_value",
+            lambda *args, **kwargs: "anthropic/claude-sonnet-4-5",
+        )
+
+        answer = resolver.resolve("model.name", repository="sourceant/sourceant")
+
+        assert answer.value == "anthropic/claude-sonnet-4-5"
+        assert answer.source == "repository"


### PR DESCRIPTION
A stateless deployment stores no settings, so resolving one attempted a read that could not succeed. Each attempt logged an error and a warning before falling back, and a setting carrying three scopes did it more than once, so an ordinary review filled the log with errors for a condition that is normal there.

The resolved value does not change. It was already the shipped default.