### PR TITLE
feat(settings): Offer models from the router and check a key before saving

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,7 @@ Choosing a model in the interface checks the key against the provider first, so 
 |---|---|---|
 | `MODEL_PROBE_TIMEOUT` | `15` | Seconds a provider gets to answer the check |
 | `MODEL_RESOLVE_TIMEOUT` | `5` | Seconds a custom endpoint's name gets to resolve |
-| `MODEL_ENDPOINTS_MAY_BE_PRIVATE` | off | Accept an endpoint on a private address |
+| `MODEL_ENDPOINTS_MAY_BE_PRIVATE` | `false` | Accept an endpoint on a private address |
 
 Leave the last one off unless the people naming endpoints are the same people who run the deployment. It is what lets a custom endpoint point at a machine only this server can reach, so turning it on where anyone else can set a model hands them this server as a way into that network.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,16 @@ GEMINI_API_KEY=your_gemini_api_key
 
 `LLM_TOKEN_LIMIT` (default `131072`) is the diff size that still fits a single-pass review. Raise it to match a model with a larger window; a diff above it is reviewed file by file instead.
 
+Choosing a model in the interface checks the key against the provider first, so a model the account cannot use is refused there rather than halfway through a scan. Three variables bound that check:
+
+| Variable | Default | What it does |
+|---|---|---|
+| `MODEL_PROBE_TIMEOUT` | `15` | Seconds a provider gets to answer the check |
+| `MODEL_RESOLVE_TIMEOUT` | `5` | Seconds a custom endpoint's name gets to resolve |
+| `MODEL_ENDPOINTS_MAY_BE_PRIVATE` | off | Accept an endpoint on a private address |
+
+Leave the last one off unless the people naming endpoints are the same people who run the deployment. It is what lets a custom endpoint point at a machine only this server can reach, so turning it on where anyone else can set a model hands them this server as a way into that network.
+
 ### GitHub App
 
 Required to post anything to GitHub. All three are needed, and the integration refuses to start without them:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,9 +26,9 @@ Choosing a model in the interface checks the key against the provider first, so 
 
 | Variable | Default | What it does |
 |---|---|---|
-| `MODEL_PROBE_TIMEOUT` | `15` | Seconds a provider gets to answer the check |
-| `MODEL_RESOLVE_TIMEOUT` | `5` | Seconds a custom endpoint's name gets to resolve |
-| `MODEL_ENDPOINTS_MAY_BE_PRIVATE` | `false` | Accept an endpoint on a private address |
+| `LLM_PROBE_TIMEOUT` | `15` | Seconds a provider gets to answer the check |
+| `LLM_RESOLVE_TIMEOUT` | `5` | Seconds a custom endpoint's name gets to resolve |
+| `LLM_ALLOW_PRIVATE_ENDPOINTS` | `false` | Accept an endpoint on a private address |
 
 Leave the last one off unless the people naming endpoints are the same people who run the deployment. It is what lets a custom endpoint point at a machine only this server can reach, so turning it on where anyone else can set a model hands them this server as a way into that network.
 

--- a/docs/reviews.md
+++ b/docs/reviews.md
@@ -60,6 +60,9 @@ Reuse is best effort: when Redis is unavailable the review is simply generated a
 | `POSITIVE_SENTIMENT_THRESHOLD` | `0.3` | How positive a comment must read to be treated as praise and dropped |
 | `REVIEW_MISSING_EXISTING_CODE_POLICY` | `drop` | What happens to a suggestion with no anchoring code: `drop`, `warn`, `keep` |
 | `LLM_TOKEN_LIMIT` | `131072` | Diff size that still fits a single-pass review |
+| `MODEL_PROBE_TIMEOUT` | `15` | Seconds a provider gets to answer a model check |
+| `MODEL_RESOLVE_TIMEOUT` | `5` | Seconds a custom endpoint's name gets to resolve |
+| `MODEL_ENDPOINTS_MAY_BE_PRIVATE` | `false` | Accept a model endpoint on a private address |
 
 ### Limits
 

