### PR TITLE
feat(core): Record a scope once and point at it by number

### DIFF
--- a/src/core/code_index/sql.py
+++ b/src/core/code_index/sql.py
@@ -7,6 +7,7 @@ from threading import RLock
 from typing import Any, Mapping
 
 from sqlalchemy import (
+    BigInteger,
     Column,
     Engine,
     Index,
@@ -20,6 +21,7 @@ from sqlalchemy import (
     select,
 )
 
+from src.core import scopes
 from src.core.scope import Scope
 from src.core.sql_support import chunked, rows_for
 
@@ -37,7 +39,6 @@ from .models import (
 )
 
 metadata = MetaData()
-scope_key_type = String(500)
 
 # How much of a repository the writer holds before committing what it has. A
 # whole one does not fit: fifty thousand files come to some hundreds of
@@ -47,33 +48,33 @@ CHECKPOINT = 20_000
 node_table = Table(
     "code_nodes",
     metadata,
-    Column("scope", scope_key_type, primary_key=True),
+    Column("scope_id", BigInteger, primary_key=True),
     Column("id", String(500), primary_key=True),
     Column("file_path", String(500), nullable=True),
     Column("properties", Text, nullable=False),
-    Index("ix_code_nodes_scope_file_path", "scope", "file_path"),
+    Index("ix_code_nodes_scope_file_path", "scope_id", "file_path"),
 )
 
 label_table = Table(
     "code_node_labels",
     metadata,
-    Column("scope", scope_key_type, primary_key=True),
+    Column("scope_id", BigInteger, primary_key=True),
     Column("node_id", String(500), primary_key=True),
     Column("label", String(255), primary_key=True),
-    Index("ix_code_node_labels_scope_label", "scope", "label"),
+    Index("ix_code_node_labels_scope_label", "scope_id", "label"),
 )
 
 edge_table = Table(
     "code_edges",
     metadata,
-    Column("scope", scope_key_type, primary_key=True),
+    Column("scope_id", BigInteger, primary_key=True),
     Column("id", String(500), primary_key=True),
     Column("source_id", String(500), nullable=False),
     Column("target_id", String(500), nullable=False),
     Column("type", String(255), nullable=False),
     Column("properties", Text, nullable=False),
-    Index("ix_code_edges_scope_source", "scope", "source_id"),
-    Index("ix_code_edges_scope_target", "scope", "target_id"),
+    Index("ix_code_edges_scope_source", "scope_id", "source_id"),
+    Index("ix_code_edges_scope_target", "scope_id", "target_id"),
 )
 
 
@@ -92,6 +93,7 @@ class SQLCodeIndexRepository:
         self._buffer: dict[str, list] | None = None
         self._checkpoint_every = CHECKPOINT
         if create_schema:
+            scopes.ensure(engine)
             metadata.create_all(engine)
 
     @contextmanager
@@ -147,21 +149,21 @@ class SQLCodeIndexRepository:
                 self._write_edges(connection, [(scope, edge)])
 
     def clear(self, scope: Scope) -> None:
-        key = _scope_key(scope)
+        key = scopes.known_id(self._engine, scope)
         with self._lock:
             with self._engine.begin() as connection:
                 for table in (node_table, label_table, edge_table):
-                    connection.execute(delete(table).where(table.c.scope == key))
+                    connection.execute(delete(table).where(table.c.scope_id == key))
 
     def remove_path(self, scope: Scope, file_path: str) -> None:
-        key = _scope_key(scope)
+        key = scopes.known_id(self._engine, scope)
         with self._lock:
             with self._engine.begin() as connection:
                 ids = [
                     row[0]
                     for row in connection.execute(
                         select(node_table.c.id).where(
-                            node_table.c.scope == key,
+                            node_table.c.scope_id == key,
                             node_table.c.file_path == file_path,
                         )
                     )
@@ -171,7 +173,7 @@ class SQLCodeIndexRepository:
                 for chunk in chunked(ids):
                     connection.execute(
                         delete(edge_table).where(
-                            edge_table.c.scope == key,
+                            edge_table.c.scope_id == key,
                             or_(
                                 edge_table.c.source_id.in_(chunk),
                                 edge_table.c.target_id.in_(chunk),
@@ -180,28 +182,28 @@ class SQLCodeIndexRepository:
                     )
                     connection.execute(
                         delete(label_table).where(
-                            label_table.c.scope == key,
+                            label_table.c.scope_id == key,
                             label_table.c.node_id.in_(chunk),
                         )
                     )
                     connection.execute(
                         delete(node_table).where(
-                            node_table.c.scope == key, node_table.c.id.in_(chunk)
+                            node_table.c.scope_id == key, node_table.c.id.in_(chunk)
                         )
                     )
 
     def file_digests(self, scope: Scope) -> dict[str, str]:
-        key = _scope_key(scope)
+        key = scopes.known_id(self._engine, scope)
         digests: dict[str, str] = {}
         with self._engine.connect() as connection:
             for row in connection.execute(
                 select(node_table.c.file_path, node_table.c.properties)
                 .join(
                     label_table,
-                    (label_table.c.scope == node_table.c.scope)
+                    (label_table.c.scope_id == node_table.c.scope_id)
                     & (label_table.c.node_id == node_table.c.id),
                 )
-                .where(node_table.c.scope == key, label_table.c.label == "File")
+                .where(node_table.c.scope_id == key, label_table.c.label == "File")
             ):
                 path, properties = row[0], json.loads(row[1])
                 digest = properties.get("digest")
@@ -210,8 +212,8 @@ class SQLCodeIndexRepository:
         return digests
 
     def search(self, query: CodeSearch) -> CodeSearchResult:
-        key = _scope_key(query.scope)
-        statement = select(node_table).where(node_table.c.scope == key)
+        key = scopes.known_id(self._engine, query.scope)
+        statement = select(node_table).where(node_table.c.scope_id == key)
         if query.node_ids:
             statement = statement.where(node_table.c.id.in_(sorted(query.node_ids)))
         path = query.properties.get("file_path")
@@ -275,7 +277,7 @@ class SQLCodeIndexRepository:
         )
 
     def traverse(self, traversal: CodeTraversal) -> CodeTraversalResult:
-        key = _scope_key(traversal.scope)
+        key = scopes.known_id(self._engine, traversal.scope)
         nodes: list[CodeNode] = []
         edges: dict[str, CodeEdge] = {}
         visited: set[str] = set()
@@ -329,8 +331,8 @@ class SQLCodeIndexRepository:
         )
 
     def graph(self, query: CodeGraphQuery) -> CodeGraphResult:
-        key = _scope_key(query.scope)
-        statement = select(node_table).where(node_table.c.scope == key)
+        key = scopes.known_id(self._engine, query.scope)
+        statement = select(node_table).where(node_table.c.scope_id == key)
         if query.path_prefix:
             statement = statement.where(
                 node_table.c.file_path.like(
@@ -375,23 +377,24 @@ class SQLCodeIndexRepository:
                 self._write_edges(connection, buffered["edges"])
 
     def _write_nodes(self, connection, entries) -> None:
-        by_key: dict[tuple[str, str], tuple[Scope, CodeNode]] = {}
+        numbered = _numbered(connection, (scope for scope, _ in entries))
+        by_key: dict[tuple[int, str], tuple[Scope, CodeNode]] = {}
         for scope, node in entries:
-            by_key[(_scope_key(scope), node.id)] = (scope, node)
-        by_scope: dict[str, list[str]] = {}
+            by_key[(numbered[scope], node.id)] = (scope, node)
+        by_scope: dict[int, list[str]] = {}
         for scope_key, node_id in by_key:
             by_scope.setdefault(scope_key, []).append(node_id)
         for scope_key, node_ids in by_scope.items():
             for chunk in chunked(node_ids):
                 connection.execute(
                     delete(node_table).where(
-                        node_table.c.scope == scope_key,
+                        node_table.c.scope_id == scope_key,
                         node_table.c.id.in_(chunk),
                     )
                 )
                 connection.execute(
                     delete(label_table).where(
-                        label_table.c.scope == scope_key,
+                        label_table.c.scope_id == scope_key,
                         label_table.c.node_id.in_(chunk),
                     )
                 )
@@ -401,7 +404,7 @@ class SQLCodeIndexRepository:
             path = node.properties.get("file_path")
             node_rows.append(
                 {
-                    "scope": scope_key,
+                    "scope_id": scope_key,
                     "id": node_id,
                     "file_path": path if isinstance(path, str) else None,
                     "properties": _encode(node.properties),
@@ -409,24 +412,25 @@ class SQLCodeIndexRepository:
             )
             for label in sorted(node.labels):
                 label_rows.append(
-                    {"scope": scope_key, "node_id": node_id, "label": label}
+                    {"scope_id": scope_key, "node_id": node_id, "label": label}
                 )
         connection.execute(node_table.insert(), node_rows)
         if label_rows:
             connection.execute(label_table.insert(), label_rows)
 
     def _write_edges(self, connection, entries) -> None:
-        by_key: dict[tuple[str, str], tuple[Scope, CodeEdge]] = {}
+        numbered = _numbered(connection, (scope for scope, _ in entries))
+        by_key: dict[tuple[int, str], tuple[Scope, CodeEdge]] = {}
         for scope, edge in entries:
-            by_key[(_scope_key(scope), edge.id)] = (scope, edge)
-        by_scope: dict[str, list[str]] = {}
+            by_key[(numbered[scope], edge.id)] = (scope, edge)
+        by_scope: dict[int, list[str]] = {}
         for scope_key, edge_id in by_key:
             by_scope.setdefault(scope_key, []).append(edge_id)
         for scope_key, edge_ids in by_scope.items():
             for chunk in chunked(edge_ids):
                 connection.execute(
                     delete(edge_table).where(
-                        edge_table.c.scope == scope_key,
+                        edge_table.c.scope_id == scope_key,
                         edge_table.c.id.in_(chunk),
                     )
                 )
@@ -434,7 +438,7 @@ class SQLCodeIndexRepository:
             edge_table.insert(),
             [
                 {
-                    "scope": scope_key,
+                    "scope_id": scope_key,
                     "id": edge_id,
                     "source_id": edge.source_id,
                     "target_id": edge.target_id,
@@ -446,15 +450,22 @@ class SQLCodeIndexRepository:
         )
 
     def _require_endpoints(self, connection, entries) -> None:
-        wanted: dict[str, set[str]] = {}
-        for scope, edge in entries:
-            wanted.setdefault(_scope_key(scope), set()).update(
+        held = list(entries)
+        buffered = list(self._buffer["nodes"]) if self._buffer is not None else []
+        numbered = _numbered(
+            connection,
+            (scope for scope, _ in held + buffered),
+        )
+        wanted: dict[int, set[str]] = {}
+        for scope, edge in held:
+            wanted.setdefault(numbered[scope], set()).update(
                 (edge.source_id, edge.target_id)
             )
         pending = {scope_key: set(ids) for scope_key, ids in wanted.items() if ids}
-        if self._buffer is not None:
-            for scope, node in self._buffer["nodes"]:
-                pending.get(_scope_key(scope), set()).discard(node.id)
+        for scope, node in buffered:
+            waiting = pending.get(numbered[scope])
+            if waiting is not None:
+                waiting.discard(node.id)
         for scope_key, ids in pending.items():
             if not ids:
                 continue
@@ -462,7 +473,7 @@ class SQLCodeIndexRepository:
                 row[0]
                 for row in connection.execute(
                     select(node_table.c.id).where(
-                        node_table.c.scope == scope_key,
+                        node_table.c.scope_id == scope_key,
                         node_table.c.id.in_(sorted(ids)),
                     )
                 )
@@ -475,14 +486,14 @@ class SQLCodeIndexRepository:
                 )
 
     def _labels_for(
-        self, connection, scope_key: str, node_ids
+        self, connection, scope_key: int, node_ids
     ) -> dict[str, frozenset[str]]:
         grouped: dict[str, set[str]] = {}
         for row in rows_for(
             node_ids,
             lambda chunk: connection.execute(
                 select(label_table.c.node_id, label_table.c.label).where(
-                    label_table.c.scope == scope_key,
+                    label_table.c.scope_id == scope_key,
                     label_table.c.node_id.in_(chunk),
                 )
             ),
@@ -497,7 +508,7 @@ class SQLCodeIndexRepository:
                 node_ids,
                 lambda chunk: connection.execute(
                     select(node_table).where(
-                        node_table.c.scope == scope_key,
+                        node_table.c.scope_id == scope_key,
                         node_table.c.id.in_(chunk),
                     )
                 ).mappings(),
@@ -509,7 +520,7 @@ class SQLCodeIndexRepository:
     ) -> list[CodeEdge]:
         if not node_ids:
             return []
-        statement = select(edge_table).where(edge_table.c.scope == scope_key)
+        statement = select(edge_table).where(edge_table.c.scope_id == scope_key)
         if traversal.direction == "outbound":
             statement = statement.where(edge_table.c.source_id.in_(node_ids))
         elif traversal.direction == "inbound":
@@ -536,7 +547,7 @@ class SQLCodeIndexRepository:
 
         def _for(chunk):
             statement = select(edge_table).where(
-                edge_table.c.scope == scope_key,
+                edge_table.c.scope_id == scope_key,
                 edge_table.c.source_id.in_(chunk),
             )
             if edge_types:
@@ -552,12 +563,21 @@ class SQLCodeIndexRepository:
         return tuple(found[key] for key in sorted(found))
 
 
-def _with_labels(statement, scope_key: str, labels, id_column):
+def _numbered(connection, asked) -> dict[Scope, int]:
+    """A number for each distinct scope, asked for once however many rows share it."""
+    found: dict[Scope, int] = {}
+    for scope in asked:
+        if scope not in found:
+            found[scope] = scopes.remembered(connection, scope)
+    return found
+
+
+def _with_labels(statement, scope_key: int, labels, id_column):
     for label in sorted(labels):
         statement = statement.where(
             select(label_table.c.label)
             .where(
-                label_table.c.scope == scope_key,
+                label_table.c.scope_id == scope_key,
                 label_table.c.node_id == id_column,
                 label_table.c.label == label,
             )
@@ -566,13 +586,13 @@ def _with_labels(statement, scope_key: str, labels, id_column):
     return statement
 
 
-def _with_any_label(statement, scope_key: str, labels, id_column):
+def _with_any_label(statement, scope_key: int, labels, id_column):
     if not labels:
         return statement
     return statement.where(
         select(label_table.c.label)
         .where(
-            label_table.c.scope == scope_key,
+            label_table.c.scope_id == scope_key,
             label_table.c.node_id == id_column,
             label_table.c.label.in_(sorted(labels)),
         )
@@ -609,10 +629,6 @@ def _edge_from_row(row: Mapping[str, Any]) -> CodeEdge:
         type=row["type"],
         properties=json.loads(row["properties"]),
     )
-
-
-def _scope_key(scope: Scope) -> str:
-    return json.dumps(scope.values, separators=(",", ":"))
 
 
 def _encode(value: Mapping[str, Any]) -> str:

--- a/src/core/impact/sql.py
+++ b/src/core/impact/sql.py
@@ -5,6 +5,7 @@ from threading import RLock
 from typing import Any, Mapping
 
 from sqlalchemy import (
+    BigInteger,
     Boolean,
     Column,
     Engine,
@@ -18,6 +19,7 @@ from sqlalchemy import (
     select,
 )
 
+from src.core import scopes
 from src.core.scope import Scope
 from src.core.sql_support import rows_for
 from src.core.topology import TopologyEvidence
@@ -29,23 +31,26 @@ from .models import (
 )
 
 metadata = MetaData()
-scope_key_type = String(500)
 
+# Five columns in one key, so these are narrower than elsewhere. MySQL allows
+# 3072 bytes and reserves four per character; a kind is a word, a revision a hash.
 mapping_table = Table(
     "impact_code_mappings",
     metadata,
-    Column("scope", scope_key_type, primary_key=True),
-    Column("change_kind", String(255), primary_key=True),
-    Column("change_id", String(500), primary_key=True),
-    Column("revision", String(255), primary_key=True),
+    Column("scope_id", BigInteger, primary_key=True),
+    Column("change_kind", String(64), primary_key=True),
+    Column("change_id", String(383), primary_key=True),
+    Column("revision", String(64), primary_key=True),
     Column("entity_id", String(255), primary_key=True),
-    Index("ix_impact_code_mappings_scope_change", "scope", "change_kind", "change_id"),
+    Index(
+        "ix_impact_code_mappings_scope_change", "scope_id", "change_kind", "change_id"
+    ),
 )
 
 check_table = Table(
     "compatibility_checks",
     metadata,
-    Column("scope", scope_key_type, primary_key=True),
+    Column("scope_id", BigInteger, primary_key=True),
     Column("id", String(255), primary_key=True),
     Column("provider_entity_id", String(255), nullable=False),
     Column("consumer_entity_id", String(255), nullable=False),
@@ -58,8 +63,8 @@ check_table = Table(
     Column("stale", Boolean, nullable=False),
     Column("evidence", Text, nullable=False),
     Column("properties", Text, nullable=False),
-    Index("ix_compatibility_checks_scope_provider", "scope", "provider_entity_id"),
-    Index("ix_compatibility_checks_scope_consumer", "scope", "consumer_entity_id"),
+    Index("ix_compatibility_checks_scope_provider", "scope_id", "provider_entity_id"),
+    Index("ix_compatibility_checks_scope_consumer", "scope_id", "consumer_entity_id"),
 )
 
 
@@ -68,6 +73,7 @@ class SQLImpactSeedRepository:
         self._engine = engine
         self._lock = RLock()
         if create_schema:
+            scopes.ensure(engine)
             metadata.create_all(engine)
 
     def put_mapping(
@@ -78,12 +84,12 @@ class SQLImpactSeedRepository:
     ) -> None:
         if not entity_ids or any(not item for item in entity_ids):
             raise ValueError("topology identities are required")
-        key = _scope_key(scope)
         with self._lock:
             with self._engine.begin() as connection:
+                key = scopes.remembered(connection, scope)
                 connection.execute(
                     delete(mapping_table).where(
-                        mapping_table.c.scope == key,
+                        mapping_table.c.scope_id == key,
                         mapping_table.c.change_kind == change.kind,
                         mapping_table.c.change_id == change.id,
                         mapping_table.c.revision == change.revision,
@@ -93,7 +99,7 @@ class SQLImpactSeedRepository:
                     mapping_table.insert(),
                     [
                         {
-                            "scope": key,
+                            "scope_id": key,
                             "change_kind": change.kind,
                             "change_id": change.id,
                             "revision": change.revision,
@@ -108,7 +114,7 @@ class SQLImpactSeedRepository:
     ) -> tuple[str, ...]:
         if not changes:
             return ()
-        key = _scope_key(scope)
+        key = scopes.known_id(self._engine, scope)
         # Grouped by kind and revision, which a single change set almost always
         # shares, so this asks once rather than once per changed file.
         grouped: dict[tuple[str, str], set[str]] = {}
@@ -122,7 +128,7 @@ class SQLImpactSeedRepository:
                     identities,
                     lambda chunk, kind=kind, revision=revision: connection.execute(
                         select(mapping_table.c.entity_id).where(
-                            mapping_table.c.scope == key,
+                            mapping_table.c.scope_id == key,
                             mapping_table.c.change_kind == kind,
                             mapping_table.c.revision == revision,
                             mapping_table.c.change_id.in_(chunk),
@@ -138,21 +144,22 @@ class SQLCompatibilityCheckRepository:
         self._engine = engine
         self._lock = RLock()
         if create_schema:
+            scopes.ensure(engine)
             metadata.create_all(engine)
 
     def put_evidence(self, scope: Scope, evidence: CompatibilityCheck) -> None:
-        key = _scope_key(scope)
         with self._lock:
             with self._engine.begin() as connection:
+                key = scopes.remembered(connection, scope)
                 connection.execute(
                     delete(check_table).where(
-                        check_table.c.scope == key,
+                        check_table.c.scope_id == key,
                         check_table.c.id == evidence.id,
                     )
                 )
                 connection.execute(
                     check_table.insert().values(
-                        scope=key,
+                        scope_id=key,
                         id=evidence.id,
                         provider_entity_id=evidence.provider_entity_id,
                         consumer_entity_id=evidence.consumer_entity_id,
@@ -169,10 +176,10 @@ class SQLCompatibilityCheckRepository:
                 )
 
     def read(self, query: CompatibilityCheckQuery) -> tuple[CompatibilityCheck, ...]:
-        key = _scope_key(query.scope)
+        key = scopes.known_id(self._engine, query.scope)
         wanted = sorted(query.entity_ids)
         statement = select(check_table).where(
-            check_table.c.scope == key,
+            check_table.c.scope_id == key,
             check_table.c.provider_entity_id.in_(wanted),
             check_table.c.consumer_entity_id.in_(wanted),
             check_table.c.confidence >= query.minimum_confidence,
@@ -232,10 +239,6 @@ def _encode_evidence(items: tuple[TopologyEvidence, ...]) -> str:
         sort_keys=True,
         separators=(",", ":"),
     )
-
-
-def _scope_key(scope: Scope) -> str:
-    return json.dumps(scope.values, separators=(",", ":"))
 
 
 def _encode(value: Mapping[str, Any]) -> str:

--- a/src/core/knowledge/sql.py
+++ b/src/core/knowledge/sql.py
@@ -6,6 +6,7 @@ from threading import RLock
 from typing import Any
 
 from sqlalchemy import (
+    BigInteger,
     Column,
     Engine,
     MetaData,
@@ -16,6 +17,7 @@ from sqlalchemy import (
     select,
 )
 
+from src.core import scopes
 from src.core.scope import Scope
 from src.core.sql_support import rows_for
 
@@ -31,11 +33,10 @@ from .models import (
 )
 
 metadata = MetaData()
-scope_type = Text().with_variant(String(500), "mysql")
 knowledge_table = Table(
     "knowledge_objects",
     metadata,
-    Column("scope", scope_type, primary_key=True),
+    Column("scope_id", BigInteger, primary_key=True),
     Column("id", String(255), primary_key=True),
     Column("kind", String(255), nullable=False),
     Column("status", String(255), nullable=False),
@@ -45,18 +46,18 @@ knowledge_table = Table(
 link_table = Table(
     "knowledge_links",
     metadata,
-    Column("scope", scope_type, primary_key=True),
+    Column("scope_id", BigInteger, primary_key=True),
     Column("id", String(255), primary_key=True),
     Column("knowledge_id", String(255), nullable=False),
     Column("target_kind", String(64), nullable=False),
-    Column("target_id", String(500), nullable=False),
+    Column("target_id", String(255), nullable=False),
     Column("properties", Text, nullable=False),
 )
 
 relationship_table = Table(
     "knowledge_relationships",
     metadata,
-    Column("scope", scope_type, primary_key=True),
+    Column("scope_id", BigInteger, primary_key=True),
     Column("id", String(255), primary_key=True),
     Column("source_id", String(255), nullable=False),
     Column("target_id", String(255), nullable=False),
@@ -72,12 +73,12 @@ class SQLKnowledgeRepository:
         self._lock = RLock()
         self._memory = InMemoryKnowledgeRepository()
         if create_schema:
+            scopes.ensure(engine)
             metadata.create_all(engine)
         self._refresh()
 
     def put(self, scope: Scope, knowledge: KnowledgeObject) -> None:
         values = {
-            "scope": self._scope_key(scope),
             "id": knowledge.id,
             "kind": knowledge.kind,
             "status": knowledge.status,
@@ -86,9 +87,10 @@ class SQLKnowledgeRepository:
         }
         with self._lock:
             with self._engine.begin() as connection:
+                values["scope_id"] = scopes.remembered(connection, scope)
                 connection.execute(
                     delete(knowledge_table).where(
-                        knowledge_table.c.scope == values["scope"],
+                        knowledge_table.c.scope_id == values["scope_id"],
                         knowledge_table.c.id == knowledge.id,
                     )
                 )
@@ -99,7 +101,6 @@ class SQLKnowledgeRepository:
         self, scope: Scope, relationship: KnowledgeRelationship
     ) -> None:
         values = {
-            "scope": self._scope_key(scope),
             "id": relationship.id,
             "source_id": relationship.source_id,
             "target_id": relationship.target_id,
@@ -111,9 +112,10 @@ class SQLKnowledgeRepository:
             self._refresh()
             self._memory.put_relationship(scope, relationship)
             with self._engine.begin() as connection:
+                values["scope_id"] = scopes.remembered(connection, scope)
                 connection.execute(
                     delete(relationship_table).where(
-                        relationship_table.c.scope == values["scope"],
+                        relationship_table.c.scope_id == values["scope_id"],
                         relationship_table.c.id == relationship.id,
                     )
                 )
@@ -121,37 +123,37 @@ class SQLKnowledgeRepository:
             self._refresh()
 
     def remove(self, scope: Scope, knowledge_id: str) -> None:
-        key = self._scope_key(scope)
+        key = scopes.known_id(self._engine, scope)
         with self._lock:
             with self._engine.begin() as connection:
                 connection.execute(
                     delete(link_table).where(
-                        link_table.c.scope == key,
+                        link_table.c.scope_id == key,
                         link_table.c.knowledge_id == knowledge_id,
                     )
                 )
                 connection.execute(
                     delete(relationship_table).where(
-                        relationship_table.c.scope == key,
+                        relationship_table.c.scope_id == key,
                         (relationship_table.c.source_id == knowledge_id)
                         | (relationship_table.c.target_id == knowledge_id),
                     )
                 )
                 connection.execute(
                     delete(knowledge_table).where(
-                        knowledge_table.c.scope == key,
+                        knowledge_table.c.scope_id == key,
                         knowledge_table.c.id == knowledge_id,
                     )
                 )
             self._refresh()
 
     def put_link(self, scope: Scope, link: KnowledgeLink) -> None:
-        key = self._scope_key(scope)
         with self._lock:
             with self._engine.begin() as connection:
+                key = scopes.remembered(connection, scope)
                 known = connection.execute(
                     select(knowledge_table.c.id).where(
-                        knowledge_table.c.scope == key,
+                        knowledge_table.c.scope_id == key,
                         knowledge_table.c.id == link.knowledge_id,
                     )
                 ).first()
@@ -161,12 +163,12 @@ class SQLKnowledgeRepository:
                     )
                 connection.execute(
                     delete(link_table).where(
-                        link_table.c.scope == key, link_table.c.id == link.id
+                        link_table.c.scope_id == key, link_table.c.id == link.id
                     )
                 )
                 connection.execute(
                     link_table.insert().values(
-                        scope=key,
+                        scope_id=key,
                         id=link.id,
                         knowledge_id=link.knowledge_id,
                         target_kind=link.target_kind,
@@ -178,13 +180,13 @@ class SQLKnowledgeRepository:
     def get_links(
         self, scope: Scope, knowledge_ids: frozenset[str]
     ) -> tuple[KnowledgeLink, ...]:
-        key = self._scope_key(scope)
+        key = scopes.known_id(self._engine, scope)
         with self._engine.connect() as connection:
             if not knowledge_ids:
                 rows = list(
                     connection.execute(
                         select(link_table)
-                        .where(link_table.c.scope == key)
+                        .where(link_table.c.scope_id == key)
                         .order_by(link_table.c.id)
                     ).mappings()
                 )
@@ -193,7 +195,7 @@ class SQLKnowledgeRepository:
                     knowledge_ids,
                     lambda chunk: connection.execute(
                         select(link_table).where(
-                            link_table.c.scope == key,
+                            link_table.c.scope_id == key,
                             link_table.c.knowledge_id.in_(chunk),
                         )
                     ).mappings(),
@@ -215,7 +217,7 @@ class SQLKnowledgeRepository:
     ) -> frozenset[str]:
         if not paths:
             return frozenset()
-        key = self._scope_key(scope)
+        key = scopes.known_id(self._engine, scope)
         with self._engine.connect() as connection:
             return frozenset(
                 row[0]
@@ -223,7 +225,7 @@ class SQLKnowledgeRepository:
                     paths,
                     lambda chunk: connection.execute(
                         select(link_table.c.knowledge_id).where(
-                            link_table.c.scope == key,
+                            link_table.c.scope_id == key,
                             link_table.c.target_id.in_(chunk),
                         )
                     ),
@@ -253,9 +255,11 @@ class SQLKnowledgeRepository:
     def _refresh(self) -> None:
         memory = InMemoryKnowledgeRepository()
         with self._engine.connect() as connection:
-            for row in connection.execute(select(knowledge_table)).mappings():
+            for row in connection.execute(
+                scopes.with_scope(knowledge_table)
+            ).mappings():
                 memory.put(
-                    self._decode_scope(row["scope"]),
+                    scopes.read(row["qualifiers"]),
                     KnowledgeObject(
                         row["id"],
                         row["kind"],
@@ -264,9 +268,11 @@ class SQLKnowledgeRepository:
                         json.loads(row["properties"]),
                     ),
                 )
-            for row in connection.execute(select(relationship_table)).mappings():
+            for row in connection.execute(
+                scopes.with_scope(relationship_table)
+            ).mappings():
                 memory.put_relationship(
-                    self._decode_scope(row["scope"]),
+                    scopes.read(row["qualifiers"]),
                     KnowledgeRelationship(
                         row["id"],
                         row["source_id"],
@@ -277,14 +283,6 @@ class SQLKnowledgeRepository:
                     ),
                 )
         self._memory = memory
-
-    @staticmethod
-    def _scope_key(scope: Scope) -> str:
-        return json.dumps(scope.values, separators=(",", ":"))
-
-    @staticmethod
-    def _decode_scope(value: str) -> Scope:
-        return Scope(tuple(tuple(item) for item in json.loads(value)))
 
     @staticmethod
     def _encode(value: Mapping[str, Any]) -> str:

--- a/src/core/requirements/sql.py
+++ b/src/core/requirements/sql.py
@@ -5,6 +5,7 @@ from threading import RLock
 from typing import Any, Mapping
 
 from sqlalchemy import (
+    BigInteger,
     Column,
     Engine,
     Index,
@@ -17,6 +18,7 @@ from sqlalchemy import (
     select,
 )
 
+from src.core import scopes
 from src.core.scope import Scope
 from src.core.sql_support import rows_for
 
@@ -33,32 +35,31 @@ from .models import (
 )
 
 metadata = MetaData()
-scope_key_type = String(500)
 
 requirement_table = Table(
     "requirements",
     metadata,
-    Column("scope", scope_key_type, primary_key=True),
+    Column("scope_id", BigInteger, primary_key=True),
     Column("id", String(255), primary_key=True),
     Column("kind", String(255), nullable=False),
     Column("status", String(255), nullable=False),
     Column("summary", Text, nullable=False),
-    Column("external_ref", String(500), nullable=False),
+    Column("external_ref", String(255), nullable=False),
     Column("properties", Text, nullable=False),
-    Index("ix_requirements_scope_external_ref", "scope", "external_ref"),
+    Index("ix_requirements_scope_external_ref", "scope_id", "external_ref"),
 )
 
 link_table = Table(
     "requirement_links",
     metadata,
-    Column("scope", scope_key_type, primary_key=True),
+    Column("scope_id", BigInteger, primary_key=True),
     Column("id", String(255), primary_key=True),
     Column("requirement_id", String(255), nullable=False),
     Column("target_kind", String(64), nullable=False),
-    Column("target_id", String(500), nullable=False),
+    Column("target_id", String(255), nullable=False),
     Column("properties", Text, nullable=False),
-    Index("ix_requirement_links_scope_requirement", "scope", "requirement_id"),
-    Index("ix_requirement_links_scope_target", "scope", "target_id"),
+    Index("ix_requirement_links_scope_requirement", "scope_id", "requirement_id"),
+    Index("ix_requirement_links_scope_target", "scope_id", "target_id"),
 )
 
 
@@ -67,21 +68,22 @@ class SQLRequirementsRepository:
         self._engine = engine
         self._lock = RLock()
         if create_schema:
+            scopes.ensure(engine)
             metadata.create_all(engine)
 
     def put(self, scope: Scope, requirement: Requirement) -> None:
-        key = _scope_key(scope)
         with self._lock:
             with self._engine.begin() as connection:
+                key = scopes.remembered(connection, scope)
                 connection.execute(
                     delete(requirement_table).where(
-                        requirement_table.c.scope == key,
+                        requirement_table.c.scope_id == key,
                         requirement_table.c.id == requirement.id,
                     )
                 )
                 connection.execute(
                     requirement_table.insert().values(
-                        scope=key,
+                        scope_id=key,
                         id=requirement.id,
                         kind=requirement.kind,
                         status=requirement.status,
@@ -92,12 +94,12 @@ class SQLRequirementsRepository:
                 )
 
     def put_link(self, scope: Scope, link: RequirementLink) -> None:
-        key = _scope_key(scope)
         with self._lock:
             with self._engine.begin() as connection:
+                key = scopes.remembered(connection, scope)
                 known = connection.execute(
                     select(requirement_table.c.id).where(
-                        requirement_table.c.scope == key,
+                        requirement_table.c.scope_id == key,
                         requirement_table.c.id == link.requirement_id,
                     )
                 ).first()
@@ -105,12 +107,12 @@ class SQLRequirementsRepository:
                     raise ValueError("a link needs a requirement in the same scope")
                 connection.execute(
                     delete(link_table).where(
-                        link_table.c.scope == key, link_table.c.id == link.id
+                        link_table.c.scope_id == key, link_table.c.id == link.id
                     )
                 )
                 connection.execute(
                     link_table.insert().values(
-                        scope=key,
+                        scope_id=key,
                         id=link.id,
                         requirement_id=link.requirement_id,
                         target_kind=link.target_kind,
@@ -120,25 +122,25 @@ class SQLRequirementsRepository:
                 )
 
     def remove(self, scope: Scope, requirement_id: str) -> None:
-        key = _scope_key(scope)
+        key = scopes.known_id(self._engine, scope)
         with self._lock:
             with self._engine.begin() as connection:
                 connection.execute(
                     delete(link_table).where(
-                        link_table.c.scope == key,
+                        link_table.c.scope_id == key,
                         link_table.c.requirement_id == requirement_id,
                     )
                 )
                 connection.execute(
                     delete(requirement_table).where(
-                        requirement_table.c.scope == key,
+                        requirement_table.c.scope_id == key,
                         requirement_table.c.id == requirement_id,
                     )
                 )
 
     def search(self, query: RequirementQuery) -> RequirementResult:
-        key = _scope_key(query.scope)
-        statement = select(requirement_table).where(requirement_table.c.scope == key)
+        key = scopes.known_id(self._engine, query.scope)
+        statement = select(requirement_table).where(requirement_table.c.scope_id == key)
         if query.ids:
             statement = statement.where(
                 requirement_table.c.id.in_(sorted(query.ids)),
@@ -176,13 +178,13 @@ class SQLRequirementsRepository:
     def get_links(
         self, scope: Scope, requirement_ids: frozenset[str]
     ) -> tuple[RequirementLink, ...]:
-        key = _scope_key(scope)
+        key = scopes.known_id(self._engine, scope)
         with self._engine.connect() as connection:
             if not requirement_ids:
                 rows = list(
                     connection.execute(
                         select(link_table)
-                        .where(link_table.c.scope == key)
+                        .where(link_table.c.scope_id == key)
                         .order_by(link_table.c.id)
                     ).mappings()
                 )
@@ -191,7 +193,7 @@ class SQLRequirementsRepository:
                     requirement_ids,
                     lambda chunk: connection.execute(
                         select(link_table).where(
-                            link_table.c.scope == key,
+                            link_table.c.scope_id == key,
                             link_table.c.requirement_id.in_(chunk),
                         )
                     ).mappings(),
@@ -200,7 +202,7 @@ class SQLRequirementsRepository:
         return tuple(found[key] for key in sorted(found))
 
     def coverage(self, query: CoverageQuery) -> CoverageReport:
-        key = _scope_key(query.scope)
+        key = scopes.known_id(self._engine, query.scope)
         requirement_ids = set(query.requirement_ids)
         if query.paths:
             with self._engine.connect() as connection:
@@ -208,7 +210,7 @@ class SQLRequirementsRepository:
                     query.paths,
                     lambda chunk: connection.execute(
                         select(link_table.c.requirement_id).where(
-                            link_table.c.scope == key,
+                            link_table.c.scope_id == key,
                             link_table.c.target_id.in_(chunk),
                         )
                     ),
@@ -223,7 +225,7 @@ class SQLRequirementsRepository:
                     requirement_ids,
                     lambda chunk: connection.execute(
                         select(requirement_table).where(
-                            requirement_table.c.scope == key,
+                            requirement_table.c.scope_id == key,
                             requirement_table.c.id.in_(chunk),
                         )
                     ).mappings(),
@@ -286,10 +288,6 @@ def _link_from_row(row: Mapping[str, Any]) -> RequirementLink:
         target_id=row["target_id"],
         properties=json.loads(row["properties"]),
     )
-
-
-def _scope_key(scope: Scope) -> str:
-    return json.dumps(scope.values, separators=(",", ":"))
 
 
 def _encode(value: Mapping[str, Any]) -> str:

--- a/src/core/review/findings_sql.py
+++ b/src/core/review/findings_sql.py
@@ -10,6 +10,7 @@ import json
 from datetime import datetime, timezone
 
 from sqlalchemy import (
+    BigInteger,
     Column,
     DateTime,
     Engine,
@@ -22,6 +23,7 @@ from sqlalchemy import (
     select,
 )
 
+from src.core import scopes
 from src.core.scope import Scope
 
 from .findings import FindingQuery, FindingResult, ReviewFinding
@@ -31,7 +33,7 @@ metadata = MetaData()
 findings_table = Table(
     "review_findings",
     metadata,
-    Column("scope", Text, primary_key=True),
+    Column("scope_id", BigInteger, primary_key=True),
     Column("id", String(128), primary_key=True),
     Column("state", String(32), nullable=False, index=True),
     Column("summary", Text, nullable=False, default=""),
@@ -44,11 +46,6 @@ findings_table = Table(
 )
 
 
-def _written(scope: Scope) -> str:
-    """A scope as one string, since it is matched whole and never queried into."""
-    return json.dumps(sorted(scope.values))
-
-
 def _now() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -59,18 +56,19 @@ class SQLFindingStore:
     def __init__(self, engine: Engine, *, create_schema: bool = False) -> None:
         self._engine = engine
         if create_schema:
+            scopes.ensure(engine)
             metadata.create_all(engine)
 
     def put_finding(self, scope: Scope, finding: ReviewFinding) -> None:
         """File one. A state already set survives, however often it is raised."""
-        written = _written(scope)
         now = _now()
         with self._engine.begin() as connection:
+            written = scopes.remembered(connection, scope)
             existing = (
                 connection.execute(
                     select(findings_table).where(
                         and_(
-                            findings_table.c.scope == written,
+                            findings_table.c.scope_id == written,
                             findings_table.c.id == finding.id,
                         )
                     )
@@ -84,7 +82,7 @@ class SQLFindingStore:
                     findings_table.update()
                     .where(
                         and_(
-                            findings_table.c.scope == written,
+                            findings_table.c.scope_id == written,
                             findings_table.c.id == finding.id,
                         )
                     )
@@ -100,7 +98,7 @@ class SQLFindingStore:
 
             connection.execute(
                 findings_table.insert().values(
-                    scope=written,
+                    scope_id=written,
                     id=finding.id,
                     state=finding.state,
                     summary=finding.summary,
@@ -115,12 +113,13 @@ class SQLFindingStore:
         """Set a state. The only thing that does; filing never changes one."""
         if not state:
             raise ValueError("a finding needs a state")
+        known = scopes.known_id(self._engine, scope)
         with self._engine.begin() as connection:
             done = connection.execute(
                 findings_table.update()
                 .where(
                     and_(
-                        findings_table.c.scope == _written(scope),
+                        findings_table.c.scope_id == known,
                         findings_table.c.id == identifier,
                     )
                 )
@@ -129,12 +128,13 @@ class SQLFindingStore:
         return done.rowcount > 0
 
     def get_finding(self, scope: Scope, identifier: str) -> ReviewFinding | None:
+        known = scopes.known_id(self._engine, scope)
         with self._engine.begin() as connection:
             row = (
                 connection.execute(
                     select(findings_table).where(
                         and_(
-                            findings_table.c.scope == _written(scope),
+                            findings_table.c.scope_id == known,
                             findings_table.c.id == identifier,
                         )
                     )
@@ -145,7 +145,8 @@ class SQLFindingStore:
         return _read(row) if row else None
 
     def search(self, query: FindingQuery) -> FindingResult:
-        where = [findings_table.c.scope == _written(query.scope)]
+        known = scopes.known_id(self._engine, query.scope)
+        where = [findings_table.c.scope_id == known]
         if query.states:
             where.append(findings_table.c.state.in_(sorted(query.states)))
 

--- a/src/core/scopes.py
+++ b/src/core/scopes.py
@@ -1,0 +1,114 @@
+"""A scope, recorded once, so that what it qualifies points at it by number.
+
+A scope says what something is about, and it grows: a repository, and a
+revision as well once a review is reading one. Written into every row it
+qualified, it made keys wide enough that MySQL would not build them, and wider
+again whenever a scope gained a qualifier. Recorded here it is one row and one
+number, and a key carrying it is eight bytes whatever the scope says.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    Connection,
+    Engine,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    select,
+)
+from sqlalchemy.dialects import mysql
+from sqlalchemy.exc import IntegrityError
+
+from src.core.scope import Scope
+
+metadata = MetaData()
+
+#: Compared byte for byte. MySQL's default collation ignores case, which would
+#: make one scope out of two repositories whose names differ only by it, and the
+#: unique column below would hand the second one the first one's number.
+QUALIFIERS = String(500).with_variant(
+    mysql.VARCHAR(500, collation="utf8mb4_bin"), "mysql"
+)
+
+#: The only place a scope is written out in full. It sits alone in its key, so
+#: its width is nobody else's problem.
+scope_table = Table(
+    "scopes",
+    metadata,
+    # SQLite only counts up a column declared INTEGER, so the wider type is
+    # asked for everywhere else and given up there.
+    Column(
+        "id",
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    ),
+    Column("qualifiers", QUALIFIERS, nullable=False, unique=True),
+)
+
+
+def written(scope: Scope) -> str:
+    """A scope as one string, the form it is stored and matched by."""
+    return json.dumps(scope.values, separators=(",", ":"))
+
+
+def read(value: str) -> Scope:
+    """The scope a stored string stands for."""
+    return Scope(tuple(tuple(item) for item in json.loads(value)))
+
+
+def known(connection: Connection, scope: Scope) -> Optional[int]:
+    """The number this scope goes by, or None if it has never been seen."""
+    return connection.execute(
+        select(scope_table.c.id).where(scope_table.c.qualifiers == written(scope))
+    ).scalar()
+
+
+def remembered(connection: Connection, scope: Scope) -> int:
+    """The number this scope goes by, recording it the first time it is seen."""
+    value = written(scope)
+    found = connection.execute(
+        select(scope_table.c.id).where(scope_table.c.qualifiers == value)
+    ).scalar()
+    if found is not None:
+        return found
+    try:
+        with connection.begin_nested():
+            connection.execute(scope_table.insert().values(qualifiers=value))
+    except IntegrityError:
+        # Two writers reaching a scope for the first time at once. The column
+        # decides which of them wrote it, and both want the same answer. It
+        # compares byte for byte, so this is the only way to get here.
+        pass
+    return connection.execute(
+        select(scope_table.c.id).where(scope_table.c.qualifiers == value)
+    ).scalar()
+
+
+def known_id(engine: Engine, scope: Scope) -> Optional[int]:
+    """The scope's number, or None when nothing has ever been in it.
+
+    Reads ask after a scope rather than record one, so querying a repository
+    nobody has written about leaves nothing behind.
+    """
+    with engine.connect() as connection:
+        return known(connection, scope)
+
+
+def with_scope(table: Table):
+    """Rows with the scope they belong to spelled out again."""
+    return select(table, scope_table.c.qualifiers).join(
+        scope_table, table.c.scope_id == scope_table.c.id
+    )
+
+
+def ensure(engine: Engine) -> None:
+    """Create the table, for stores that build their own schema."""
+    metadata.create_all(engine)

--- a/src/core/topology/sql.py
+++ b/src/core/topology/sql.py
@@ -6,6 +6,7 @@ from threading import RLock
 from typing import Any
 
 from sqlalchemy import (
+    BigInteger,
     Boolean,
     Column,
     Engine,
@@ -18,6 +19,7 @@ from sqlalchemy import (
     select,
 )
 
+from src.core import scopes
 from src.core.scope import Scope
 
 from .memory import InMemoryTopologyRepository
@@ -32,11 +34,10 @@ from .models import (
 )
 
 metadata = MetaData()
-scope_type = Text().with_variant(String(500), "mysql")
 entity_table = Table(
     "topology_entities",
     metadata,
-    Column("scope", scope_type, primary_key=True),
+    Column("scope_id", BigInteger, primary_key=True),
     Column("id", String(255), primary_key=True),
     Column("kind", String(255), nullable=False),
     Column("status", String(255), nullable=False),
@@ -48,7 +49,7 @@ entity_table = Table(
 relationship_table = Table(
     "topology_relationships",
     metadata,
-    Column("scope", scope_type, primary_key=True),
+    Column("scope_id", BigInteger, primary_key=True),
     Column("id", String(255), primary_key=True),
     Column("source_id", String(255), nullable=False),
     Column("target_id", String(255), nullable=False),
@@ -67,12 +68,12 @@ class SQLTopologyRepository:
         self._lock = RLock()
         self._memory = InMemoryTopologyRepository()
         if create_schema:
+            scopes.ensure(engine)
             metadata.create_all(engine)
         self._refresh()
 
     def put_entity(self, scope: Scope, entity: TopologyEntity) -> None:
         values = {
-            "scope": self._scope_key(scope),
             "id": entity.id,
             "kind": entity.kind,
             "status": entity.status,
@@ -83,9 +84,10 @@ class SQLTopologyRepository:
         }
         with self._lock:
             with self._engine.begin() as connection:
+                values["scope_id"] = scopes.remembered(connection, scope)
                 connection.execute(
                     delete(entity_table).where(
-                        entity_table.c.scope == values["scope"],
+                        entity_table.c.scope_id == values["scope_id"],
                         entity_table.c.id == entity.id,
                     )
                 )
@@ -96,7 +98,6 @@ class SQLTopologyRepository:
         self, scope: Scope, relationship: TopologyRelationship
     ) -> None:
         values = {
-            "scope": self._scope_key(scope),
             "id": relationship.id,
             "source_id": relationship.source_id,
             "target_id": relationship.target_id,
@@ -111,9 +112,10 @@ class SQLTopologyRepository:
             self._refresh()
             self._memory.put_relationship(scope, relationship)
             with self._engine.begin() as connection:
+                values["scope_id"] = scopes.remembered(connection, scope)
                 connection.execute(
                     delete(relationship_table).where(
-                        relationship_table.c.scope == values["scope"],
+                        relationship_table.c.scope_id == values["scope_id"],
                         relationship_table.c.id == relationship.id,
                     )
                 )
@@ -121,7 +123,7 @@ class SQLTopologyRepository:
             self._refresh()
 
     def remove_entity(self, scope: Scope, entity_id: str) -> bool:
-        scope_key = self._scope_key(scope)
+        scope_key = scopes.known_id(self._engine, scope)
         with self._lock:
             self._refresh()
             if not self._memory.remove_entity(scope, entity_id):
@@ -129,14 +131,14 @@ class SQLTopologyRepository:
             with self._engine.begin() as connection:
                 connection.execute(
                     delete(relationship_table).where(
-                        relationship_table.c.scope == scope_key,
+                        relationship_table.c.scope_id == scope_key,
                         (relationship_table.c.source_id == entity_id)
                         | (relationship_table.c.target_id == entity_id),
                     )
                 )
                 connection.execute(
                     delete(entity_table).where(
-                        entity_table.c.scope == scope_key,
+                        entity_table.c.scope_id == scope_key,
                         entity_table.c.id == entity_id,
                     )
                 )
@@ -144,7 +146,7 @@ class SQLTopologyRepository:
             return True
 
     def remove_relationship(self, scope: Scope, relationship_id: str) -> bool:
-        scope_key = self._scope_key(scope)
+        scope_key = scopes.known_id(self._engine, scope)
         with self._lock:
             self._refresh()
             if not self._memory.remove_relationship(scope, relationship_id):
@@ -152,7 +154,7 @@ class SQLTopologyRepository:
             with self._engine.begin() as connection:
                 connection.execute(
                     delete(relationship_table).where(
-                        relationship_table.c.scope == scope_key,
+                        relationship_table.c.scope_id == scope_key,
                         relationship_table.c.id == relationship_id,
                     )
                 )
@@ -185,9 +187,9 @@ class SQLTopologyRepository:
     def _refresh(self) -> None:
         memory = InMemoryTopologyRepository()
         with self._engine.connect() as connection:
-            for row in connection.execute(select(entity_table)).mappings():
+            for row in connection.execute(scopes.with_scope(entity_table)).mappings():
                 memory.put_entity(
-                    self._decode_scope(row["scope"]),
+                    scopes.read(row["qualifiers"]),
                     TopologyEntity(
                         row["id"],
                         row["kind"],
@@ -198,9 +200,11 @@ class SQLTopologyRepository:
                         self._decode_evidence(row["evidence"]),
                     ),
                 )
-            for row in connection.execute(select(relationship_table)).mappings():
+            for row in connection.execute(
+                scopes.with_scope(relationship_table)
+            ).mappings():
                 memory.put_relationship(
-                    self._decode_scope(row["scope"]),
+                    scopes.read(row["qualifiers"]),
                     TopologyRelationship(
                         row["id"],
                         row["source_id"],
@@ -214,14 +218,6 @@ class SQLTopologyRepository:
                     ),
                 )
         self._memory = memory
-
-    @staticmethod
-    def _scope_key(scope: Scope) -> str:
-        return json.dumps(scope.values, separators=(",", ":"))
-
-    @staticmethod
-    def _decode_scope(value: str) -> Scope:
-        return Scope(tuple(tuple(item) for item in json.loads(value)))
 
     @staticmethod
     def _encode(value: Mapping[str, Any]) -> str:

--- a/src/migrations/versions/create_change_impact_tables.py
+++ b/src/migrations/versions/create_change_impact_tables.py
@@ -10,25 +10,38 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    # Keyed on five columns, which is what makes these narrower than the
+    # same kind of column elsewhere: a kind is a word and a revision is a
+    # commit hash, and together they have to stay inside 3072 bytes.
     op.create_table(
         "impact_code_mappings",
-        sa.Column("scope", sa.String(length=500), nullable=False),
-        sa.Column("change_kind", sa.String(length=255), nullable=False),
-        sa.Column("change_id", sa.String(length=500), nullable=False),
-        sa.Column("revision", sa.String(length=255), nullable=False),
+        sa.Column(
+            "scope_id",
+            sa.BigInteger(),
+            sa.ForeignKey("scopes.id"),
+            nullable=False,
+        ),
+        sa.Column("change_kind", sa.String(length=64), nullable=False),
+        sa.Column("change_id", sa.String(length=383), nullable=False),
+        sa.Column("revision", sa.String(length=64), nullable=False),
         sa.Column("entity_id", sa.String(length=255), nullable=False),
         sa.PrimaryKeyConstraint(
-            "scope", "change_kind", "change_id", "revision", "entity_id"
+            "scope_id", "change_kind", "change_id", "revision", "entity_id"
         ),
     )
     op.create_index(
         "ix_impact_code_mappings_scope_change",
         "impact_code_mappings",
-        ["scope", "change_kind", "change_id"],
+        ["scope_id", "change_kind", "change_id"],
     )
     op.create_table(
         "compatibility_checks",
-        sa.Column("scope", sa.String(length=500), nullable=False),
+        sa.Column(
+            "scope_id",
+            sa.BigInteger(),
+            sa.ForeignKey("scopes.id"),
+            nullable=False,
+        ),
         sa.Column("id", sa.String(length=255), nullable=False),
         sa.Column("provider_entity_id", sa.String(length=255), nullable=False),
         sa.Column("consumer_entity_id", sa.String(length=255), nullable=False),
@@ -41,17 +54,17 @@ def upgrade() -> None:
         sa.Column("stale", sa.Boolean(), nullable=False),
         sa.Column("evidence", sa.Text(), nullable=False),
         sa.Column("properties", sa.Text(), nullable=False),
-        sa.PrimaryKeyConstraint("scope", "id"),
+        sa.PrimaryKeyConstraint("scope_id", "id"),
     )
     op.create_index(
         "ix_compatibility_checks_scope_provider",
         "compatibility_checks",
-        ["scope", "provider_entity_id"],
+        ["scope_id", "provider_entity_id"],
     )
     op.create_index(
         "ix_compatibility_checks_scope_consumer",
         "compatibility_checks",
-        ["scope", "consumer_entity_id"],
+        ["scope_id", "consumer_entity_id"],
     )
 
 

--- a/src/migrations/versions/create_code_index_tables.py
+++ b/src/migrations/versions/create_code_index_tables.py
@@ -12,37 +12,56 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.create_table(
         "code_nodes",
-        sa.Column("scope", sa.String(length=500), nullable=False),
+        sa.Column(
+            "scope_id",
+            sa.BigInteger(),
+            sa.ForeignKey("scopes.id"),
+            nullable=False,
+        ),
         sa.Column("id", sa.String(length=500), nullable=False),
         sa.Column("file_path", sa.String(length=500), nullable=True),
         sa.Column("properties", sa.Text(), nullable=False),
-        sa.PrimaryKeyConstraint("scope", "id"),
+        sa.PrimaryKeyConstraint("scope_id", "id"),
     )
     op.create_index(
-        "ix_code_nodes_scope_file_path", "code_nodes", ["scope", "file_path"]
+        "ix_code_nodes_scope_file_path", "code_nodes", ["scope_id", "file_path"]
     )
     op.create_table(
         "code_node_labels",
-        sa.Column("scope", sa.String(length=500), nullable=False),
+        sa.Column(
+            "scope_id",
+            sa.BigInteger(),
+            sa.ForeignKey("scopes.id"),
+            nullable=False,
+        ),
         sa.Column("node_id", sa.String(length=500), nullable=False),
         sa.Column("label", sa.String(length=255), nullable=False),
-        sa.PrimaryKeyConstraint("scope", "node_id", "label"),
+        sa.PrimaryKeyConstraint("scope_id", "node_id", "label"),
     )
     op.create_index(
-        "ix_code_node_labels_scope_label", "code_node_labels", ["scope", "label"]
+        "ix_code_node_labels_scope_label", "code_node_labels", ["scope_id", "label"]
     )
     op.create_table(
         "code_edges",
-        sa.Column("scope", sa.String(length=500), nullable=False),
+        sa.Column(
+            "scope_id",
+            sa.BigInteger(),
+            sa.ForeignKey("scopes.id"),
+            nullable=False,
+        ),
         sa.Column("id", sa.String(length=500), nullable=False),
         sa.Column("source_id", sa.String(length=500), nullable=False),
         sa.Column("target_id", sa.String(length=500), nullable=False),
         sa.Column("type", sa.String(length=255), nullable=False),
         sa.Column("properties", sa.Text(), nullable=False),
-        sa.PrimaryKeyConstraint("scope", "id"),
+        sa.PrimaryKeyConstraint("scope_id", "id"),
     )
-    op.create_index("ix_code_edges_scope_source", "code_edges", ["scope", "source_id"])
-    op.create_index("ix_code_edges_scope_target", "code_edges", ["scope", "target_id"])
+    op.create_index(
+        "ix_code_edges_scope_source", "code_edges", ["scope_id", "source_id"]
+    )
+    op.create_index(
+        "ix_code_edges_scope_target", "code_edges", ["scope_id", "target_id"]
+    )
 
 
 def downgrade() -> None:

--- a/src/migrations/versions/create_knowledge_links.py
+++ b/src/migrations/versions/create_knowledge_links.py
@@ -13,8 +13,9 @@ def upgrade() -> None:
     op.create_table(
         "knowledge_links",
         sa.Column(
-            "scope",
-            sa.Text().with_variant(sa.String(length=500), "mysql"),
+            "scope_id",
+            sa.BigInteger(),
+            sa.ForeignKey("scopes.id"),
             nullable=False,
         ),
         sa.Column("id", sa.String(length=255), nullable=False),
@@ -22,15 +23,15 @@ def upgrade() -> None:
         sa.Column("target_kind", sa.String(length=64), nullable=False),
         sa.Column("target_id", sa.String(length=500), nullable=False),
         sa.Column("properties", sa.Text(), nullable=False),
-        sa.PrimaryKeyConstraint("scope", "id"),
+        sa.PrimaryKeyConstraint("scope_id", "id"),
     )
     op.create_index(
         "ix_knowledge_links_scope_knowledge",
         "knowledge_links",
-        ["scope", "knowledge_id"],
+        ["scope_id", "knowledge_id"],
     )
     op.create_index(
-        "ix_knowledge_links_scope_target", "knowledge_links", ["scope", "target_id"]
+        "ix_knowledge_links_scope_target", "knowledge_links", ["scope_id", "target_id"]
     )
 
 

--- a/src/migrations/versions/create_knowledge_tables.py
+++ b/src/migrations/versions/create_knowledge_tables.py
@@ -2,6 +2,7 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import mysql
 
 revision = "knowledge_001"
 down_revision = "configs_001"
@@ -10,11 +11,37 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    # Every scoped table points at a scope by number rather than writing it out.
+    # Created here because this is the first table that needs one. A scope grows
+    # whenever it gains a qualifier, and MySQL will not build a key over 3072
+    # bytes, so the scope itself is the only place it is written in full.
+    op.create_table(
+        "scopes",
+        sa.Column(
+            "id",
+            sa.BigInteger().with_variant(sa.Integer(), "sqlite"),
+            autoincrement=True,
+            nullable=False,
+        ),
+        # Compared byte for byte. MySQL's default collation ignores case,
+        # which would make one scope of two repositories whose names differ
+        # only by it.
+        sa.Column(
+            "qualifiers",
+            sa.String(length=500).with_variant(
+                mysql.VARCHAR(500, collation="utf8mb4_bin"), "mysql"
+            ),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("qualifiers", name="uq_scopes_qualifiers"),
+    )
     op.create_table(
         "knowledge_objects",
         sa.Column(
-            "scope",
-            sa.Text().with_variant(sa.String(length=500), "mysql"),
+            "scope_id",
+            sa.BigInteger(),
+            sa.ForeignKey("scopes.id"),
             nullable=False,
         ),
         sa.Column("id", sa.String(length=255), nullable=False),
@@ -22,13 +49,14 @@ def upgrade() -> None:
         sa.Column("status", sa.String(length=255), nullable=False),
         sa.Column("summary", sa.Text(), nullable=False),
         sa.Column("properties", sa.Text(), nullable=False),
-        sa.PrimaryKeyConstraint("scope", "id"),
+        sa.PrimaryKeyConstraint("scope_id", "id"),
     )
     op.create_table(
         "knowledge_relationships",
         sa.Column(
-            "scope",
-            sa.Text().with_variant(sa.String(length=500), "mysql"),
+            "scope_id",
+            sa.BigInteger(),
+            sa.ForeignKey("scopes.id"),
             nullable=False,
         ),
         sa.Column("id", sa.String(length=255), nullable=False),
@@ -37,10 +65,11 @@ def upgrade() -> None:
         sa.Column("type", sa.String(length=255), nullable=False),
         sa.Column("status", sa.String(length=255), nullable=False),
         sa.Column("properties", sa.Text(), nullable=False),
-        sa.PrimaryKeyConstraint("scope", "id"),
+        sa.PrimaryKeyConstraint("scope_id", "id"),
     )
 
 
 def downgrade() -> None:
     op.drop_table("knowledge_relationships")
     op.drop_table("knowledge_objects")
+    op.drop_table("scopes")

--- a/src/migrations/versions/create_requirement_tables.py
+++ b/src/migrations/versions/create_requirement_tables.py
@@ -12,37 +12,49 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.create_table(
         "requirements",
-        sa.Column("scope", sa.String(length=500), nullable=False),
+        sa.Column(
+            "scope_id",
+            sa.BigInteger(),
+            sa.ForeignKey("scopes.id"),
+            nullable=False,
+        ),
         sa.Column("id", sa.String(length=255), nullable=False),
         sa.Column("kind", sa.String(length=255), nullable=False),
         sa.Column("status", sa.String(length=255), nullable=False),
         sa.Column("summary", sa.Text(), nullable=False),
         sa.Column("external_ref", sa.String(length=500), nullable=False),
         sa.Column("properties", sa.Text(), nullable=False),
-        sa.PrimaryKeyConstraint("scope", "id"),
+        sa.PrimaryKeyConstraint("scope_id", "id"),
     )
     op.create_index(
-        "ix_requirements_scope_external_ref", "requirements", ["scope", "external_ref"]
+        "ix_requirements_scope_external_ref",
+        "requirements",
+        ["scope_id", "external_ref"],
     )
     op.create_table(
         "requirement_links",
-        sa.Column("scope", sa.String(length=500), nullable=False),
+        sa.Column(
+            "scope_id",
+            sa.BigInteger(),
+            sa.ForeignKey("scopes.id"),
+            nullable=False,
+        ),
         sa.Column("id", sa.String(length=255), nullable=False),
         sa.Column("requirement_id", sa.String(length=255), nullable=False),
         sa.Column("target_kind", sa.String(length=64), nullable=False),
         sa.Column("target_id", sa.String(length=500), nullable=False),
         sa.Column("properties", sa.Text(), nullable=False),
-        sa.PrimaryKeyConstraint("scope", "id"),
+        sa.PrimaryKeyConstraint("scope_id", "id"),
     )
     op.create_index(
         "ix_requirement_links_scope_requirement",
         "requirement_links",
-        ["scope", "requirement_id"],
+        ["scope_id", "requirement_id"],
     )
     op.create_index(
         "ix_requirement_links_scope_target",
         "requirement_links",
-        ["scope", "target_id"],
+        ["scope_id", "target_id"],
     )
 
 

--- a/src/migrations/versions/create_review_findings.py
+++ b/src/migrations/versions/create_review_findings.py
@@ -16,18 +16,23 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         "review_findings",
-        sa.Column("scope", sa.Text(), nullable=False),
+        sa.Column(
+            "scope_id",
+            sa.BigInteger(),
+            sa.ForeignKey("scopes.id"),
+            nullable=False,
+        ),
         # A fingerprint rather than a position: an edit above a finding moves
         # its line, and an identity that moves loses whatever state somebody
         # set on it.
         sa.Column("id", sa.String(128), nullable=False),
         sa.Column("state", sa.String(32), nullable=False, index=True),
-        sa.Column("summary", sa.Text(), nullable=False, server_default=""),
+        sa.Column("summary", sa.Text(), nullable=False),
         sa.Column("code_anchor", sa.String(500), nullable=True),
-        sa.Column("properties", sa.Text(), nullable=False, server_default="{}"),
+        sa.Column("properties", sa.Text(), nullable=False),
         sa.Column("first_seen", sa.DateTime(timezone=True), nullable=True),
         sa.Column("last_seen", sa.DateTime(timezone=True), nullable=True),
-        sa.PrimaryKeyConstraint("scope", "id"),
+        sa.PrimaryKeyConstraint("scope_id", "id"),
     )
 
 

--- a/src/migrations/versions/create_topology_tables.py
+++ b/src/migrations/versions/create_topology_tables.py
@@ -13,8 +13,9 @@ def upgrade() -> None:
     op.create_table(
         "topology_entities",
         sa.Column(
-            "scope",
-            sa.Text().with_variant(sa.String(length=500), "mysql"),
+            "scope_id",
+            sa.BigInteger(),
+            sa.ForeignKey("scopes.id"),
             nullable=False,
         ),
         sa.Column("id", sa.String(length=255), nullable=False),
@@ -24,13 +25,14 @@ def upgrade() -> None:
         sa.Column("stale", sa.Boolean(), nullable=False),
         sa.Column("properties", sa.Text(), nullable=False),
         sa.Column("evidence", sa.Text(), nullable=False),
-        sa.PrimaryKeyConstraint("scope", "id"),
+        sa.PrimaryKeyConstraint("scope_id", "id"),
     )
     op.create_table(
         "topology_relationships",
         sa.Column(
-            "scope",
-            sa.Text().with_variant(sa.String(length=500), "mysql"),
+            "scope_id",
+            sa.BigInteger(),
+            sa.ForeignKey("scopes.id"),
             nullable=False,
         ),
         sa.Column("id", sa.String(length=255), nullable=False),
@@ -42,7 +44,7 @@ def upgrade() -> None:
         sa.Column("stale", sa.Boolean(), nullable=False),
         sa.Column("properties", sa.Text(), nullable=False),
         sa.Column("evidence", sa.Text(), nullable=False),
-        sa.PrimaryKeyConstraint("scope", "id"),
+        sa.PrimaryKeyConstraint("scope_id", "id"),
     )
 
 

--- a/src/tests/unit/test_core_sqlite_knowledge.py
+++ b/src/tests/unit/test_core_sqlite_knowledge.py
@@ -16,13 +16,25 @@ PROJECT = Scope.from_mapping({"project": "one"})
 OTHER_PROJECT = Scope.from_mapping({"project": "two"})
 
 
-def test_sql_knowledge_scope_keys_compile_for_supported_databases():
+def _mysql_key_bytes(table) -> int:
+    """What MySQL counts the primary key as, reserving four bytes a character."""
+    total = 0
+    for column in table.primary_key:
+        kind = column.type.dialect_impl(mysql.dialect())
+        total += (kind.length * 4) if getattr(kind, "length", None) else 8
+    return total
+
+
+def test_a_scope_is_carried_as_a_number_so_the_key_fits_every_database():
+    """A scope grows whenever it gains a qualifier, so a key that spells one out
+    has no width that is both safe and small enough for MySQL to build."""
     for table in (knowledge_table, relationship_table):
         mysql_ddl = str(CreateTable(table).compile(dialect=mysql.dialect()))
         postgres_ddl = str(CreateTable(table).compile(dialect=postgresql.dialect()))
 
-        assert "scope VARCHAR(500) NOT NULL" in mysql_ddl
-        assert "scope TEXT NOT NULL" in postgres_ddl
+        assert "scope_id BIGINT NOT NULL" in mysql_ddl
+        assert "scope_id BIGINT NOT NULL" in postgres_ddl
+        assert _mysql_key_bytes(table) <= 3072
 
 
 def test_sql_knowledge_survives_restart_and_preserves_scope(tmp_path):

--- a/src/tests/unit/test_core_sqlite_topology.py
+++ b/src/tests/unit/test_core_sqlite_topology.py
@@ -18,13 +18,23 @@ PROJECT = Scope.from_mapping({"project": "one"})
 OTHER_PROJECT = Scope.from_mapping({"project": "two"})
 
 
-def test_sql_topology_scope_keys_compile_for_supported_databases():
+def _mysql_key_bytes(table) -> int:
+    """What MySQL counts the primary key as, reserving four bytes a character."""
+    total = 0
+    for column in table.primary_key:
+        kind = column.type.dialect_impl(mysql.dialect())
+        total += (kind.length * 4) if getattr(kind, "length", None) else 8
+    return total
+
+
+def test_a_scope_is_carried_as_a_number_so_the_key_fits_every_database():
     for table in (entity_table, relationship_table):
         mysql_ddl = str(CreateTable(table).compile(dialect=mysql.dialect()))
         postgres_ddl = str(CreateTable(table).compile(dialect=postgresql.dialect()))
 
-        assert "scope VARCHAR(500) NOT NULL" in mysql_ddl
-        assert "scope TEXT NOT NULL" in postgres_ddl
+        assert "scope_id BIGINT NOT NULL" in mysql_ddl
+        assert "scope_id BIGINT NOT NULL" in postgres_ddl
+        assert _mysql_key_bytes(table) <= 3072
 
 
 def test_sql_topology_survives_restart_and_preserves_scope(tmp_path):

--- a/src/tests/unit/test_sql_under_load.py
+++ b/src/tests/unit/test_sql_under_load.py
@@ -26,11 +26,20 @@ def _engine(tmp_path, name):
 
 
 def _counted(engine):
-    counted = {"n": 0}
+    """Statements, with the ones asking after a scope counted separately.
+
+    A scope is the same for every row in a write, so looking one up must not
+    grow with the number of rows. Counting them apart keeps that visible
+    instead of hiding it in the total.
+    """
+    counted = {"n": 0, "scopes": 0}
 
     @event.listens_for(engine, "before_cursor_execute")
     def _count(conn, cursor, statement, parameters, context, executemany):
-        counted["n"] += 1
+        if " scopes" in statement:
+            counted["scopes"] += 1
+        else:
+            counted["n"] += 1
 
     return counted
 
@@ -146,6 +155,8 @@ def test_impact_seeds_ask_once_per_kind_not_once_per_file(tmp_path):
 
     assert store.resolve(SCOPE, changes) == ("system:billing",)
     assert counted["n"] == 1
+    # One hundred changed files, and the scope is looked up once.
+    assert counted["scopes"] == 1
 
 
 def test_impact_seeds_over_thousands_of_changed_files(tmp_path):
@@ -161,3 +172,21 @@ def test_impact_seeds_over_thousands_of_changed_files(tmp_path):
     store.put_mapping(SCOPE, changes[0], ("system:billing",))
 
     assert store.resolve(SCOPE, changes) == ("system:billing",)
+
+
+def test_indexing_asks_for_the_scope_once_not_once_per_node(tmp_path):
+    """Every node in a flush shares one scope, so the lookups must not scale
+    with the nodes. Asking per row turned a flush of thousands into thousands
+    of extra round trips."""
+    engine = _engine(tmp_path, "code-scope.db")
+    store = SQLCodeIndexRepository(engine, create_schema=True)
+    counted = _counted(engine)
+
+    with store.bulk_writes():
+        for index in range(MANY):
+            store.put_node(
+                SCOPE,
+                CodeNode(f"file:src/f{index}.py", frozenset({"File"}), {}),
+            )
+
+    assert counted["scopes"] < 20


### PR DESCRIPTION
A scope grows whenever it gains a qualifier, so writing one into every row it qualified gave MySQL keys it will not build. The code graph, requirements, impact mappings and findings could not be created there at all.

A scope is recorded once now, and everything scoped carries its number. Only the mapping of a change to the code it touches has columns sized down, because its key is five columns wide.

Existing databases are rebuilt rather than migrated.