### PR TITLE
refactor(settings): Keep one name for the local scope

### DIFF
--- a/src/api/routes/knowledge.py
+++ b/src/api/routes/knowledge.py
@@ -19,7 +19,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from src.api.routes.code import find_repository, registered, require_local
-from src.api.routes.local_settings import WHOEVER_IS_HERE, model_for_this_machine
+from src.api.routes.local_settings import model_for_this_machine
+from src.core.environment import LOCAL
 from src.config.db import get_engine
 from src.core.knowledge.proposing import propose
 from src.core.knowledge.seeding import read
@@ -160,7 +161,7 @@ def accept_above() -> float:
     from src.core.settings.resolver import resolve
 
     try:
-        return float(resolve("knowledge.accept_above", user=WHOEVER_IS_HERE).value or 0)
+        return float(resolve("knowledge.accept_above", user=LOCAL).value or 0)
     except Exception:  # noqa: BLE001 - a store that cannot answer accepts nothing
         return 0.0
 

--- a/src/api/routes/local_settings.py
+++ b/src/api/routes/local_settings.py
@@ -2,7 +2,9 @@
 
 The settings API proper is scoped to a user, repository or organisation and
 answers to a signed token. There is no sign-in here, so these routes are the
-same store at the user scope with one fixed identity.
+same store at the user scope under one fixed identity. Nothing about the
+computer feeds into it, because a renamed machine would otherwise lose what was
+configured on it.
 
 Gated like the rest of the local surface. See ``code.py``.
 """
@@ -16,17 +18,13 @@ from pydantic import BaseModel
 
 from src.api.routes.code import require_local
 from src.api.routes.settings import _described
-from src.core.environment import environment
+from src.core.environment import LOCAL, environment
 from src.core.model import SettingsModelSource
 from src.core.responses import success_response
 from src.core.settings.definitions import USER
 from src.core.settings.resolver import clear_value, resolve_all, set_value
 
 router = APIRouter()
-
-# The scope has to be something, and anything derived from the computer would
-# move the settings when it is renamed.
-WHOEVER_IS_HERE = "local"
 
 
 def model_for_this_machine():
@@ -35,10 +33,10 @@ def model_for_this_machine():
     Unlike a hosted deployment there is no fallback: the bill is the user's,
     so an unchosen model stays unchosen.
     """
-    here = environment()
-    if here is not None:
-        return here.provider_for(here.workspace_for())
-    return SettingsModelSource(fallback_model="").provider_for(user=WHOEVER_IS_HERE)
+    deployment = environment()
+    if deployment is not None:
+        return deployment.provider_for(deployment.workspace_for())
+    return SettingsModelSource(fallback_model="").provider_for(user=LOCAL)
 
 
 @router.get("", dependencies=[Depends(require_local)])
@@ -49,7 +47,7 @@ def read_local_settings():
     ``settings.py``.
     """
     return success_response(
-        [_described(resolved) for resolved in resolve_all(user=WHOEVER_IS_HERE)]
+        [_described(resolved) for resolved in resolve_all(user=LOCAL)]
     )
 
 
@@ -61,9 +59,7 @@ class ValueInput(BaseModel):
 def write_local_setting(key: str, body: ValueInput):
     """Give one setting a value."""
     try:
-        return success_response(
-            _described(set_value(USER, WHOEVER_IS_HERE, key, body.value))
-        )
+        return success_response(_described(set_value(USER, LOCAL, key, body.value)))
     except KeyError as error:
         raise HTTPException(
             status_code=404, detail=f"No setting called {key}"
@@ -76,7 +72,7 @@ def write_local_setting(key: str, body: ValueInput):
 def reset_local_setting(key: str):
     """Put one setting back to its default."""
     try:
-        clear_value(USER, WHOEVER_IS_HERE, key)
+        clear_value(USER, LOCAL, key)
     except KeyError as error:
         raise HTTPException(
             status_code=404, detail=f"No setting called {key}"

--- a/src/api/routes/skills.py
+++ b/src/api/routes/skills.py
@@ -97,11 +97,11 @@ def where(scope: str, repository: str) -> Path:
 
 def elsewhere() -> tuple[str, ...]:
     """The folders somebody told this machine to look in as well."""
-    from src.api.routes.local_settings import WHOEVER_IS_HERE
+    from src.core.environment import LOCAL
     from src.core.settings.resolver import resolve
 
     try:
-        named = str(resolve("skills.paths", user=WHOEVER_IS_HERE).value or "")
+        named = str(resolve("skills.paths", user=LOCAL).value or "")
     except Exception:  # noqa: BLE001 - a store that cannot answer is no folders
         return ()
     return tuple(line.strip() for line in named.splitlines() if line.strip())

--- a/src/core/environment/__init__.py
+++ b/src/core/environment/__init__.py
@@ -22,8 +22,8 @@ def workspace_here(
     claims: Optional[dict] = None, services: ServiceRegistry = service_registry
 ) -> str:
     """The workspace this request acts in. LOCAL where no environment registered."""
-    here = environment(services)
-    return here.workspace_for(claims) if here is not None else LOCAL
+    deployment = environment(services)
+    return deployment.workspace_for(claims) if deployment is not None else LOCAL
 
 
 __all__ = [


### PR DESCRIPTION
Collapse the two constants naming the local scope into one. Settings written under one were invisible to code reading the other.