--- a/docs/reviews.md
+++ b/docs/reviews.md
@@ -60,9 +60,9 @@ Reuse is best effort: when Redis is unavailable the review is simply generated a
 | `POSITIVE_SENTIMENT_THRESHOLD` | `0.3` | How positive a comment must read to be treated as praise and dropped |
 | `REVIEW_MISSING_EXISTING_CODE_POLICY` | `drop` | What happens to a suggestion with no anchoring code: `drop`, `warn`, `keep` |
 | `LLM_TOKEN_LIMIT` | `131072` | Diff size that still fits a single-pass review |
-| `MODEL_PROBE_TIMEOUT` | `15` | Seconds a provider gets to answer a model check |
-| `MODEL_RESOLVE_TIMEOUT` | `5` | Seconds a custom endpoint's name gets to resolve |
-| `MODEL_ENDPOINTS_MAY_BE_PRIVATE` | `false` | Accept a model endpoint on a private address |
+| `LLM_PROBE_TIMEOUT` | `15` | Seconds a provider gets to answer a model check |
+| `LLM_RESOLVE_TIMEOUT` | `5` | Seconds a custom endpoint's name gets to resolve |
+| `LLM_ALLOW_PRIVATE_ENDPOINTS` | `false` | Accept a model endpoint on a private address |
 
 ### Limits
 

--- a/src/api/routes/settings.py
+++ b/src/api/routes/settings.py
@@ -9,10 +9,10 @@ from dataclasses import asdict
 from typing import Any, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, SecretStr, field_validator
 
 from src.auth import get_current_user
-from src.core.model.catalogue import offered, refused
+from src.core.model.catalogue import offered, reachable, refused
 from src.core.responses import success_response
 from src.core.workspace import workspace_in
 from src.core.settings import (
@@ -38,10 +38,24 @@ class SettingInput(BaseModel):
 
 class ModelCheck(BaseModel):
     model: str
-    api_key: str
+    #: Never read back and never logged, so it cannot reach a trace by accident.
+    api_key: SecretStr
     # Optional, and null rather than absent when it reaches here through a
     # gateway that turns empty strings into nulls on the way.
     base_url: Optional[str] = ""
+
+    @field_validator("base_url")
+    @classmethod
+    def _somewhere_a_provider_lives(cls, given: Optional[str]) -> str:
+        """Refuse an endpoint that is not a provider on the public internet.
+
+        Whatever is named here is a host this server then sends a request to,
+        carrying the key it was given. Left open, anybody who can reach this can
+        use it to knock on addresses only this machine can see.
+        """
+        if not given:
+            return ""
+        return reachable(given)
 
 
 def _authorize_user_scope(scope: Scope, scope_id: str, user: dict) -> None:
@@ -94,14 +108,16 @@ def _described(resolved: Resolved) -> dict:
     }
 
 
+# Both of these wait on something outside this process, and neither awaits it.
+# Declared without async, they are run on a thread and the loop stays free.
 @router.get("/models")
-async def models(user: dict = Depends(get_current_user)):
+def models(user: dict = Depends(get_current_user)):
     """Every model that can be named here, by provider."""
     return success_response(offered())
 
 
 @router.post("/models/check")
-async def check_model(
+def check_model(
     payload: ModelCheck,
     user: dict = Depends(get_current_user),
 ):
@@ -110,7 +126,11 @@ async def check_model(
     A provider's catalogue says what exists. What an account may use is a
     subset, and the two only differ when somebody is already waiting.
     """
-    why = refused(payload.model, payload.api_key, payload.base_url or "")
+    why = refused(
+        payload.model,
+        payload.api_key.get_secret_value(),
+        payload.base_url or "",
+    )
     return success_response({"usable": why is None, "reason": why})
 
 

--- a/src/api/routes/settings.py
+++ b/src/api/routes/settings.py
@@ -6,12 +6,13 @@ inheriting.
 """
 
 from dataclasses import asdict
-from typing import Any, Literal
+from typing import Any, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from src.auth import get_current_user
+from src.core.model.catalogue import offered, refused
 from src.core.responses import success_response
 from src.core.workspace import workspace_in
 from src.core.settings import (
@@ -33,6 +34,14 @@ Scope = Literal["user", "repository", "workspace", "organization"]
 
 class SettingInput(BaseModel):
     value: Any
+
+
+class ModelCheck(BaseModel):
+    model: str
+    api_key: str
+    # Optional, and null rather than absent when it reaches here through a
+    # gateway that turns empty strings into nulls on the way.
+    base_url: Optional[str] = ""
 
 
 def _authorize_user_scope(scope: Scope, scope_id: str, user: dict) -> None:
@@ -83,6 +92,26 @@ def _described(resolved: Resolved) -> dict:
         "choices": list(setting.choices) if setting else [],
         "group": setting.group if setting else "General",
     }
+
+
+@router.get("/models")
+async def models(user: dict = Depends(get_current_user)):
+    """Every model that can be named here, by provider."""
+    return success_response(offered())
+
+
+@router.post("/models/check")
+async def check_model(
+    payload: ModelCheck,
+    user: dict = Depends(get_current_user),
+):
+    """Whether a key can use a model, asked of the provider rather than guessed.
+
+    A provider's catalogue says what exists. What an account may use is a
+    subset, and the two only differ when somebody is already waiting.
+    """
+    why = refused(payload.model, payload.api_key, payload.base_url or "")
+    return success_response({"usable": why is None, "reason": why})
 
 
 @router.get("/catalogue")

--- a/src/api/routes/settings.py
+++ b/src/api/routes/settings.py
@@ -9,7 +9,7 @@ from dataclasses import asdict
 from typing import Any, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, SecretStr, field_validator
+from pydantic import BaseModel, HttpUrl, SecretStr, field_validator
 
 from src.auth import get_current_user
 from src.core.model.catalogue import offered, reachable, refused
@@ -42,20 +42,27 @@ class ModelCheck(BaseModel):
     api_key: SecretStr
     # Optional, and null rather than absent when it reaches here through a
     # gateway that turns empty strings into nulls on the way.
-    base_url: Optional[str] = ""
+    base_url: Optional[HttpUrl] = None
 
-    @field_validator("base_url")
+    @field_validator("base_url", mode="before")
     @classmethod
-    def _somewhere_a_provider_lives(cls, given: Optional[str]) -> str:
-        """Refuse an endpoint that is not a provider on the public internet.
+    def _absent_rather_than_empty(cls, given):
+        """An empty string is nobody's endpoint, so it is not read as one."""
+        return given or None
 
-        Whatever is named here is a host this server then sends a request to,
-        carrying the key it was given. Left open, anybody who can reach this can
-        use it to knock on addresses only this machine can see.
+    @field_validator("base_url", mode="after")
+    @classmethod
+    def _somewhere_a_provider_lives(cls, given: Optional[HttpUrl]):
+        """Refuse an endpoint that is not on the public internet.
+
+        A well-formed address still says nothing about where it points, and
+        whatever is named here is a host this server then sends a request to,
+        carrying the key it was given.
         """
-        if not given:
-            return ""
-        return reachable(given)
+        if given is None:
+            return None
+        reachable(str(given))
+        return given
 
 
 def _authorize_user_scope(scope: Scope, scope_id: str, user: dict) -> None:
@@ -129,7 +136,7 @@ def check_model(
     why = refused(
         payload.model,
         payload.api_key.get_secret_value(),
-        payload.base_url or "",
+        str(payload.base_url) if payload.base_url else "",
     )
     return success_response({"usable": why is None, "reason": why})
 

--- a/src/core/model/catalogue.py
+++ b/src/core/model/catalogue.py
@@ -7,11 +7,30 @@ second, so it is asked rather than assumed.
 
 from __future__ import annotations
 
+import ipaddress
+import os
+import socket
+from functools import lru_cache
 from typing import Optional
+from urllib.parse import urlparse
 
 from src.utils.logger import logger
 
+# How long a provider gets to answer a check. Unbounded, a provider that has
+# stopped answering holds the thread until something else gives up first.
+PROBE_SECONDS = int(os.getenv("MODEL_PROBE_TIMEOUT", "15"))
 
+# A deployment running its own models reaches them on an address only it can
+# see, so it has to be able to say so. Off by default, because anywhere a person
+# other than the operator can name an endpoint, this is the whole attack.
+PRIVATE_ENDPOINTS = os.getenv("MODEL_ENDPOINTS_MAY_BE_PRIVATE", "").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
+
+@lru_cache(maxsize=1)
 def offered() -> list[dict]:
     """Every model litellm can route to, by provider.
 
@@ -34,6 +53,36 @@ def offered() -> list[dict]:
     return catalogue
 
 
+def reachable(url: str) -> str:
+    """The endpoint, if this server may be asked to call it.
+
+    Whatever is named here is somewhere this server then sends a request to,
+    carrying whatever key came with it. Left open, it answers questions about
+    the network it sits in on behalf of anybody who can reach it.
+
+    A name is resolved to decide, and a name can resolve differently a moment
+    later, so this narrows the opening rather than closing it.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        raise ValueError("base_url must be an http or https address")
+    if PRIVATE_ENDPOINTS:
+        return url
+    for address in _addresses(parsed.hostname):
+        if not address.is_global:
+            raise ValueError("base_url must be an address on the public internet")
+    return url
+
+
+def _addresses(host: str) -> list:
+    """Every address a name answers with, because one of them is enough."""
+    try:
+        found = socket.getaddrinfo(host, None)
+    except socket.gaierror as unknown:
+        raise ValueError("base_url does not resolve") from unknown
+    return [ipaddress.ip_address(entry[4][0]) for entry in found]
+
+
 def refused(model: str, api_key: str, base_url: str = "") -> Optional[str]:
     """Why this key cannot use this model, or None when it can.
 
@@ -50,6 +99,7 @@ def refused(model: str, api_key: str, base_url: str = "") -> Optional[str]:
         litellm.completion(
             messages=[{"role": "user", "content": "ping"}],
             max_tokens=1,
+            timeout=PROBE_SECONDS,
             **asked,
         )
         return None

--- a/src/core/model/catalogue.py
+++ b/src/core/model/catalogue.py
@@ -37,16 +37,16 @@ def _seconds(name: str, fallback: int) -> int:
 
 # How long a provider gets to answer a check. Unbounded, a provider that has
 # stopped answering holds the thread until something else gives up first.
-PROBE_SECONDS = _seconds("MODEL_PROBE_TIMEOUT", 15)
+PROBE_SECONDS = _seconds("LLM_PROBE_TIMEOUT", 15)
 
 # How long a name gets to resolve, for the same reason.
-RESOLVE_SECONDS = _seconds("MODEL_RESOLVE_TIMEOUT", 5)
+RESOLVE_SECONDS = _seconds("LLM_RESOLVE_TIMEOUT", 5)
 
 # A deployment running its own models reaches them on an address only it can
 # see, so an operator can say so and have private addresses accepted. Off by
 # default, because anywhere a person other than the operator names an endpoint,
 # turning it on hands them this server as a way to reach that network.
-PRIVATE_ENDPOINTS = os.getenv("MODEL_ENDPOINTS_MAY_BE_PRIVATE", "").lower() in (
+PRIVATE_ENDPOINTS = os.getenv("LLM_ALLOW_PRIVATE_ENDPOINTS", "").lower() in (
     "1",
     "true",
     "yes",

--- a/src/core/model/catalogue.py
+++ b/src/core/model/catalogue.py
@@ -1,0 +1,68 @@
+"""Which models can be named, and which of them a key can actually use.
+
+Two different questions, and answering only the first is what puts a model in
+front of somebody that their account will refuse. The provider decides the
+second, so it is asked rather than assumed.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from src.utils.logger import logger
+
+
+def offered() -> list[dict]:
+    """Every model litellm can route to, by provider.
+
+    Read from litellm rather than kept here, because a list written by hand goes
+    out of date the week after it is written, and this one is already shipped
+    with the thing that does the routing.
+
+    litellm refreshes this from the network when it is imported and falls back
+    to the copy it ships with otherwise, so a deployment with no outbound access
+    offers an older list rather than none.
+    """
+    import litellm
+
+    catalogue = []
+    for provider, models in litellm.models_by_provider.items():
+        named = sorted(models)
+        if named:
+            catalogue.append({"provider": provider, "models": named})
+    catalogue.sort(key=lambda entry: entry["provider"])
+    return catalogue
+
+
+def refused(model: str, api_key: str, base_url: str = "") -> Optional[str]:
+    """Why this key cannot use this model, or None when it can.
+
+    A provider lists what exists; an account is entitled to a subset of it. The
+    difference only shows on a real call, so a small one is made here rather
+    than leaving it to be discovered halfway through reading a repository.
+    """
+    import litellm
+
+    asked = {"model": model, "api_key": api_key}
+    if base_url:
+        asked["api_base"] = base_url
+    try:
+        litellm.completion(
+            messages=[{"role": "user", "content": "ping"}],
+            max_tokens=1,
+            **asked,
+        )
+        return None
+    except Exception as error:
+        logger.info(f"{model} was refused: {error}")
+        return _plainly(error)
+
+
+def _plainly(error: Exception) -> str:
+    """The provider's own words, without the wrapping litellm adds to them."""
+    said = str(error)
+    for marker in ("Exception - ", "Error: "):
+        _, found, rest = said.partition(marker)
+        if found and rest:
+            said = rest
+    return said.strip().split("\n")[0][:300]

--- a/src/core/model/catalogue.py
+++ b/src/core/model/catalogue.py
@@ -10,19 +10,42 @@ from __future__ import annotations
 import ipaddress
 import os
 import socket
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as TookTooLong
 from functools import lru_cache
 from typing import Optional
 from urllib.parse import urlparse
 
 from src.utils.logger import logger
 
+
+def _seconds(name: str, fallback: int) -> int:
+    """A whole number of seconds from the environment, or the fallback.
+
+    Read at import, so anything that raises here takes the process down before
+    it serves a request. A mistyped variable is worth a line in the log and a
+    sensible default, not a deployment that will not start.
+    """
+    given = os.getenv(name, "")
+    try:
+        seconds = int(given)
+    except ValueError:
+        if given:
+            logger.warning(f"{name} is not a number of seconds, using {fallback}")
+        return fallback
+    return seconds if seconds > 0 else fallback
+
+
 # How long a provider gets to answer a check. Unbounded, a provider that has
 # stopped answering holds the thread until something else gives up first.
-PROBE_SECONDS = int(os.getenv("MODEL_PROBE_TIMEOUT", "15"))
+PROBE_SECONDS = _seconds("MODEL_PROBE_TIMEOUT", 15)
+
+# How long a name gets to resolve, for the same reason.
+RESOLVE_SECONDS = _seconds("MODEL_RESOLVE_TIMEOUT", 5)
 
 # A deployment running its own models reaches them on an address only it can
-# see, so it has to be able to say so. Off by default, because anywhere a person
-# other than the operator can name an endpoint, this is the whole attack.
+# see, so an operator can say so and have private addresses accepted. Off by
+# default, because anywhere a person other than the operator names an endpoint,
+# turning it on hands them this server as a way to reach that network.
 PRIVATE_ENDPOINTS = os.getenv("MODEL_ENDPOINTS_MAY_BE_PRIVATE", "").lower() in (
     "1",
     "true",
@@ -75,11 +98,23 @@ def reachable(url: str) -> str:
 
 
 def _addresses(host: str) -> list:
-    """Every address a name answers with, because one of them is enough."""
+    """Every address a name answers with, because one of them is enough.
+
+    Resolving has no timeout of its own, so it is waited on rather than called
+    directly. The lookup itself cannot be cancelled; this bounds how long
+    anybody waits on it, not how long it runs.
+    """
+    asking = ThreadPoolExecutor(max_workers=1)
     try:
-        found = socket.getaddrinfo(host, None)
+        found = asking.submit(socket.getaddrinfo, host, None).result(
+            timeout=RESOLVE_SECONDS
+        )
+    except TookTooLong as slow:
+        raise ValueError("base_url did not resolve in time") from slow
     except socket.gaierror as unknown:
         raise ValueError("base_url does not resolve") from unknown
+    finally:
+        asking.shutdown(wait=False)
     return [ipaddress.ip_address(entry[4][0]) for entry in found]
 
 
@@ -100,6 +135,11 @@ def refused(model: str, api_key: str, base_url: str = "") -> Optional[str]:
             messages=[{"role": "user", "content": "ping"}],
             max_tokens=1,
             timeout=PROBE_SECONDS,
+            # One question, asked once. Retrying a provider that is not
+            # answering turns a bounded wait into several of them, and the
+            # client underneath retries on its own unless it is told not to.
+            num_retries=0,
+            max_retries=0,
             **asked,
         )
         return None

--- a/src/tests/unit/test_model_catalogue_api.py
+++ b/src/tests/unit/test_model_catalogue_api.py
@@ -1,0 +1,98 @@
+"""What may be named as a model, and whether a key may actually use it."""
+
+import os
+import time
+from unittest.mock import patch
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.main import app
+
+TEST_JWT_SECRET = "model-catalogue-test-secret"
+
+
+def _headers() -> dict:
+    token = jwt.encode(
+        {
+            "sub": "42",
+            "scope": {"workspace_id": "7", "repository_ids": []},
+            "exp": int(time.time()) + 300,
+        },
+        os.environ["JWT_SECRET"],
+        algorithm="HS256",
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", TEST_JWT_SECRET)
+    with TestClient(app) as started:
+        yield started
+
+
+def test_the_models_offered_come_from_the_router_rather_than_a_list_here(client):
+    """A list written by hand goes stale. This one ships with the thing that
+    does the routing, so it describes what can actually be reached."""
+    answered = client.get("/api/settings/models", headers=_headers())
+
+    assert answered.status_code == 200
+    catalogue = answered.json()["data"]
+    providers = {entry["provider"] for entry in catalogue}
+    assert {"anthropic", "openai", "moonshot"} <= providers
+    for entry in catalogue:
+        assert entry["models"], f"{entry['provider']} offered nothing"
+
+
+def test_a_model_the_key_cannot_use_is_reported_before_it_is_saved(client):
+    """A provider's catalogue says what exists. An account may use a subset, and
+    the two only differ once somebody is already waiting on a scan."""
+    with patch(
+        "litellm.completion",
+        side_effect=Exception(
+            "MoonshotException - Not found the model kimi-k2-0905-preview"
+        ),
+    ):
+        answered = client.post(
+            "/api/settings/models/check",
+            headers=_headers(),
+            json={"model": "moonshot/kimi-k2-0905-preview", "api_key": "a-key"},
+        )
+
+    assert answered.status_code == 200
+    said = answered.json()["data"]
+    assert said["usable"] is False
+    assert "Not found the model" in said["reason"]
+
+
+def test_a_model_the_key_can_use_says_so(client):
+    with patch("litellm.completion", return_value=object()):
+        answered = client.post(
+            "/api/settings/models/check",
+            headers=_headers(),
+            json={"model": "moonshot/kimi-k2.7-code", "api_key": "a-key"},
+        )
+
+    assert answered.status_code == 200
+    assert answered.json()["data"] == {"usable": True, "reason": None}
+
+
+def test_a_null_base_url_is_taken_as_none_given(client):
+    """The gateway in front of this turns empty strings into nulls, so a model
+    with no endpoint of its own arrives as null rather than absent."""
+    with patch("litellm.completion", return_value=object()) as called:
+        answered = client.post(
+            "/api/settings/models/check",
+            headers=_headers(),
+            json={
+                "model": "moonshot/kimi-k2.7-code",
+                "api_key": "a-key",
+                "base_url": None,
+            },
+        )
+
+    assert answered.status_code == 200
+    assert answered.json()["data"]["usable"] is True
+    assert "api_base" not in called.call_args.kwargs

--- a/src/tests/unit/test_model_catalogue_api.py
+++ b/src/tests/unit/test_model_catalogue_api.py
@@ -132,15 +132,34 @@ def test_an_endpoint_that_is_not_a_web_address_is_refused(client):
 
 def test_a_provider_that_stops_answering_does_not_hold_the_request(client):
     """Unbounded, one unresponsive endpoint keeps a thread until something else
-    gives up first."""
+    gives up first, and a client that retries on its own turns one wait into
+    several."""
     with patch("litellm.completion", return_value=object()) as called:
-        client.post(
+        answered = client.post(
             "/api/settings/models/check",
             headers=_headers(),
             json={"model": "moonshot/kimi-k2.7-code", "api_key": "a-key"},
         )
 
+    assert answered.status_code == 200
     assert called.call_args.kwargs["timeout"] > 0
+    assert called.call_args.kwargs["num_retries"] == 0
+    assert called.call_args.kwargs["max_retries"] == 0
+
+
+def test_a_mistyped_timeout_does_not_stop_the_process_starting(monkeypatch):
+    """It is read at import, so anything that raises takes the deployment down
+    before it serves a request."""
+    from src.core.model.catalogue import _seconds
+
+    monkeypatch.setenv("A_TIMEOUT", "half a minute")
+    assert _seconds("A_TIMEOUT", 15) == 15
+
+    monkeypatch.setenv("A_TIMEOUT", "0")
+    assert _seconds("A_TIMEOUT", 15) == 15
+
+    monkeypatch.setenv("A_TIMEOUT", "45")
+    assert _seconds("A_TIMEOUT", 15) == 45
 
 
 def test_the_key_is_never_read_back(client):

--- a/src/tests/unit/test_model_catalogue_api.py
+++ b/src/tests/unit/test_model_catalogue_api.py
@@ -96,3 +96,61 @@ def test_a_null_base_url_is_taken_as_none_given(client):
     assert answered.status_code == 200
     assert answered.json()["data"]["usable"] is True
     assert "api_base" not in called.call_args.kwargs
+
+
+def test_an_endpoint_only_this_machine_can_see_is_refused(client):
+    """Whatever is named here is somewhere the server then sends a request to,
+    carrying the key it was given, so anybody who can reach this could otherwise
+    use it to knock on addresses only this machine can see."""
+    answered = client.post(
+        "/api/settings/models/check",
+        headers=_headers(),
+        json={
+            "model": "moonshot/kimi-k2.7-code",
+            "api_key": "a-key",
+            "base_url": "http://127.0.0.1:11434/v1",
+        },
+    )
+
+    assert answered.status_code == 422
+    assert "public internet" in answered.text
+
+
+def test_an_endpoint_that_is_not_a_web_address_is_refused(client):
+    answered = client.post(
+        "/api/settings/models/check",
+        headers=_headers(),
+        json={
+            "model": "moonshot/kimi-k2.7-code",
+            "api_key": "a-key",
+            "base_url": "file:///etc/passwd",
+        },
+    )
+
+    assert answered.status_code == 422
+
+
+def test_a_provider_that_stops_answering_does_not_hold_the_request(client):
+    """Unbounded, one unresponsive endpoint keeps a thread until something else
+    gives up first."""
+    with patch("litellm.completion", return_value=object()) as called:
+        client.post(
+            "/api/settings/models/check",
+            headers=_headers(),
+            json={"model": "moonshot/kimi-k2.7-code", "api_key": "a-key"},
+        )
+
+    assert called.call_args.kwargs["timeout"] > 0
+
+
+def test_the_key_is_never_read_back(client):
+    """It is written like any other credential and answered with never, so it
+    cannot reach a log the first time somebody debugs this screen."""
+    with patch("litellm.completion", return_value=object()):
+        answered = client.post(
+            "/api/settings/models/check",
+            headers=_headers(),
+            json={"model": "moonshot/kimi-k2.7-code", "api_key": "sk-not-in-here"},
+        )
+
+    assert "sk-not-in-here" not in answered.text


### PR DESCRIPTION
Offer models from the router instead of a hand-written list that had gone stale.

Picking one now checks it against the key that will pay for it. An account can use only part of what a provider lists, and the gap otherwise shows up mid-scan.
