### PR TITLE
feat(jobs): Add a durable, fair queue the core owns

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -13,6 +13,7 @@ from src.utils.logger import logger
 from src.utils.migration_paths import migrations_root, resolve_version_locations
 from alembic.config import Config, CommandLine
 
+from src.cli.work_command import work_command
 from src.cli.index_commands import (
     index_command,
     repo_group,
@@ -97,6 +98,7 @@ cli.add_command(repo_group)
 cli.add_command(index_command)
 cli.add_command(requirements_group)
 cli.add_command(serve_command)
+cli.add_command(work_command)
 
 if __name__ == "__main__":
     cli()

--- a/src/cli/work_command.py
+++ b/src/cli/work_command.py
@@ -1,0 +1,50 @@
+"""The `sourceant work` command: one process doing background work.
+
+One job at a time. More at once is more of these, not more threads, because a
+worker has to be able to stop work that has gone on too long and a thread
+cannot be stopped. Running several is a matter for whatever starts them.
+"""
+
+import click
+
+from src.config.db import get_engine
+from src.core.jobs import WITHIN_SECONDS, LANES, job_store
+from src.core.jobs.worker import Worker
+from src.utils.logger import logger
+
+
+@click.command(name="work")
+@click.option(
+    "--lane",
+    default=WITHIN_SECONDS,
+    type=click.Choice(LANES),
+    help="Which promise this worker keeps. Lanes are named by how long work in "
+    "them may wait.",
+)
+@click.option("--name", default="", help="What this worker calls itself in the logs.")
+@click.option(
+    "--poll", default=1.0, help="Seconds between looks at the queue when it is empty."
+)
+@click.option(
+    "--max-jobs",
+    default=0,
+    help="Stop after this many jobs so a fresh process takes over. Zero never stops.",
+)
+@click.option(
+    "--max-time",
+    default=0.0,
+    help="Stop after this many seconds, for the same reason. Zero never stops.",
+)
+def work_command(lane, name, poll, max_jobs, max_time):
+    """Claim background work for one lane and do it."""
+    if get_engine() is None:
+        raise click.ClickException(
+            "There is no database here, so there is no queue to work. "
+            "Background work runs in the request that asked for it instead."
+        )
+
+    worker = Worker(job_store(), lane, name=name, poll_seconds=poll)
+    worker.attend()
+    logger.info(f"{worker.name} is working the {lane} lane")
+    done = worker.work(max_jobs=max_jobs, max_time=max_time)
+    logger.info(f"{worker.name} stopped after {done} jobs")

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from dotenv import load_dotenv
 
@@ -24,13 +25,33 @@ DATABASE_URL = os.getenv("DATABASE_URL")
 if not STATELESS_MODE and DATABASE_URL is None:
     DATABASE_URL = default_database_url()
 
+
+def whole_number(name: str, fallback: int) -> int:
+    """A positive whole number from the environment, or the fallback.
+
+    Read as the process starts, so anything that raises here stops a deployment
+    before it serves a request. A mistyped variable is worth a line in the log
+    and a sensible default, not a service that will not come up.
+    """
+    given = os.getenv(name, "")
+    try:
+        number = int(given)
+    except ValueError:
+        if given:
+            logging.getLogger(__name__).warning(
+                f"{name} is not a whole number, using {fallback}"
+            )
+        return fallback
+    return number if number > 0 else fallback
+
+
 REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
-REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
+REDIS_PORT = whole_number("REDIS_PORT", 6379)
 # 128K tokens - a conservative default compatible with most LLM providers
 DEFAULT_TOKEN_LIMIT = 131072
 
 LLM_MODEL = os.getenv("LLM_MODEL", "gemini/gemini-2.5-flash")
-LLM_TOKEN_LIMIT = int(os.getenv("LLM_TOKEN_LIMIT", DEFAULT_TOKEN_LIMIT))
+LLM_TOKEN_LIMIT = whole_number("LLM_TOKEN_LIMIT", DEFAULT_TOKEN_LIMIT)
 LOG_DRIVER: str = os.getenv("LOG_DRIVER", "console")
 LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO").upper()
 LOG_FILE: str = os.getenv("LOG_FILE", "sourceant.log")

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -42,7 +42,12 @@ def whole_number(name: str, fallback: int) -> int:
                 f"{name} is not a whole number, using {fallback}"
             )
         return fallback
-    return number if number > 0 else fallback
+    if number > 0:
+        return number
+    logging.getLogger(__name__).warning(
+        f"{name} must be greater than zero, using {fallback}"
+    )
+    return fallback
 
 
 REDIS_HOST = os.getenv("REDIS_HOST", "localhost")

--- a/src/core/jobs/__init__.py
+++ b/src/core/jobs/__init__.py
@@ -1,0 +1,170 @@
+"""Background work: asked for here, done somewhere else, and accounted for.
+
+Work is separated into lanes named by the latency they promise, so a scan that
+takes hours cannot sit in front of a webhook that has seconds. Within a lane
+every tenant takes an equal turn up to a fixed cap, so one customer's backlog
+cannot starve another's.
+
+A claim on a job is a lease rather than a promise. A worker that is killed
+writes nothing, so nothing running inside it could be what recovers its work:
+instead the claim simply lapses and the next poll offers the job again. That is
+also why delivery is at least once, and why work that must not be repeated says
+so with `max_attempts=1` rather than hoping.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from src.config.db import get_engine
+from src.core.services import ServiceRegistry, service_registry
+from src.utils.logger import logger
+
+from .backoff import after as backoff_after
+from .fairness import share
+from .interfaces import (
+    JobAdmin,
+    JobBatches,
+    JobHandler,
+    JobMiddleware,
+    JobQueue,
+    JobStore,
+    JobWakeup,
+)
+from .memory import InMemoryJobQueue, InMemoryJobStore
+from .models import (
+    BY_NOBODY,
+    BY_REPOSITORY,
+    BY_WORKSPACE,
+    CANCELLED,
+    DEAD,
+    FAILED,
+    LANES,
+    QUEUED,
+    RUNNING,
+    SUCCEEDED,
+    WITHIN_HOURS,
+    WITHIN_MINUTES,
+    WITHIN_SECONDS,
+    Batch,
+    Candidate,
+    Job,
+    JobOutcome,
+    JobRequest,
+    Lease,
+)
+from .sql import SQLJobStore
+
+_core = None
+
+
+def _default():
+    """The core's own store, built the first time anything asks for one.
+
+    A deployment with a database gets the durable one. A machine running
+    without one still gets a working queue, in this process only, because
+    refusing to accept work is worse than accepting it without durability
+    somewhere that never had any to begin with.
+    """
+    global _core
+    if _core is None:
+        engine = get_engine()
+        if engine is None:
+            logger.info("No database, so background work is kept in this process only.")
+            _core = InMemoryJobStore()
+        else:
+            _core = SQLJobStore(engine, create_schema=True)
+    return _core
+
+
+def job_store(services: ServiceRegistry = service_registry) -> JobStore:
+    """Whatever registered as a store, else the core's own."""
+    try:
+        return services.resolve(JobStore)
+    except LookupError:
+        return _default()
+
+
+def job_queue(services: ServiceRegistry = service_registry) -> JobQueue:
+    """Whatever registered as a queue, else whatever is storing the jobs."""
+    try:
+        return services.resolve(JobQueue)
+    except LookupError:
+        return job_store(services)
+
+
+def enqueue(
+    request: JobRequest,
+    *,
+    session: Any = None,
+    services: ServiceRegistry = service_registry,
+) -> int:
+    """Ask for work, in the caller's transaction where one is given."""
+    return job_queue(services).enqueue(request, session=session)
+
+
+def handlers(services: ServiceRegistry = service_registry) -> tuple[JobHandler, ...]:
+    """Every handler contributed, whatever it came from.
+
+    Contributed rather than registered, because handlers are additive: a plugin
+    adding one is not answering a question the core already had an answer to.
+    """
+    return services.contributions(JobHandler)
+
+
+def handler_for(
+    kind: str, services: ServiceRegistry = service_registry
+) -> Optional[JobHandler]:
+    """The handler for one kind of work, or None when nothing claims it."""
+    for handler in handlers(services):
+        if getattr(handler, "kind", None) == kind:
+            return handler
+    return None
+
+
+def middleware(
+    services: ServiceRegistry = service_registry,
+) -> tuple[JobMiddleware, ...]:
+    """Everything wrapped around a handler before it runs."""
+    return services.contributions(JobMiddleware)
+
+
+__all__ = [
+    "BY_NOBODY",
+    "BY_REPOSITORY",
+    "BY_WORKSPACE",
+    "Batch",
+    "CANCELLED",
+    "Candidate",
+    "DEAD",
+    "FAILED",
+    "InMemoryJobQueue",
+    "InMemoryJobStore",
+    "Job",
+    "JobAdmin",
+    "JobBatches",
+    "JobHandler",
+    "JobMiddleware",
+    "JobOutcome",
+    "JobQueue",
+    "JobRequest",
+    "JobStore",
+    "JobWakeup",
+    "LANES",
+    "Lease",
+    "QUEUED",
+    "RUNNING",
+    "SQLJobStore",
+    "SUCCEEDED",
+    "WITHIN_HOURS",
+    "WITHIN_MINUTES",
+    "WITHIN_SECONDS",
+    "backoff_after",
+    "enqueue",
+    "handler_for",
+    "handlers",
+    "job_queue",
+    "job_store",
+    "middleware",
+    "share",
+]

--- a/src/core/jobs/__init__.py
+++ b/src/core/jobs/__init__.py
@@ -55,6 +55,7 @@ from .models import (
     Lease,
 )
 from .sql import SQLJobStore
+from .sweep import Sweeper
 from .worker import Worker
 
 _core = None
@@ -159,6 +160,7 @@ __all__ = [
     "RateLimited",
     "SQLJobStore",
     "SUCCEEDED",
+    "Sweeper",
     "Throttled",
     "WITHIN_HOURS",
     "WITHIN_MINUTES",

--- a/src/core/jobs/__init__.py
+++ b/src/core/jobs/__init__.py
@@ -32,6 +32,7 @@ from .interfaces import (
     JobWakeup,
 )
 from .memory import InMemoryJobQueue, InMemoryJobStore
+from .middleware import RateLimited, Throttled
 from .models import (
     BY_NOBODY,
     BY_REPOSITORY,
@@ -54,6 +55,7 @@ from .models import (
     Lease,
 )
 from .sql import SQLJobStore
+from .worker import Worker
 
 _core = None
 
@@ -154,11 +156,14 @@ __all__ = [
     "Lease",
     "QUEUED",
     "RUNNING",
+    "RateLimited",
     "SQLJobStore",
     "SUCCEEDED",
+    "Throttled",
     "WITHIN_HOURS",
     "WITHIN_MINUTES",
     "WITHIN_SECONDS",
+    "Worker",
     "backoff_after",
     "enqueue",
     "handler_for",

--- a/src/core/jobs/backoff.py
+++ b/src/core/jobs/backoff.py
@@ -1,0 +1,34 @@
+"""How long to wait before trying a job again.
+
+Kept apart from both stores so the two cannot drift, and pure so the numbers
+can be asserted rather than observed.
+"""
+
+from __future__ import annotations
+
+import random
+
+BASE_SECONDS = 5
+CEILING_SECONDS = 3600
+
+
+def after(
+    attempt: int,
+    *,
+    base: int = BASE_SECONDS,
+    ceiling: int = CEILING_SECONDS,
+    jitter: bool = True,
+) -> int:
+    """Seconds to wait after `attempt` failures.
+
+    Doubling, up to a ceiling, with jitter. The jitter is not decoration: a
+    provider that refused ten jobs at once refused them at the same instant, and
+    without it all ten would come back at the same instant too and be refused
+    again together.
+    """
+    if attempt <= 0:
+        return 0
+    doubled = min(base * (2 ** (attempt - 1)), ceiling)
+    if not jitter:
+        return doubled
+    return random.randint(doubled // 2 or 1, doubled)

--- a/src/core/jobs/fairness.py
+++ b/src/core/jobs/fairness.py
@@ -1,0 +1,96 @@
+"""Choosing which queued jobs to run next, and for whom.
+
+This is the whole of the fairness rule, and it touches nothing. It
+is given what is queued, what is already running and what may not overlap, and
+it answers with job ids. That makes the rule readable on its own and testable
+without a database, which matters because "one customer starved another" is not
+something anybody wants to be debugging against live data.
+
+The rule: every tenant gets an equal share, capped. Not a share proportional to
+what they asked for, which would let whoever enqueued most win, and not first
+come first served, which is the same thing said differently.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Optional, Sequence
+
+from .models import Candidate
+
+#: Stands in for a tenant nothing has run for yet, so they sort ahead of
+#: everyone who has already had a turn.
+NEVER = float("-inf")
+
+
+def share(
+    candidates: Sequence[Candidate],
+    *,
+    busy: Mapping[str, int],
+    cap: int,
+    budget: int,
+    last_served: Optional[Mapping[str, float]] = None,
+    held: Optional[Iterable[str]] = None,
+) -> tuple[int, ...]:
+    """Which of `candidates` to claim now, in the order to claim them.
+
+    `candidates` arrives in the order the database offered it, which is by
+    priority and then by age, and that order is kept within each tenant so a
+    tenant's own work stays first in first out.
+
+    Tenants take turns, least recently served first. A tenant with one job
+    waiting is served on the first rotation rather than behind another tenant's
+    five hundred, which is the entire point.
+
+    A job whose `exclusive_key` is already held is passed over rather than
+    blocking its tenant, because otherwise one busy repository stops every
+    other repository belonging to the same customer.
+    """
+    if budget <= 0 or cap <= 0 or not candidates:
+        return ()
+
+    served = last_served or {}
+    taken_keys = set(held or ())
+    by_tenant: dict[str, list[Candidate]] = {}
+    for candidate in candidates:
+        by_tenant.setdefault(candidate.tenant, []).append(candidate)
+
+    # Least recently served first. Where two tenants have never been served, or
+    # were served at the same moment, the one whose oldest job is older goes
+    # first, which keeps the answer stable rather than dependent on dict order.
+    def turn(tenant: str) -> tuple[float, int]:
+        return (served.get(tenant, NEVER), by_tenant[tenant][0].id)
+
+    order = sorted(by_tenant, key=turn)
+    cursors = {tenant: 0 for tenant in order}
+    taken: dict[str, int] = {}
+    chosen: list[int] = []
+
+    while len(chosen) < budget:
+        progressed = False
+        for tenant in order:
+            if len(chosen) >= budget:
+                break
+            if busy.get(tenant, 0) + taken.get(tenant, 0) >= cap:
+                continue
+
+            queue = by_tenant[tenant]
+            index = cursors[tenant]
+            while index < len(queue):
+                candidate = queue[index]
+                index += 1
+                if candidate.exclusive_key and candidate.exclusive_key in taken_keys:
+                    continue
+                if candidate.exclusive_key:
+                    taken_keys.add(candidate.exclusive_key)
+                chosen.append(candidate.id)
+                taken[tenant] = taken.get(tenant, 0) + 1
+                progressed = True
+                break
+            cursors[tenant] = index
+
+        # Nothing was takeable anywhere on a full rotation, so going round again
+        # would only produce the same answer more slowly.
+        if not progressed:
+            break
+
+    return tuple(chosen)

--- a/src/core/jobs/interfaces.py
+++ b/src/core/jobs/interfaces.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Any, Optional, Protocol, Sequence, runtime_checkable
+
+from .models import Batch, Job, JobOutcome, JobRequest, Lease
+
+
+@runtime_checkable
+class JobQueue(Protocol):
+    """Where work is asked for.
+
+    `session` exists so an enqueue can join the caller's transaction. A row
+    written and then enqueued outside it leaves the two able to disagree: the
+    row says queued and nothing is coming for it. Implementations that have no
+    transaction to join accept the argument and ignore it.
+    """
+
+    def enqueue(self, request: JobRequest, *, session: Any = None) -> int: ...
+
+
+@runtime_checkable
+class JobStore(Protocol):
+    """Where work is kept, claimed and finished.
+
+    Delivery is at least once. A worker can die between finishing the work and
+    recording that it finished, and no amount of care here changes that, so a
+    handler that must not run twice says so with `max_attempts=1` rather than
+    assuming.
+    """
+
+    def claim(self, lane: str, worker: str, budget: int) -> Sequence[Lease]: ...
+
+    def heartbeat(self, lease: Lease) -> bool: ...
+
+    def finish(self, lease: Lease, outcome: JobOutcome) -> None: ...
+
+    def release(self, lease: Lease, *, delay_seconds: int = 0) -> None: ...
+
+
+@runtime_checkable
+class JobHandler(Protocol):
+    """Something that does one kind of work.
+
+    `kind` is matched against the job's own, so a plugin contributes handlers
+    without the core knowing what they are for.
+    """
+
+    kind: str
+
+    def run(self, job: Job) -> JobOutcome: ...
+
+
+@runtime_checkable
+class JobMiddleware(Protocol):
+    """Something wrapped around a handler.
+
+    Concerns like refusing to overlap, or backing off after repeated refusals
+    from a provider, are the same whatever the work is. Composing them here
+    keeps them out of both the handler and the table, and lets a plugin add its
+    own without a schema change.
+
+    Returning None from `before` lets the work proceed. Returning an outcome
+    stops it and is recorded as that outcome, which is how a job that cannot
+    take its lock puts itself back in the queue.
+    """
+
+    def before(self, job: Job) -> Optional[JobOutcome]: ...
+
+    def after(self, job: Job, outcome: JobOutcome) -> JobOutcome: ...
+
+
+@runtime_checkable
+class JobBatches(Protocol):
+    """Progress across several jobs asked for together."""
+
+    def open(self, name: str, total: int, *, tenant: str = "") -> Batch: ...
+
+    def record(self, batch_id: int, *, failed: bool = False) -> Optional[Batch]: ...
+
+    def read_batch(self, batch_id: int) -> Optional[Batch]: ...
+
+
+@runtime_checkable
+class JobWakeup(Protocol):
+    """Being told a job arrived rather than asking.
+
+    Optional on purpose. Only some databases can push, and a store that cannot
+    is not deficient: polling with a jittered interval is the contract, and
+    this only ever shortens the wait.
+    """
+
+    def wait(self, lane: str, timeout: float) -> bool: ...
+
+
+@runtime_checkable
+class JobAdmin(Protocol):
+    """Reading and steering the queue from outside a worker."""
+
+    def pending(self, lane: str = "", limit: int = 100) -> Sequence[Job]: ...
+
+    def cancel(self, job_id: int) -> bool: ...
+
+    def retry(self, job_id: int) -> bool: ...

--- a/src/core/jobs/memory.py
+++ b/src/core/jobs/memory.py
@@ -1,0 +1,356 @@
+"""Keeping jobs in this process only.
+
+This is the reference for how the queue behaves. The database-backed store has
+to agree with it, and the tests that pin the behaviour run against both, so
+anywhere the two differ is a bug in one of them rather than a detail of the
+storage.
+
+It also serves a deployment that has no database, where background work is done
+in the request that asked for it and durability is neither offered nor wanted.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from threading import RLock
+from typing import Any, Optional, Sequence
+
+from . import backoff
+from .fairness import share
+from .models import (
+    CANCELLED,
+    DEAD,
+    FAILED,
+    QUEUED,
+    RUNNING,
+    SUCCEEDED,
+    Batch,
+    Candidate,
+    Job,
+    JobOutcome,
+    JobRequest,
+    Lease,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class InMemoryJobStore:
+    """Jobs, locks and batches held in this process.
+
+    Everything is guarded by one lock. Contention is not a concern here: a
+    process that needed more than one lock's worth of throughput would be one
+    that ought to be using the database-backed store.
+    """
+
+    def __init__(self, *, lease_seconds: int = 60, cap: int = 3, now=_now) -> None:
+        self._lease_seconds = lease_seconds
+        self._cap = cap
+        self._now = now
+        self._lock = RLock()
+        self._jobs: dict[int, dict] = {}
+        self._locks: dict[str, dict] = {}
+        self._batches: dict[int, Batch] = {}
+        self._next_id = 1
+        self._next_batch = 1
+
+    def enqueue(self, request: JobRequest, *, session: Any = None) -> int:
+        """Write a job down and answer with its id.
+
+        `session` is accepted and ignored. Nothing here is transactional, so
+        there is no transaction to join, but a caller should not have to know
+        which store it is talking to.
+        """
+        with self._lock:
+            slot = request.dedupe_slot
+            if slot:
+                for row in self._jobs.values():
+                    if row["dedupe_slot"] == slot and row["state"] == QUEUED:
+                        return row["id"]
+            job_id = self._next_id
+            self._next_id += 1
+            now = self._now()
+            self._jobs[job_id] = {
+                "id": job_id,
+                "lane": request.lane,
+                "kind": request.kind,
+                "payload": dict(request.payload),
+                "state": QUEUED,
+                "tenant": request.tenant,
+                "tenant_kind": request.tenant_kind,
+                "scope_id": request.scope_id,
+                "priority": request.priority,
+                "attempt": 0,
+                "max_attempts": request.max_attempts,
+                "deadline_seconds": request.deadline_seconds,
+                "exclusive_key": request.exclusive_key,
+                "dedupe_slot": slot or f"job:{uuid.uuid4()}",
+                "batch_id": request.batch_id,
+                "available_at": now + timedelta(seconds=request.delay_seconds),
+                "lease_until": None,
+                "leased_by": None,
+                "claimed_at": None,
+                "error": "",
+                "created_at": now,
+            }
+            return job_id
+
+    def claim(self, lane: str, worker: str, budget: int) -> Sequence[Lease]:
+        """Take up to `budget` jobs for this worker, fairly.
+
+        A running job whose lease has lapsed is offered alongside the queued
+        ones. That is what recovers work from a worker that was killed, and it
+        happens on an ordinary poll rather than needing anything scheduled.
+        """
+        with self._lock:
+            now = self._now()
+            busy: dict[str, int] = {}
+            held: set[str] = set()
+            last_served: dict[str, float] = {}
+            for row in self._jobs.values():
+                if row["state"] != RUNNING or not self._held(row, now):
+                    continue
+                busy[row["tenant"]] = busy.get(row["tenant"], 0) + 1
+                if row["exclusive_key"]:
+                    held.add(row["exclusive_key"])
+                claimed = row.get("claimed_at")
+                if claimed:
+                    stamp = claimed.timestamp()
+                    if stamp > last_served.get(row["tenant"], float("-inf")):
+                        last_served[row["tenant"]] = stamp
+
+            for key, lock in list(self._locks.items()):
+                if lock["expires_at"] > now:
+                    held.add(key)
+                else:
+                    del self._locks[key]
+
+            offered = [
+                row
+                for row in self._jobs.values()
+                if row["lane"] == lane and self._takeable(row, now)
+            ]
+            offered.sort(key=lambda row: (-row["priority"], row["id"]))
+            candidates = [
+                Candidate(row["id"], row["tenant"], row["exclusive_key"])
+                for row in offered
+            ]
+
+            chosen = share(
+                candidates,
+                busy=busy,
+                cap=self._cap,
+                budget=budget,
+                last_served=last_served,
+                held=held,
+            )
+
+            leases: list[Lease] = []
+            for job_id in chosen:
+                row = self._jobs[job_id]
+                if not self._takeable(row, now):
+                    continue
+                key = row["exclusive_key"]
+                if key and not self._take_lock(key, job_id, now):
+                    continue
+                row["state"] = RUNNING
+                row["attempt"] += 1
+                row["leased_by"] = worker
+                row["claimed_at"] = now
+                row["lease_until"] = now + timedelta(seconds=self._lease_seconds)
+                leases.append(
+                    Lease(job=self._read(row), worker=worker, until=row["lease_until"])
+                )
+            return leases
+
+    def heartbeat(self, lease: Lease) -> bool:
+        """Extend a claim, and say whether it was still ours to extend.
+
+        A false answer means the lease lapsed and somebody else has the job, so
+        the work must stop rather than finish into a row it no longer owns.
+        """
+        with self._lock:
+            row = self._jobs.get(lease.job.id)
+            if row is None or row["state"] != RUNNING:
+                return False
+            if row["leased_by"] != lease.worker:
+                return False
+            now = self._now()
+            row["lease_until"] = now + timedelta(seconds=self._lease_seconds)
+            key = row["exclusive_key"]
+            if key and key in self._locks and self._locks[key]["job_id"] == row["id"]:
+                self._locks[key]["expires_at"] = row["lease_until"]
+            return True
+
+    def finish(self, lease: Lease, outcome: JobOutcome) -> None:
+        """Record how a job ended, and queue it again where that is wanted."""
+        with self._lock:
+            row = self._jobs.get(lease.job.id)
+            if row is None or row["leased_by"] != lease.worker:
+                return
+            now = self._now()
+            self._drop_lock(row)
+            if outcome.succeeded:
+                row["state"] = SUCCEEDED
+                row["error"] = ""
+                self._settle(row, failed=False)
+            elif outcome.retry and row["attempt"] < row["max_attempts"]:
+                wait = outcome.retry_in
+                if wait is None:
+                    wait = backoff.after(row["attempt"])
+                row["state"] = QUEUED
+                row["error"] = outcome.error
+                row["available_at"] = now + timedelta(seconds=wait)
+            else:
+                exhausted = row["attempt"] >= row["max_attempts"]
+                row["state"] = DEAD if exhausted else FAILED
+                row["error"] = outcome.error
+                self._settle(row, failed=True)
+            row["lease_until"] = None
+            row["leased_by"] = None
+
+    def release(self, lease: Lease, *, delay_seconds: int = 0) -> None:
+        """Hand a claim back without counting it as an attempt.
+
+        Used when a job was taken but could not start, which is not the same as
+        having tried and failed.
+        """
+        with self._lock:
+            row = self._jobs.get(lease.job.id)
+            if row is None or row["leased_by"] != lease.worker:
+                return
+            self._drop_lock(row)
+            row["state"] = QUEUED
+            row["attempt"] = max(0, row["attempt"] - 1)
+            row["leased_by"] = None
+            row["lease_until"] = None
+            row["available_at"] = self._now() + timedelta(seconds=delay_seconds)
+
+    def open(self, name: str, total: int, *, tenant: str = "") -> Batch:
+        with self._lock:
+            batch = Batch(
+                id=self._next_batch,
+                name=name,
+                total=total,
+                pending=total,
+                tenant=tenant,
+            )
+            self._batches[batch.id] = batch
+            self._next_batch += 1
+            return batch
+
+    def record(self, batch_id: int, *, failed: bool = False) -> Optional[Batch]:
+        with self._lock:
+            batch = self._batches.get(batch_id)
+            if batch is None:
+                return None
+            pending = max(0, batch.pending - 1)
+            from dataclasses import replace
+
+            updated = replace(
+                batch,
+                pending=pending,
+                failed=batch.failed + (1 if failed else 0),
+                finished_at=self._now() if pending == 0 else batch.finished_at,
+            )
+            self._batches[batch_id] = updated
+            return updated
+
+    def read_batch(self, batch_id: int) -> Optional[Batch]:
+        with self._lock:
+            return self._batches.get(batch_id)
+
+    def read(self, job_id: int) -> Optional[Job]:
+        with self._lock:
+            row = self._jobs.get(job_id)
+            return None if row is None else self._read(row)
+
+    def pending(self, lane: str = "", limit: int = 100) -> Sequence[Job]:
+        with self._lock:
+            rows = [
+                row
+                for row in self._jobs.values()
+                if row["state"] == QUEUED and (not lane or row["lane"] == lane)
+            ]
+            rows.sort(key=lambda row: (-row["priority"], row["id"]))
+            return [self._read(row) for row in rows[:limit]]
+
+    def cancel(self, job_id: int) -> bool:
+        with self._lock:
+            row = self._jobs.get(job_id)
+            if row is None or row["state"] != QUEUED:
+                return False
+            row["state"] = CANCELLED
+            return True
+
+    def _takeable(self, row: dict, now: datetime) -> bool:
+        """Queued and due, or running on a lease that has lapsed."""
+        if row["state"] == QUEUED:
+            return row["available_at"] <= now
+        return row["state"] == RUNNING and not self._held(row, now)
+
+    @staticmethod
+    def _held(row: dict, now: datetime) -> bool:
+        """Whether a running job's claim is still good.
+
+        A claim that has lapsed is not a job somebody is doing. It is a job
+        whose worker is most likely gone, which is why the claim query offers
+        it again rather than waiting for anything to notice.
+        """
+        until = row.get("lease_until")
+        return bool(until and until > now)
+
+    def _take_lock(self, key: str, job_id: int, now: datetime) -> bool:
+        held = self._locks.get(key)
+        if held and held["expires_at"] > now and held["job_id"] != job_id:
+            return False
+        self._locks[key] = {
+            "job_id": job_id,
+            "taken_at": now,
+            "expires_at": now + timedelta(seconds=self._lease_seconds),
+        }
+        return True
+
+    def _drop_lock(self, row: dict) -> None:
+        key = row["exclusive_key"]
+        if key and self._locks.get(key, {}).get("job_id") == row["id"]:
+            del self._locks[key]
+
+    def _settle(self, row: dict, *, failed: bool) -> None:
+        if row["batch_id"]:
+            self.record(row["batch_id"], failed=failed)
+        # A finished job releases its dedupe key, so the same work can be
+        # asked for again.
+        row["dedupe_slot"] = f"job:{uuid.uuid4()}"
+
+    @staticmethod
+    def _read(row: dict) -> Job:
+        return Job(
+            id=row["id"],
+            lane=row["lane"],
+            kind=row["kind"],
+            payload=dict(row["payload"]),
+            state=row["state"],
+            tenant=row["tenant"],
+            tenant_kind=row["tenant_kind"],
+            scope_id=row["scope_id"],
+            priority=row["priority"],
+            attempt=row["attempt"],
+            max_attempts=row["max_attempts"],
+            deadline_seconds=row["deadline_seconds"],
+            exclusive_key=row["exclusive_key"],
+            dedupe_slot=row["dedupe_slot"],
+            batch_id=row["batch_id"],
+            available_at=row["available_at"],
+            lease_until=row["lease_until"],
+            leased_by=row["leased_by"],
+            error=row["error"],
+        )
+
+
+#: One object satisfies both asking for work and taking it, so a test or a
+#: single-process deployment needs only this.
+InMemoryJobQueue = InMemoryJobStore

--- a/src/core/jobs/memory.py
+++ b/src/core/jobs/memory.py
@@ -306,6 +306,11 @@ class InMemoryJobStore:
             if row is None or row["state"] != QUEUED:
                 return False
             row["state"] = CANCELLED
+            # Cancelled is an ending like any other: it releases the key so the
+            # same work can be asked for again, and it is dated so that tidying
+            # up eventually reaches it.
+            row["finished_at"] = self._now()
+            row["dedupe_slot"] = f"job:{uuid.uuid4()}"
             return True
 
     def _takeable(self, row: dict, now: datetime) -> bool:

--- a/src/core/jobs/memory.py
+++ b/src/core/jobs/memory.py
@@ -95,6 +95,7 @@ class InMemoryJobStore:
                 "claimed_at": None,
                 "error": "",
                 "created_at": now,
+                "finished_at": None,
             }
             return job_id
 
@@ -196,6 +197,7 @@ class InMemoryJobStore:
             if outcome.succeeded:
                 row["state"] = SUCCEEDED
                 row["error"] = ""
+                row["finished_at"] = now
                 self._settle(row, failed=False)
             elif outcome.retry and row["attempt"] < row["max_attempts"]:
                 wait = outcome.retry_in
@@ -208,6 +210,7 @@ class InMemoryJobStore:
                 exhausted = row["attempt"] >= row["max_attempts"]
                 row["state"] = DEAD if exhausted else FAILED
                 row["error"] = outcome.error
+                row["finished_at"] = now
                 self._settle(row, failed=True)
             row["lease_until"] = None
             row["leased_by"] = None
@@ -277,6 +280,25 @@ class InMemoryJobStore:
             ]
             rows.sort(key=lambda row: (-row["priority"], row["id"]))
             return [self._read(row) for row in rows[:limit]]
+
+    def prune(self, keep_finished_for_days: int = 14) -> int:
+        """Clear away jobs finished long enough ago to be of no interest."""
+        with self._lock:
+            now = self._now()
+            cleared = 0
+            if keep_finished_for_days > 0:
+                cutoff = now - timedelta(days=keep_finished_for_days)
+                for job_id, row in list(self._jobs.items()):
+                    finished = row.get("finished_at")
+                    if row["state"] in (SUCCEEDED, FAILED, DEAD, CANCELLED) and (
+                        finished is not None and finished < cutoff
+                    ):
+                        del self._jobs[job_id]
+                        cleared += 1
+            for key, lock in list(self._locks.items()):
+                if lock["expires_at"] <= now:
+                    del self._locks[key]
+            return cleared
 
     def cancel(self, job_id: int) -> bool:
         with self._lock:

--- a/src/core/jobs/middleware.py
+++ b/src/core/jobs/middleware.py
@@ -1,0 +1,105 @@
+"""Things wrapped around a handler, rather than written into every one of them.
+
+Refusing to overlap is not here. It has to be decided at the moment a job is
+claimed, or a job that cannot have its lock would be claimed and then handed
+straight back, so the store does it. What is here is everything that can only
+be decided once a job is about to run.
+
+A plugin contributes its own the same way it contributes a handler, so a
+concern that matters to one kind of work does not become a column everybody
+else carries.
+"""
+
+from __future__ import annotations
+
+from threading import RLock
+from time import monotonic
+from typing import Optional
+
+from src.utils.logger import logger
+
+from .models import Job, JobOutcome
+
+
+class Throttled:
+    """Stops asking a provider that has just refused us several times.
+
+    A rate limit reached by one job is reached by the next twenty, and trying
+    them anyway turns one refusal into twenty. Worse, with a customer's own key
+    paying, those attempts spend somebody's quota to learn what the first one
+    already said.
+
+    Failures are counted per key, which is usually the tenant, so one
+    customer's exhausted quota does not stop anybody else's work.
+    """
+
+    def __init__(
+        self, *, allowance: int = 5, window: float = 60.0, pause: float = 60.0
+    ):
+        self._allowance = allowance
+        self._window = window
+        self._pause = pause
+        self._lock = RLock()
+        self._failures: dict[str, list[float]] = {}
+        self._paused_until: dict[str, float] = {}
+
+    def _key(self, job: Job) -> str:
+        return job.tenant or job.kind
+
+    def before(self, job: Job) -> Optional[JobOutcome]:
+        with self._lock:
+            until = self._paused_until.get(self._key(job), 0.0)
+            waiting = until - monotonic()
+        if waiting <= 0:
+            return None
+        logger.info(f"Holding {job.kind} for {int(waiting)}s after repeated refusals")
+        return JobOutcome.failed(
+            "held back after repeated refusals", retry=True, retry_in=int(waiting) + 1
+        )
+
+    def after(self, job: Job, outcome: JobOutcome) -> JobOutcome:
+        key = self._key(job)
+        now = monotonic()
+        with self._lock:
+            if outcome.succeeded:
+                self._failures.pop(key, None)
+                return outcome
+            recent = [
+                at for at in self._failures.get(key, []) if now - at < self._window
+            ]
+            recent.append(now)
+            self._failures[key] = recent
+            if len(recent) >= self._allowance:
+                self._paused_until[key] = now + self._pause
+                self._failures[key] = []
+                logger.warning(
+                    f"{key} refused {len(recent)} times; pausing it for {self._pause}s"
+                )
+        return outcome
+
+
+class RateLimited:
+    """Keeps a key under a fixed number of starts in a window."""
+
+    def __init__(self, *, starts: int = 60, window: float = 60.0):
+        self._starts = starts
+        self._window = window
+        self._lock = RLock()
+        self._seen: dict[str, list[float]] = {}
+
+    def before(self, job: Job) -> Optional[JobOutcome]:
+        key = job.tenant or job.kind
+        now = monotonic()
+        with self._lock:
+            recent = [at for at in self._seen.get(key, []) if now - at < self._window]
+            if len(recent) >= self._starts:
+                oldest = recent[0]
+                self._seen[key] = recent
+                wait = int(self._window - (now - oldest)) + 1
+                return JobOutcome.failed("rate limited", retry=True, retry_in=wait)
+            recent.append(now)
+            self._seen[key] = recent
+        return None
+
+    def after(self, job: Job, outcome: JobOutcome) -> JobOutcome:
+        return outcome

--- a/src/core/jobs/models.py
+++ b/src/core/jobs/models.py
@@ -1,0 +1,177 @@
+"""A unit of background work, and what is known about it.
+
+Nothing here touches a database or a queue. These are the shapes the rest of
+the subsystem passes around, so that the fairness rules and the tests that
+cover them can run without either.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Mapping, Optional
+
+# Lanes are named by the latency they promise rather than by what runs in
+# them, so picking one answers how long the work may wait.
+WITHIN_SECONDS = "within_seconds"
+WITHIN_MINUTES = "within_minutes"
+WITHIN_HOURS = "within_hours"
+
+LANES: tuple[str, ...] = (WITHIN_SECONDS, WITHIN_MINUTES, WITHIN_HOURS)
+
+QUEUED = "queued"
+RUNNING = "running"
+SUCCEEDED = "succeeded"
+FAILED = "failed"
+DEAD = "dead"
+CANCELLED = "cancelled"
+
+# What a tenant string stands for. A delivery for a repository nobody has
+# connected still has to be fair against other such repositories, so "none" is
+# a last resort rather than the usual case.
+BY_WORKSPACE = "workspace"
+BY_REPOSITORY = "repository"
+BY_NOBODY = "none"
+
+
+@dataclass(frozen=True)
+class JobRequest:
+    """Work asked for, before anything has been written down.
+
+    `deadline_seconds` is not the lease. A lease says how long a claim stays
+    good without word from the worker. A deadline says when the work itself has
+    gone on too long. Treat them as one and you get either a healthy job killed
+    or a hung job renewing its claim for ever.
+    """
+
+    lane: str
+    kind: str
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    tenant: str = ""
+    tenant_kind: str = BY_NOBODY
+    scope_id: Optional[int] = None
+    priority: int = 0
+    delay_seconds: int = 0
+    deadline_seconds: int = 300
+    max_attempts: int = 1
+    #: A key at most one running job may hold. Where two jobs would tread on the
+    #: same files, the second waits rather than both proceeding.
+    exclusive_key: Optional[str] = None
+    #: A key at most one *queued* job may occupy. Left unset, the job gets one
+    #: of its own so it never collides with anything.
+    dedupe_slot: Optional[str] = None
+    batch_id: Optional[int] = None
+
+    def for_(self, tenant: Optional[str], kind: str = BY_WORKSPACE) -> "JobRequest":
+        """The same request, attributed to whoever it is for.
+
+        A tenant that cannot be worked out is not an error. It means this job
+        shares a bucket with every other unattributed job, which is worse for
+        it than being named but better than being invisible to the share.
+        """
+        from dataclasses import replace
+
+        if not tenant:
+            return replace(self, tenant="", tenant_kind=BY_NOBODY)
+        return replace(self, tenant=str(tenant), tenant_kind=kind)
+
+
+@dataclass(frozen=True)
+class Job:
+    """A job as it stands now, read back from wherever it is kept."""
+
+    id: int
+    lane: str
+    kind: str
+    payload: Mapping[str, Any]
+    state: str
+    tenant: str = ""
+    tenant_kind: str = BY_NOBODY
+    scope_id: Optional[int] = None
+    priority: int = 0
+    attempt: int = 0
+    max_attempts: int = 1
+    deadline_seconds: int = 300
+    exclusive_key: Optional[str] = None
+    dedupe_slot: str = ""
+    batch_id: Optional[int] = None
+    available_at: Optional[datetime] = None
+    lease_until: Optional[datetime] = None
+    leased_by: Optional[str] = None
+    error: str = ""
+
+    @property
+    def exhausted(self) -> bool:
+        """Whether another attempt is allowed after this one."""
+        return self.attempt >= self.max_attempts
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """The little of a queued job that choosing between jobs needs.
+
+    Kept separate from `Job` so a poll can read three columns rather than every
+    payload it is not going to run.
+    """
+
+    id: int
+    tenant: str
+    exclusive_key: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class Lease:
+    """A claim on a job, good until it is renewed or it lapses."""
+
+    job: Job
+    worker: str
+    until: datetime
+
+
+@dataclass(frozen=True)
+class JobOutcome:
+    """How a job ended, and whether it should be tried again.
+
+    `retry_in` overrides the usual backoff, which is what lets a provider's own
+    `Retry-After` be honoured instead of guessed at.
+    """
+
+    succeeded: bool
+    error: str = ""
+    retry: bool = False
+    retry_in: Optional[int] = None
+
+    @staticmethod
+    def ok() -> "JobOutcome":
+        return JobOutcome(succeeded=True)
+
+    @staticmethod
+    def failed(error: str, *, retry: bool = False, retry_in: Optional[int] = None):
+        return JobOutcome(succeeded=False, error=error, retry=retry, retry_in=retry_in)
+
+
+@dataclass(frozen=True)
+class Batch:
+    """Several jobs asked for together, so their progress can be read as one.
+
+    Counting is what this is for. Seven repositories initialised at once should
+    read as "two of seven done" rather than as seven unrelated rows, six of
+    which look like nothing is happening.
+    """
+
+    id: int
+    name: str
+    total: int = 0
+    pending: int = 0
+    failed: int = 0
+    tenant: str = ""
+    cancelled_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+
+    @property
+    def done(self) -> int:
+        return self.total - self.pending
+
+    @property
+    def finished(self) -> bool:
+        return self.pending <= 0

--- a/src/core/jobs/sql.py
+++ b/src/core/jobs/sql.py
@@ -639,11 +639,19 @@ class SQLJobStore:
 
     def cancel(self, job_id: int) -> bool:
         with self._engine.begin() as connection:
+            now = self._clock(connection)
             return (
                 connection.execute(
                     update(job_table)
                     .where(and_(job_table.c.id == job_id, job_table.c.state == QUEUED))
-                    .values(state=CANCELLED)
+                    .values(
+                        state=CANCELLED,
+                        # Cancelled is an ending like any other: it releases the
+                        # key so the same work can be asked for again, and it is
+                        # dated so that tidying up eventually reaches it.
+                        finished_at=now,
+                        dedupe_slot=f"job:{uuid.uuid4()}",
+                    )
                 ).rowcount
                 == 1
             )

--- a/src/core/jobs/sql.py
+++ b/src/core/jobs/sql.py
@@ -1,0 +1,651 @@
+"""Keeping jobs in the deployment's own database.
+
+The queue lives in the same database as everything else on purpose. A job and
+the row it is about are then written in one transaction, so the two can never
+disagree about whether work was asked for, and a job survives anything the
+database survives.
+
+Correctness rests on a compare and swap rather than on locking. `FOR UPDATE
+SKIP LOCKED` is added where the dialect has it, but only to save wasted work:
+two workers that both try to claim the same row still produce exactly one
+winner without it, which is what lets the same code run on SQLite.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional, Sequence
+
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    DateTime,
+    Engine,
+    Index,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    Text,
+    and_,
+    delete,
+    func,
+    or_,
+    select,
+    update,
+)
+from sqlalchemy.exc import IntegrityError
+
+from src.utils.logger import logger
+
+from . import backoff
+from .fairness import share
+from .models import (
+    CANCELLED,
+    DEAD,
+    FAILED,
+    QUEUED,
+    RUNNING,
+    SUCCEEDED,
+    Batch,
+    Candidate,
+    Job,
+    JobOutcome,
+    JobRequest,
+    Lease,
+)
+
+metadata = MetaData()
+
+#: A dialect that can pass over a row another worker is already holding. Where
+#: it is missing the claim still works; it just does more work to find that out.
+SKIPS_LOCKED = ("postgresql", "mysql")
+
+job_table = Table(
+    "jobs",
+    metadata,
+    Column(
+        "id",
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    ),
+    Column("lane", String(64), nullable=False),
+    Column("kind", String(255), nullable=False),
+    Column("tenant", String(255), nullable=False, default=""),
+    Column("tenant_kind", String(32), nullable=False, default=""),
+    Column("scope_id", BigInteger, nullable=True),
+    Column("payload", Text, nullable=False),
+    Column("state", String(16), nullable=False),
+    Column("priority", Integer, nullable=False, default=0),
+    Column("available_at", DateTime, nullable=False),
+    Column("deadline_seconds", Integer, nullable=False, default=300),
+    Column("attempt", Integer, nullable=False, default=0),
+    Column("max_attempts", Integer, nullable=False, default=1),
+    Column("exclusive_key", String(255), nullable=True),
+    # Unique, and holding the job's own id once it is no longer queued, so that
+    # "at most one queued job per key" needs no partial index. MySQL has none.
+    Column("dedupe_slot", String(255), nullable=False),
+    Column("batch_id", BigInteger, nullable=True),
+    Column("lease_until", DateTime, nullable=True),
+    Column("leased_by", String(255), nullable=True),
+    Column("claimed_at", DateTime, nullable=True),
+    Column("started_at", DateTime, nullable=True),
+    Column("finished_at", DateTime, nullable=True),
+    Column("created_at", DateTime, nullable=False),
+    Column("error", Text, nullable=False, default=""),
+    Index("ix_jobs_ready", "lane", "state", "available_at", "priority", "id"),
+    Index("ix_jobs_tenant", "lane", "state", "tenant"),
+    Index("ix_jobs_lease", "state", "lease_until"),
+    Index("ux_jobs_dedupe", "dedupe_slot", unique=True),
+)
+
+# The mutex. A primary key makes taking one an INSERT that either works or
+# does not, on every engine, with no dialect branching.
+job_lock_table = Table(
+    "job_locks",
+    metadata,
+    Column("key", String(255), primary_key=True),
+    Column("job_id", BigInteger, nullable=False),
+    Column("taken_at", DateTime, nullable=False),
+    # A lock with no expiry is held for ever by a worker that dies holding it.
+    Column("expires_at", DateTime, nullable=False),
+)
+
+job_batch_table = Table(
+    "job_batches",
+    metadata,
+    Column(
+        "id",
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    ),
+    Column("name", String(255), nullable=False),
+    Column("tenant", String(255), nullable=False, default=""),
+    Column("total", Integer, nullable=False, default=0),
+    Column("pending", Integer, nullable=False, default=0),
+    Column("failed", Integer, nullable=False, default=0),
+    Column("created_at", DateTime, nullable=False),
+    Column("cancelled_at", DateTime, nullable=True),
+    Column("finished_at", DateTime, nullable=True),
+)
+
+
+def _naive(moment: datetime) -> datetime:
+    """The same moment in UTC, without a timezone on it.
+
+    Postgres hands back an aware datetime and SQLite a naive one. Comparing one
+    with the other raises, so everything below this line is naive UTC.
+    """
+    if moment.tzinfo is None:
+        return moment
+    return moment.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+class SQLJobStore:
+    """Jobs kept in a database, claimed by compare and swap."""
+
+    def __init__(
+        self,
+        engine: Engine,
+        *,
+        create_schema: bool = False,
+        lease_seconds: int = 60,
+        cap: int = 3,
+        worker_window: int = 200,
+        now=None,
+    ) -> None:
+        self._engine = engine
+        # Overridable only so a test can move time on rather than sleep. Left
+        # alone, the database is the one clock every worker shares.
+        self._now = now
+        self._lease_seconds = lease_seconds
+        self._cap = cap
+        self._window = worker_window
+        if create_schema:
+            metadata.create_all(engine)
+
+    def _clock(self, connection) -> datetime:
+        """Now, according to the database rather than this machine.
+
+        Workers do not share a clock. One running a few seconds fast would
+        expire leases that are perfectly healthy, and the job would be run twice
+        while the first copy was still going.
+        """
+        if self._now is not None:
+            return _naive(self._now())
+        return _naive(
+            connection.execute(select(func.current_timestamp(type_=DateTime))).scalar()
+        )
+
+    def enqueue(self, request: JobRequest, *, session: Any = None) -> int:
+        """Write a job down, in the caller's transaction where there is one.
+
+        Joining the caller's transaction is the point of the `session`
+        argument. A row written and committed, and only then enqueued, can end
+        up with nothing coming for it if the enqueue fails, which is how a run
+        sits saying "queued" for ever.
+        """
+        if session is not None:
+            connection = (
+                session.connection() if hasattr(session, "connection") else session
+            )
+            return self._insert(connection, request)
+        with self._engine.begin() as connection:
+            return self._insert(connection, request)
+
+    def _insert(self, connection, request: JobRequest) -> int:
+        now = self._clock(connection)
+        slot = request.dedupe_slot
+        values = {
+            "lane": request.lane,
+            "kind": request.kind,
+            "tenant": request.tenant,
+            "tenant_kind": request.tenant_kind,
+            "scope_id": request.scope_id,
+            "payload": json.dumps(dict(request.payload)),
+            "state": QUEUED,
+            "priority": request.priority,
+            "available_at": now + timedelta(seconds=request.delay_seconds),
+            "deadline_seconds": request.deadline_seconds,
+            "attempt": 0,
+            "max_attempts": request.max_attempts,
+            "exclusive_key": request.exclusive_key,
+            "dedupe_slot": slot or f"job:{uuid.uuid4()}",
+            "batch_id": request.batch_id,
+            "created_at": now,
+            "error": "",
+        }
+        if not slot:
+            return connection.execute(
+                job_table.insert().values(**values)
+            ).inserted_primary_key[0]
+
+        # A savepoint, so that losing the race for a dedupe key does not take
+        # the caller's whole transaction down with it on Postgres.
+        try:
+            with connection.begin_nested():
+                return connection.execute(
+                    job_table.insert().values(**values)
+                ).inserted_primary_key[0]
+        except IntegrityError:
+            existing = connection.execute(
+                select(job_table.c.id).where(job_table.c.dedupe_slot == slot)
+            ).scalar()
+            if existing is None:
+                raise
+            return existing
+
+    def claim(self, lane: str, worker: str, budget: int) -> Sequence[Lease]:
+        """Take up to `budget` jobs for this worker, fairly.
+
+        Work whose lease has lapsed is offered next to work that has never run.
+        That is what recovers a job from a worker that was killed, and it
+        happens here rather than in anything scheduled, so the recovery works on
+        a deployment that never runs the sweep at all.
+        """
+        if budget <= 0:
+            return []
+        with self._engine.begin() as connection:
+            now = self._clock(connection)
+            busy, held, last_served = self._census(connection, lane, now)
+            connection.execute(
+                delete(job_lock_table).where(job_lock_table.c.expires_at <= now)
+            )
+            held |= self._locked(connection, now)
+            candidates = self._candidates(connection, lane, now)
+
+        chosen = share(
+            candidates,
+            busy=busy,
+            cap=self._cap,
+            budget=budget,
+            last_served=last_served,
+            held=held,
+        )
+        return [
+            lease
+            for job_id in chosen
+            if (lease := self._take(job_id, worker)) is not None
+        ]
+
+    def _census(self, connection, lane: str, now: datetime):
+        """What is running for whom, and when each tenant last had a turn."""
+        rows = connection.execute(
+            select(
+                job_table.c.tenant,
+                func.count(job_table.c.id),
+                func.max(job_table.c.claimed_at),
+            )
+            .where(
+                and_(
+                    job_table.c.lane == lane,
+                    job_table.c.state == RUNNING,
+                    job_table.c.lease_until > now,
+                )
+            )
+            .group_by(job_table.c.tenant)
+        ).all()
+        busy = {tenant: count for tenant, count, _ in rows}
+        last_served = {
+            tenant: _naive(claimed).timestamp()
+            for tenant, _, claimed in rows
+            if claimed is not None
+        }
+        running_keys = connection.execute(
+            select(job_table.c.exclusive_key).where(
+                and_(
+                    job_table.c.state == RUNNING,
+                    job_table.c.lease_until > now,
+                    job_table.c.exclusive_key.is_not(None),
+                )
+            )
+        ).scalars()
+        return busy, set(running_keys), last_served
+
+    def _locked(self, connection, now: datetime) -> set:
+        return set(
+            connection.execute(
+                select(job_lock_table.c.key).where(job_lock_table.c.expires_at > now)
+            ).scalars()
+        )
+
+    def _candidates(self, connection, lane: str, now: datetime) -> list:
+        """Queued and due, or running on a claim that has lapsed."""
+        query = (
+            select(job_table.c.id, job_table.c.tenant, job_table.c.exclusive_key)
+            .where(
+                and_(
+                    job_table.c.lane == lane,
+                    or_(
+                        and_(
+                            job_table.c.state == QUEUED,
+                            job_table.c.available_at <= now,
+                        ),
+                        and_(
+                            job_table.c.state == RUNNING,
+                            job_table.c.lease_until <= now,
+                        ),
+                    ),
+                )
+            )
+            .order_by(job_table.c.priority.desc(), job_table.c.id)
+            .limit(self._window)
+        )
+        if self._engine.dialect.name in SKIPS_LOCKED:
+            query = query.with_for_update(skip_locked=True)
+        return [
+            Candidate(id=row.id, tenant=row.tenant, exclusive_key=row.exclusive_key)
+            for row in connection.execute(query).all()
+        ]
+
+    def _take(self, job_id: int, worker: str) -> Optional[Lease]:
+        """Claim one job, and its lock where it needs one.
+
+        The lock is taken before the claim so that failing to get it costs
+        nothing: there is no claim yet to hand back.
+        """
+        with self._engine.begin() as connection:
+            now = self._clock(connection)
+            until = now + timedelta(seconds=self._lease_seconds)
+            row = connection.execute(
+                select(job_table).where(job_table.c.id == job_id)
+            ).one_or_none()
+            if row is None:
+                return None
+            if row.exclusive_key and not self._lock(
+                connection, row.exclusive_key, job_id, now, until
+            ):
+                return None
+
+            claimed = connection.execute(
+                update(job_table)
+                .where(
+                    and_(
+                        job_table.c.id == job_id,
+                        or_(
+                            and_(
+                                job_table.c.state == QUEUED,
+                                job_table.c.available_at <= now,
+                            ),
+                            and_(
+                                job_table.c.state == RUNNING,
+                                job_table.c.lease_until <= now,
+                            ),
+                        ),
+                    )
+                )
+                .values(
+                    state=RUNNING,
+                    leased_by=worker,
+                    lease_until=until,
+                    attempt=job_table.c.attempt + 1,
+                    claimed_at=now,
+                    started_at=now,
+                )
+            ).rowcount
+            if claimed != 1:
+                # Somebody else won it. Give back the lock we just took, or the
+                # key stays held by a job we are not running.
+                if row.exclusive_key:
+                    connection.execute(
+                        delete(job_lock_table).where(
+                            and_(
+                                job_lock_table.c.key == row.exclusive_key,
+                                job_lock_table.c.job_id == job_id,
+                            )
+                        )
+                    )
+                return None
+
+            fresh = connection.execute(
+                select(job_table).where(job_table.c.id == job_id)
+            ).one()
+            return Lease(job=_as_job(fresh), worker=worker, until=until)
+
+    def _lock(self, connection, key: str, job_id: int, now, until) -> bool:
+        connection.execute(
+            delete(job_lock_table).where(
+                and_(job_lock_table.c.key == key, job_lock_table.c.expires_at <= now)
+            )
+        )
+        try:
+            with connection.begin_nested():
+                connection.execute(
+                    job_lock_table.insert().values(
+                        key=key, job_id=job_id, taken_at=now, expires_at=until
+                    )
+                )
+            return True
+        except IntegrityError:
+            return False
+
+    def heartbeat(self, lease: Lease) -> bool:
+        """Extend a claim, and say whether it was still ours to extend."""
+        with self._engine.begin() as connection:
+            now = self._clock(connection)
+            until = now + timedelta(seconds=self._lease_seconds)
+            kept = connection.execute(
+                update(job_table)
+                .where(
+                    and_(
+                        job_table.c.id == lease.job.id,
+                        job_table.c.state == RUNNING,
+                        job_table.c.leased_by == lease.worker,
+                        job_table.c.lease_until > now,
+                    )
+                )
+                .values(lease_until=until)
+            ).rowcount
+            if kept != 1:
+                return False
+            if lease.job.exclusive_key:
+                connection.execute(
+                    update(job_lock_table)
+                    .where(
+                        and_(
+                            job_lock_table.c.key == lease.job.exclusive_key,
+                            job_lock_table.c.job_id == lease.job.id,
+                        )
+                    )
+                    .values(expires_at=until)
+                )
+            return True
+
+    def finish(self, lease: Lease, outcome: JobOutcome) -> None:
+        """Record how a job ended, and queue it again where that is wanted."""
+        with self._engine.begin() as connection:
+            now = self._clock(connection)
+            row = connection.execute(
+                select(job_table).where(job_table.c.id == lease.job.id)
+            ).one_or_none()
+            if row is None or row.leased_by != lease.worker:
+                return
+            self._unlock(connection, row)
+
+            if outcome.succeeded:
+                values = {
+                    "state": SUCCEEDED,
+                    "error": "",
+                    "finished_at": now,
+                    "dedupe_slot": f"job:{uuid.uuid4()}",
+                }
+                self._settle(connection, row, now, failed=False)
+            elif outcome.retry and row.attempt < row.max_attempts:
+                wait = outcome.retry_in
+                if wait is None:
+                    wait = backoff.after(row.attempt)
+                values = {
+                    "state": QUEUED,
+                    "error": outcome.error,
+                    "available_at": now + timedelta(seconds=wait),
+                }
+            else:
+                values = {
+                    "state": DEAD if row.attempt >= row.max_attempts else FAILED,
+                    "error": outcome.error,
+                    "finished_at": now,
+                    "dedupe_slot": f"job:{uuid.uuid4()}",
+                }
+                self._settle(connection, row, now, failed=True)
+
+            values.update({"lease_until": None, "leased_by": None})
+            connection.execute(
+                update(job_table).where(job_table.c.id == row.id).values(**values)
+            )
+
+    def release(self, lease: Lease, *, delay_seconds: int = 0) -> None:
+        """Hand a claim back without counting it as an attempt."""
+        with self._engine.begin() as connection:
+            now = self._clock(connection)
+            row = connection.execute(
+                select(job_table).where(job_table.c.id == lease.job.id)
+            ).one_or_none()
+            if row is None or row.leased_by != lease.worker:
+                return
+            self._unlock(connection, row)
+            connection.execute(
+                update(job_table)
+                .where(job_table.c.id == row.id)
+                .values(
+                    state=QUEUED,
+                    attempt=max(0, row.attempt - 1),
+                    leased_by=None,
+                    lease_until=None,
+                    available_at=now + timedelta(seconds=delay_seconds),
+                )
+            )
+
+    def _unlock(self, connection, row) -> None:
+        if row.exclusive_key:
+            connection.execute(
+                delete(job_lock_table).where(
+                    and_(
+                        job_lock_table.c.key == row.exclusive_key,
+                        job_lock_table.c.job_id == row.id,
+                    )
+                )
+            )
+
+    def open(self, name: str, total: int, *, tenant: str = "") -> Batch:
+        with self._engine.begin() as connection:
+            now = self._clock(connection)
+            batch_id = connection.execute(
+                job_batch_table.insert().values(
+                    name=name,
+                    tenant=tenant,
+                    total=total,
+                    pending=total,
+                    failed=0,
+                    created_at=now,
+                )
+            ).inserted_primary_key[0]
+        return Batch(id=batch_id, name=name, total=total, pending=total, tenant=tenant)
+
+    def record(self, batch_id: int, *, failed: bool = False) -> Optional[Batch]:
+        with self._engine.begin() as connection:
+            self._settle_batch(connection, batch_id, self._clock(connection), failed)
+        return self.read_batch(batch_id)
+
+    def _settle(self, connection, row, now, *, failed: bool) -> None:
+        if row.batch_id:
+            self._settle_batch(connection, row.batch_id, now, failed)
+
+    def _settle_batch(self, connection, batch_id: int, now, failed: bool) -> None:
+        connection.execute(
+            update(job_batch_table)
+            .where(
+                and_(job_batch_table.c.id == batch_id, job_batch_table.c.pending > 0)
+            )
+            .values(
+                pending=job_batch_table.c.pending - 1,
+                failed=job_batch_table.c.failed + (1 if failed else 0),
+            )
+        )
+        connection.execute(
+            update(job_batch_table)
+            .where(
+                and_(
+                    job_batch_table.c.id == batch_id,
+                    job_batch_table.c.pending <= 0,
+                    job_batch_table.c.finished_at.is_(None),
+                )
+            )
+            .values(finished_at=now)
+        )
+
+    def read_batch(self, batch_id: int) -> Optional[Batch]:
+        with self._engine.connect() as connection:
+            row = connection.execute(
+                select(job_batch_table).where(job_batch_table.c.id == batch_id)
+            ).one_or_none()
+        if row is None:
+            return None
+        return Batch(
+            id=row.id,
+            name=row.name,
+            total=row.total,
+            pending=row.pending,
+            failed=row.failed,
+            tenant=row.tenant,
+            cancelled_at=row.cancelled_at,
+            finished_at=row.finished_at,
+        )
+
+    def read(self, job_id: int) -> Optional[Job]:
+        with self._engine.connect() as connection:
+            row = connection.execute(
+                select(job_table).where(job_table.c.id == job_id)
+            ).one_or_none()
+        return None if row is None else _as_job(row)
+
+    def pending(self, lane: str = "", limit: int = 100) -> Sequence[Job]:
+        query = select(job_table).where(job_table.c.state == QUEUED)
+        if lane:
+            query = query.where(job_table.c.lane == lane)
+        query = query.order_by(job_table.c.priority.desc(), job_table.c.id).limit(limit)
+        with self._engine.connect() as connection:
+            return [_as_job(row) for row in connection.execute(query).all()]
+
+    def cancel(self, job_id: int) -> bool:
+        with self._engine.begin() as connection:
+            return (
+                connection.execute(
+                    update(job_table)
+                    .where(and_(job_table.c.id == job_id, job_table.c.state == QUEUED))
+                    .values(state=CANCELLED)
+                ).rowcount
+                == 1
+            )
+
+
+def _as_job(row) -> Job:
+    try:
+        payload = json.loads(row.payload)
+    except (TypeError, ValueError):
+        logger.warning(f"Job {row.id} has a payload that is not readable")
+        payload = {}
+    return Job(
+        id=row.id,
+        lane=row.lane,
+        kind=row.kind,
+        payload=payload,
+        state=row.state,
+        tenant=row.tenant,
+        tenant_kind=row.tenant_kind,
+        scope_id=row.scope_id,
+        priority=row.priority,
+        attempt=row.attempt,
+        max_attempts=row.max_attempts,
+        deadline_seconds=row.deadline_seconds,
+        exclusive_key=row.exclusive_key,
+        dedupe_slot=row.dedupe_slot,
+        batch_id=row.batch_id,
+        available_at=row.available_at,
+        lease_until=row.lease_until,
+        leased_by=row.leased_by,
+        error=row.error or "",
+    )

--- a/src/core/jobs/sql.py
+++ b/src/core/jobs/sql.py
@@ -610,6 +610,33 @@ class SQLJobStore:
         with self._engine.connect() as connection:
             return [_as_job(row) for row in connection.execute(query).all()]
 
+    def prune(self, keep_finished_for_days: int = 14) -> int:
+        """Clear away jobs finished long enough ago to be of no interest.
+
+        Zero keeps them for ever, which is what the setting offers and also how
+        this table becomes the largest one in the database.
+        """
+        with self._engine.begin() as connection:
+            now = self._clock(connection)
+            cleared = 0
+            if keep_finished_for_days > 0:
+                cutoff = now - timedelta(days=keep_finished_for_days)
+                cleared = connection.execute(
+                    delete(job_table).where(
+                        and_(
+                            job_table.c.state.in_((SUCCEEDED, FAILED, DEAD, CANCELLED)),
+                            job_table.c.finished_at.is_not(None),
+                            job_table.c.finished_at < cutoff,
+                        )
+                    )
+                ).rowcount
+            # A lock outliving its job would hold work back for ever, and the
+            # claim only passes over ones that have not expired yet.
+            connection.execute(
+                delete(job_lock_table).where(job_lock_table.c.expires_at <= now)
+            )
+            return cleared or 0
+
     def cancel(self, job_id: int) -> bool:
         with self._engine.begin() as connection:
             return (

--- a/src/core/jobs/sweep.py
+++ b/src/core/jobs/sweep.py
@@ -58,7 +58,10 @@ class Sweeper:
             return JobOutcome.failed(f"{type(error).__name__}: {error}", retry=True)
         if cleared:
             logger.info(f"Cleared {cleared} finished jobs")
-        self.arrange(store)
+        if self.arrange(store) is None:
+            # Each tidy asks for the next, so one that cannot is the end of all
+            # tidying. Failing here has it tried again instead.
+            return JobOutcome.failed("could not ask for the next tidy", retry=True)
         return JobOutcome.ok()
 
     def arrange(self, store=None) -> Optional[int]:

--- a/src/core/jobs/sweep.py
+++ b/src/core/jobs/sweep.py
@@ -1,0 +1,88 @@
+"""Tidying up after the queue.
+
+Nothing here is on the critical path, and that is the point. Recovering work
+from a worker that died is done by the claim itself, so this can lag, fail, or
+never run at all on a given deployment without work being lost. What it does is
+stop the table growing without limit, which is the way a queue in a database
+goes wrong slowly rather than loudly.
+
+It is itself a job, so it needs no scheduler: each run asks for the next one.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from src.core.services import ServiceRegistry, service_registry
+from src.utils.logger import logger
+
+from .models import WITHIN_MINUTES, JobOutcome, JobRequest
+
+#: How often the tidying runs, and the key that stops two being queued at once.
+SWEEP_KIND = "jobs.sweep"
+SWEEP_SLOT = "jobs.sweep"
+EVERY_SECONDS = 3600
+
+
+class Sweeper:
+    """Clears away what the queue has finished with."""
+
+    kind = SWEEP_KIND
+
+    def __init__(
+        self,
+        store: Any = None,
+        *,
+        keep_finished_for_days: int = 14,
+        every_seconds: int = EVERY_SECONDS,
+        services: ServiceRegistry = service_registry,
+    ) -> None:
+        self._store = store
+        self._days = keep_finished_for_days
+        self._every = every_seconds
+        self._services = services
+
+    def _own(self):
+        if self._store is not None:
+            return self._store
+        from . import job_store
+
+        return job_store(self._services)
+
+    def run(self, job=None) -> JobOutcome:
+        store = self._own()
+        try:
+            cleared = store.prune(self._days)
+        except Exception as error:
+            logger.warning(f"Could not tidy the queue: {error}")
+            return JobOutcome.failed(f"{type(error).__name__}: {error}", retry=True)
+        if cleared:
+            logger.info(f"Cleared {cleared} finished jobs")
+        self.arrange(store)
+        return JobOutcome.ok()
+
+    def arrange(self, store=None) -> Optional[int]:
+        """Ask for the next tidying.
+
+        The dedupe key means asking twice queues one, so this is safe to call
+        whenever, including from something starting up that cannot know whether
+        a sweep is already waiting.
+        """
+        store = store or self._own()
+        try:
+            return store.enqueue(
+                JobRequest(
+                    lane=WITHIN_MINUTES,
+                    kind=SWEEP_KIND,
+                    dedupe_slot=SWEEP_SLOT,
+                    delay_seconds=self._every,
+                    deadline_seconds=300,
+                    max_attempts=3,
+                    priority=-10,
+                )
+            )
+        except Exception:
+            logger.warning(
+                "Could not arrange the next tidy of the queue", exc_info=True
+            )
+            return None

--- a/src/core/jobs/worker.py
+++ b/src/core/jobs/worker.py
@@ -108,7 +108,6 @@ class Worker:
             return self._store.claim(self._lane, self._name, 1)
         except Exception:
             logger.warning(f"{self._name} could not claim work", exc_info=True)
-            self._stopping.wait(self._poll)
             return []
 
     def perform(self, lease: Lease) -> JobOutcome:
@@ -168,7 +167,13 @@ class Worker:
             return self._overran(job, lease, beating)
         if not answer:
             return JobOutcome.failed("the job stopped without saying how")
-        return answer[0]
+        said = answer[0]
+        if not isinstance(said, JobOutcome):
+            logger.error(
+                f"{job.kind} answered with {type(said).__name__}, not an outcome"
+            )
+            return JobOutcome.failed(f"{job.kind} did not say how it went")
+        return said
 
     def _overran(self, job: Job, lease: Lease, beating: "_Heartbeat") -> JobOutcome:
         """Record a job that outran its deadline, then take the process down.

--- a/src/core/jobs/worker.py
+++ b/src/core/jobs/worker.py
@@ -1,0 +1,243 @@
+"""Doing the work: claiming a job, keeping the claim alive, and finishing it.
+
+One job at a time. More than one at once is another process, not another
+thread, because a worker has to be able to stop a job that has gone on too long
+and Python cannot stop a thread. Where the deadline is missed this process
+records the job and then exits, so whatever it was running dies with it and the
+supervisor starts a fresh one. That is the only honest way to enforce a
+deadline in this language.
+
+The lease and the deadline are two different things and the difference matters.
+A lease says how long a claim stays good without word from the worker, and is
+renewed for as long as the work is alive. A deadline says when the work itself
+has gone on too long. Treating them as one gives you either a healthy job
+killed at an arbitrary point, or a hung job renewing its claim for ever.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import threading
+from time import monotonic
+from typing import Optional, Sequence
+
+from src.core.services import ServiceRegistry, service_registry
+from src.utils.logger import logger
+
+from .interfaces import JobHandler, JobMiddleware, JobStore
+from .models import Job, JobOutcome, Lease
+
+#: Told to the supervisor when a job outran its deadline, so a restart is
+#: understood as intended rather than as a crash.
+DEADLINE_EXIT = 75
+
+
+class Worker:
+    """Claims work for one lane and does it."""
+
+    def __init__(
+        self,
+        store: JobStore,
+        lane: str,
+        *,
+        name: str = "",
+        poll_seconds: float = 1.0,
+        heartbeat_seconds: float = 20.0,
+        services: ServiceRegistry = service_registry,
+        halt=os._exit,
+    ) -> None:
+        self._store = store
+        self._lane = lane
+        self._name = name or f"{socket.gethostname()}:{os.getpid()}"
+        self._poll = poll_seconds
+        self._heartbeat = heartbeat_seconds
+        self._services = services
+        # Injectable only so a test can watch this happen rather than take the
+        # test runner down with it.
+        self._halt = halt
+        self._stopping = threading.Event()
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def stop(self, *_) -> None:
+        """Finish the job in hand and then stop.
+
+        A worker killed mid-job loses nothing, because the lease lapses and the
+        job is offered again. Draining is still better: it avoids doing the same
+        work twice for no reason.
+        """
+        logger.info(f"{self._name} will stop once the job in hand is done")
+        self._stopping.set()
+
+    def attend(self) -> None:
+        """Stop cleanly when asked to, rather than being killed mid-job."""
+        for asked in (signal.SIGTERM, signal.SIGINT):
+            signal.signal(asked, self.stop)
+
+    def work(self, *, max_jobs: int = 0, max_time: float = 0.0) -> int:
+        """Claim and run jobs until told to stop, or until a limit is reached.
+
+        The limits exist so a long-lived process is replaced periodically rather
+        than kept until something it leaked matters.
+        """
+        started = monotonic()
+        done = 0
+        while not self._stopping.is_set():
+            if max_jobs and done >= max_jobs:
+                logger.info(f"{self._name} has done {done} jobs and will be replaced")
+                break
+            if max_time and monotonic() - started >= max_time:
+                logger.info(f"{self._name} has run its time and will be replaced")
+                break
+
+            leases = self._claim()
+            if not leases:
+                self._stopping.wait(self._poll)
+                continue
+            for lease in leases:
+                self.perform(lease)
+                done += 1
+        return done
+
+    def _claim(self) -> Sequence[Lease]:
+        try:
+            return self._store.claim(self._lane, self._name, 1)
+        except Exception:
+            logger.warning(f"{self._name} could not claim work", exc_info=True)
+            self._stopping.wait(self._poll)
+            return []
+
+    def perform(self, lease: Lease) -> JobOutcome:
+        """Run one job, keeping its claim alive while it runs."""
+        job = lease.job
+        beating = _Heartbeat(self._store, lease, self._heartbeat)
+        beating.start()
+        try:
+            outcome = self._guarded(job, lease, beating)
+        finally:
+            beating.stop()
+        try:
+            self._store.finish(lease, outcome)
+        except Exception:
+            logger.warning(f"Could not record how job {job.id} ended", exc_info=True)
+        return outcome
+
+    def _guarded(self, job: Job, lease: Lease, beating: "_Heartbeat") -> JobOutcome:
+        wrapping = list(self._services.contributions(JobMiddleware))
+        for layer in wrapping:
+            held = _safely(layer.before, job)
+            if held is not None:
+                return held
+
+        handler = self._handler(job.kind)
+        if handler is None:
+            # A handler installed on one deployment may be absent on another,
+            # so this is a fact about this machine and not about the job.
+            logger.error(f"Nothing here handles {job.kind}, so job {job.id} cannot run")
+            return JobOutcome.failed(f"no handler for {job.kind}")
+
+        outcome = self._run(handler, job, lease, beating)
+        for layer in reversed(wrapping):
+            try:
+                outcome = layer.after(job, outcome)
+            except Exception:
+                logger.warning("A job middleware failed on the way out", exc_info=True)
+        return outcome
+
+    def _run(
+        self, handler, job: Job, lease: Lease, beating: "_Heartbeat"
+    ) -> JobOutcome:
+        answer: list = []
+
+        def perform() -> None:
+            try:
+                answer.append(handler.run(job))
+            except Exception as error:
+                logger.warning(f"Job {job.id} ({job.kind}) failed", exc_info=True)
+                answer.append(JobOutcome.failed(f"{type(error).__name__}: {error}"))
+
+        doing = threading.Thread(target=perform, name=f"job-{job.id}", daemon=True)
+        doing.start()
+        doing.join(timeout=job.deadline_seconds)
+
+        if doing.is_alive():
+            return self._overran(job, lease, beating)
+        if not answer:
+            return JobOutcome.failed("the job stopped without saying how")
+        return answer[0]
+
+    def _overran(self, job: Job, lease: Lease, beating: "_Heartbeat") -> JobOutcome:
+        """Record a job that outran its deadline, then take the process down.
+
+        The work is still running and cannot be stopped from here. Leaving it
+        would mean a job recorded as finished while it carries on writing, so
+        the process goes and takes it with it.
+        """
+        logger.error(
+            f"Job {job.id} ({job.kind}) passed {job.deadline_seconds}s; "
+            f"{self._name} is stopping so it cannot carry on"
+        )
+        beating.stop()
+        try:
+            self._store.finish(
+                lease, JobOutcome.failed(f"went past {job.deadline_seconds}s")
+            )
+        except Exception:
+            logger.warning("Could not record the job that overran", exc_info=True)
+        self._halt(DEADLINE_EXIT)
+        return JobOutcome.failed(f"went past {job.deadline_seconds}s")
+
+    def _handler(self, kind: str) -> Optional[JobHandler]:
+        for handler in self._services.contributions(JobHandler):
+            if getattr(handler, "kind", None) == kind:
+                return handler
+        return None
+
+
+class _Heartbeat:
+    """Renews a claim while its job runs, and notices when it is taken away."""
+
+    def __init__(self, store: JobStore, lease: Lease, every: float) -> None:
+        self._store = store
+        self._lease = lease
+        self._every = every
+        self._stopping = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self.lost = False
+
+    def start(self) -> None:
+        self._thread = threading.Thread(
+            target=self._beat, name=f"heartbeat-{self._lease.job.id}", daemon=True
+        )
+        self._thread.start()
+
+    def _beat(self) -> None:
+        while not self._stopping.wait(self._every):
+            try:
+                if not self._store.heartbeat(self._lease):
+                    # Somebody else holds the job now, and the work already
+                    # running cannot be interrupted from here.
+                    self.lost = True
+                    logger.warning(
+                        f"The claim on job {self._lease.job.id} lapsed and was taken"
+                    )
+                    return
+            except Exception:
+                logger.warning("Could not renew a claim", exc_info=True)
+
+    def stop(self) -> None:
+        self._stopping.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1)
+
+
+def _safely(call, job: Job) -> Optional[JobOutcome]:
+    try:
+        return call(job)
+    except Exception:
+        logger.warning("A job middleware failed on the way in", exc_info=True)
+        return None

--- a/src/core/model/catalogue.py
+++ b/src/core/model/catalogue.py
@@ -15,32 +15,15 @@ from functools import lru_cache
 from typing import Optional
 from urllib.parse import urlparse
 
+from src.config.settings import whole_number
 from src.utils.logger import logger
-
-
-def _seconds(name: str, fallback: int) -> int:
-    """A whole number of seconds from the environment, or the fallback.
-
-    Read at import, so anything that raises here takes the process down before
-    it serves a request. A mistyped variable is worth a line in the log and a
-    sensible default, not a deployment that will not start.
-    """
-    given = os.getenv(name, "")
-    try:
-        seconds = int(given)
-    except ValueError:
-        if given:
-            logger.warning(f"{name} is not a number of seconds, using {fallback}")
-        return fallback
-    return seconds if seconds > 0 else fallback
-
 
 # How long a provider gets to answer a check. Unbounded, a provider that has
 # stopped answering holds the thread until something else gives up first.
-PROBE_SECONDS = _seconds("LLM_PROBE_TIMEOUT", 15)
+PROBE_SECONDS = whole_number("LLM_PROBE_TIMEOUT", 15)
 
 # How long a name gets to resolve, for the same reason.
-RESOLVE_SECONDS = _seconds("LLM_RESOLVE_TIMEOUT", 5)
+RESOLVE_SECONDS = whole_number("LLM_RESOLVE_TIMEOUT", 5)
 
 # A deployment running its own models reaches them on an address only it can
 # see, so an operator can say so and have private addresses accepted. Off by

--- a/src/core/settings/definitions.py
+++ b/src/core/settings/definitions.py
@@ -345,6 +345,40 @@ SETTINGS: tuple[Setting, ...] = (
         group="Skills",
         listed=True,
     ),
+    # How much background work runs at once, and how much of it any one
+    # customer may have. The cap is what stops a large backlog belonging to one
+    # workspace from being the only thing running.
+    Setting(
+        key="jobs.per_workspace",
+        label="Jobs at once for one workspace",
+        description=(
+            "How many pieces of background work may run at the same time for a "
+            "single workspace. Everyone gets an equal turn up to this number, "
+            "so a large backlog waits rather than crowding everybody else out."
+        ),
+        type=ConfigType.INT,
+        scopes=(WORKSPACE, ORGANIZATION),
+        default=3,
+        minimum=1,
+        maximum=100,
+        group="Background work",
+    ),
+    Setting(
+        key="jobs.keep_finished_for",
+        label="Keep finished jobs for",
+        description=(
+            "How many days a finished job is kept before it is cleared away. "
+            "Zero keeps them for ever, which makes this the largest table in "
+            "the database soon enough."
+        ),
+        type=ConfigType.INT,
+        scopes=(ORGANIZATION,),
+        default=14,
+        minimum=0,
+        maximum=365,
+        unit="days",
+        group="Background work",
+    ),
 )
 
 BY_KEY: Mapping[str, Setting] = {setting.key: setting for setting in SETTINGS}

--- a/src/events/dispatcher.py
+++ b/src/events/dispatcher.py
@@ -1,4 +1,3 @@
-import os
 from contextvars import ContextVar
 from typing import Optional, Dict, Any
 
@@ -12,6 +11,7 @@ from src.config.settings import (
     QUEUE_MODE,
     REDIS_HOST,
     REDIS_PORT,
+    whole_number,
 )
 
 from src.events.event import Event
@@ -28,7 +28,7 @@ bg_tasks_cv: ContextVar[Optional[BackgroundTasks]] = ContextVar(
 
 # How long a delivery may take. A review of a large change asks a model
 # several times and outlasts the queue's own default of 180 seconds.
-DELIVERY_TIMEOUT = int(os.getenv("DELIVERY_TIMEOUT", "1800"))
+DELIVERY_TIMEOUT = whole_number("QUEUE_DELIVERY_TIMEOUT", 1800)
 
 q = None
 if QUEUE_MODE == "redis":

--- a/src/events/dispatcher.py
+++ b/src/events/dispatcher.py
@@ -1,3 +1,4 @@
+import os
 from contextvars import ContextVar
 from typing import Optional, Dict, Any
 
@@ -12,6 +13,7 @@ from src.config.settings import (
     REDIS_HOST,
     REDIS_PORT,
 )
+
 from src.events.event import Event
 from src.events.repository_event import RepositoryEvent
 from src.integrations.github.github_webhook_parser import GitHubWebhookParser
@@ -23,6 +25,10 @@ from src.utils.logger import logger
 bg_tasks_cv: ContextVar[Optional[BackgroundTasks]] = ContextVar(
     "bg_tasks", default=None
 )
+
+# How long a delivery may take. A review of a large change asks a model
+# several times and outlasts the queue's own default of 180 seconds.
+DELIVERY_TIMEOUT = int(os.getenv("DELIVERY_TIMEOUT", "1800"))
 
 q = None
 if QUEUE_MODE == "redis":
@@ -50,7 +56,9 @@ class EventDispatcher:
         if QUEUE_MODE in ["redis", "redislite"]:
             if not q:
                 raise RuntimeError(f"{QUEUE_MODE} queue not initialized.")
-            q.enqueue(self._process_event_sync, event)
+            # Unstated, this takes the queue's default of 180 seconds and the
+            # job is stopped partway through with nothing recorded.
+            q.enqueue(self._process_event_sync, event, job_timeout=DELIVERY_TIMEOUT)
 
         elif QUEUE_MODE == "request":
             background_tasks = bg_tasks_cv.get()

--- a/src/migrations/versions/create_jobs.py
+++ b/src/migrations/versions/create_jobs.py
@@ -1,0 +1,85 @@
+"""Background work, the locks that keep it from overlapping, and its batches."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "jobs_001"
+down_revision = "token_usage_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "jobs",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("lane", sa.String(length=64), nullable=False),
+        sa.Column("kind", sa.String(length=255), nullable=False),
+        sa.Column("tenant", sa.String(length=255), nullable=False, server_default=""),
+        sa.Column(
+            "tenant_kind", sa.String(length=32), nullable=False, server_default=""
+        ),
+        sa.Column("scope_id", sa.BigInteger(), nullable=True),
+        sa.Column("payload", sa.Text(), nullable=False),
+        sa.Column("state", sa.String(length=16), nullable=False),
+        sa.Column("priority", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("available_at", sa.DateTime(), nullable=False),
+        sa.Column(
+            "deadline_seconds", sa.Integer(), nullable=False, server_default="300"
+        ),
+        sa.Column("attempt", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("max_attempts", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("exclusive_key", sa.String(length=255), nullable=True),
+        sa.Column("dedupe_slot", sa.String(length=255), nullable=False),
+        sa.Column("batch_id", sa.BigInteger(), nullable=True),
+        sa.Column("lease_until", sa.DateTime(), nullable=True),
+        sa.Column("leased_by", sa.String(length=255), nullable=True),
+        sa.Column("claimed_at", sa.DateTime(), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("finished_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("error", sa.Text(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_jobs_ready", "jobs", ["lane", "state", "available_at", "priority", "id"]
+    )
+    op.create_index("ix_jobs_tenant", "jobs", ["lane", "state", "tenant"])
+    op.create_index("ix_jobs_lease", "jobs", ["state", "lease_until"])
+    # At most one queued job may hold a key. A finished job is given a key of
+    # its own so the same work can be asked for again, which is why this is a
+    # plain unique index rather than a partial one MySQL could not build.
+    op.create_index("ux_jobs_dedupe", "jobs", ["dedupe_slot"], unique=True)
+
+    op.create_table(
+        "job_locks",
+        sa.Column("key", sa.String(length=255), nullable=False),
+        sa.Column("job_id", sa.BigInteger(), nullable=False),
+        sa.Column("taken_at", sa.DateTime(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("key"),
+    )
+
+    op.create_table(
+        "job_batches",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("tenant", sa.String(length=255), nullable=False, server_default=""),
+        sa.Column("total", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("pending", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("failed", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("cancelled_at", sa.DateTime(), nullable=True),
+        sa.Column("finished_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("job_batches")
+    op.drop_table("job_locks")
+    op.drop_index("ux_jobs_dedupe", table_name="jobs")
+    op.drop_index("ix_jobs_lease", table_name="jobs")
+    op.drop_index("ix_jobs_tenant", table_name="jobs")
+    op.drop_index("ix_jobs_ready", table_name="jobs")
+    op.drop_table("jobs")

--- a/src/migrations/versions/create_jobs.py
+++ b/src/migrations/versions/create_jobs.py
@@ -12,7 +12,12 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         "jobs",
-        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column(
+            "id",
+            sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+            autoincrement=True,
+            nullable=False,
+        ),
         sa.Column("lane", sa.String(length=64), nullable=False),
         sa.Column("kind", sa.String(length=255), nullable=False),
         sa.Column("tenant", sa.String(length=255), nullable=False, server_default=""),
@@ -62,7 +67,12 @@ def upgrade() -> None:
 
     op.create_table(
         "job_batches",
-        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column(
+            "id",
+            sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+            autoincrement=True,
+            nullable=False,
+        ),
         sa.Column("name", sa.String(length=255), nullable=False),
         sa.Column("tenant", sa.String(length=255), nullable=False, server_default=""),
         sa.Column("total", sa.Integer(), nullable=False, server_default="0"),

--- a/src/tests/unit/test_core_jobs_fairness.py
+++ b/src/tests/unit/test_core_jobs_fairness.py
@@ -1,0 +1,117 @@
+"""Who gets to run next when more is queued than can be run.
+
+Every case here is one a deployment meets the first time two customers are busy
+at once, and none of them needs a database to be true.
+"""
+
+from src.core.jobs.fairness import share
+from src.core.jobs.models import Candidate
+
+
+def _queued(tenant: str, ids, key=None) -> list:
+    return [Candidate(id=i, tenant=tenant, exclusive_key=key) for i in ids]
+
+
+def test_two_tenants_with_the_same_backlog_get_the_same_share():
+    """Neither of them enqueued their way to the front. Whoever asked first
+    would otherwise take everything, which is what a single queue does now."""
+    candidates = _queued("acme", range(1, 501)) + _queued("globex", range(501, 1001))
+
+    chosen = share(candidates, busy={}, cap=3, budget=20)
+
+    assert sum(1 for job in chosen if job < 501) == 3
+    assert sum(1 for job in chosen if job >= 501) == 3
+
+
+def test_a_tenant_with_one_job_does_not_wait_behind_another_tenants_backlog():
+    """A single job must not wait behind five hundred belonging to somebody
+    else, or one busy tenant is the only one anything happens for."""
+    candidates = _queued("acme", range(1, 501)) + _queued("globex", [900])
+
+    chosen = share(candidates, busy={}, cap=3, budget=4)
+
+    assert 900 in chosen
+    assert chosen.index(900) == 1
+
+
+def test_a_tenant_already_at_its_cap_is_passed_over():
+    """The cap counts what is running everywhere, not just what this worker
+    started, or every worker would grant the same tenant its own full share."""
+    candidates = _queued("acme", [1, 2, 3]) + _queued("globex", [4, 5])
+
+    chosen = share(candidates, busy={"acme": 3}, cap=3, budget=10)
+
+    assert chosen == (4, 5)
+
+
+def test_one_tenants_own_work_stays_in_the_order_it_was_asked_for():
+    """Fairness is between tenants. Within one, a queue that reordered itself
+    would be a queue nobody could reason about."""
+    candidates = _queued("acme", [7, 8, 9])
+
+    chosen = share(candidates, busy={}, cap=5, budget=5)
+
+    assert chosen == (7, 8, 9)
+
+
+def test_the_tenant_served_longest_ago_goes_first():
+    """Equal share only means anything if the turn actually rotates."""
+    candidates = _queued("acme", [1]) + _queued("globex", [2])
+
+    chosen = share(
+        candidates,
+        busy={},
+        cap=3,
+        budget=2,
+        last_served={"acme": 100.0, "globex": 50.0},
+    )
+
+    assert chosen == (2, 1)
+
+
+def test_a_job_cannot_be_taken_while_its_key_is_held():
+    """Two runs for one repository would delete each other's checkout, so the
+    second waits instead of both proceeding."""
+    candidates = _queued("acme", [1], key="working-area:5")
+
+    chosen = share(candidates, busy={}, cap=3, budget=5, held={"working-area:5"})
+
+    assert chosen == ()
+
+
+def test_two_queued_jobs_wanting_the_same_key_do_not_both_go():
+    """The lock is taken after the claim, so choosing both would only mean one
+    of them immediately handing its claim back."""
+    candidates = _queued("acme", [1, 2], key="working-area:5")
+
+    chosen = share(candidates, busy={}, cap=3, budget=5)
+
+    assert chosen == (1,)
+
+
+def test_a_held_key_does_not_stall_the_rest_of_that_tenants_work():
+    """Otherwise one busy repository stops every other repository belonging to
+    the same customer, which is a worse outage than the one being prevented."""
+    candidates = [
+        Candidate(id=1, tenant="acme", exclusive_key="working-area:5"),
+        Candidate(id=2, tenant="acme"),
+    ]
+
+    chosen = share(candidates, busy={}, cap=3, budget=5, held={"working-area:5"})
+
+    assert chosen == (2,)
+
+
+def test_nothing_is_taken_without_budget():
+    """A worker with no free slot must not claim work it cannot start, because
+    a claim it never begins looks exactly like a job that hung."""
+    assert share(_queued("acme", [1, 2]), busy={}, cap=3, budget=0) == ()
+
+
+def test_a_full_rotation_that_takes_nothing_stops_rather_than_spinning():
+    """Every candidate blocked is an ordinary state, not a reason to loop."""
+    candidates = _queued("acme", [1, 2], key="k") + _queued("globex", [3], key="k")
+
+    chosen = share(candidates, busy={}, cap=3, budget=50, held={"k"})
+
+    assert chosen == ()

--- a/src/tests/unit/test_core_jobs_recovery.py
+++ b/src/tests/unit/test_core_jobs_recovery.py
@@ -1,0 +1,106 @@
+"""Work outliving the worker that was doing it.
+
+A worker killed outright writes nothing, so recovery cannot be anything that
+runs inside it. The kill here is real for that reason: a second worker picks
+the job up because the claim lapsed, with nothing scheduled and nothing swept.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import sqlalchemy as sa
+
+from src.core.jobs.models import WITHIN_SECONDS, JobRequest
+from src.core.jobs.sql import SQLJobStore
+
+WORKER = textwrap.dedent("""
+    import sys, time
+    import sqlalchemy as sa
+    from src.core.jobs.sql import SQLJobStore
+    from src.core.jobs.worker import Worker
+    from src.core.jobs.interfaces import JobHandler
+    from src.core.services import ServiceRegistry
+    from src.core.jobs.models import WITHIN_SECONDS, JobOutcome
+
+    class Forever:
+        kind = "test.long"
+        def run(self, job):
+            while True:
+                time.sleep(0.05)
+
+    services = ServiceRegistry()
+    services.contribute(JobHandler, Forever(), "test")
+    store = SQLJobStore(sa.create_engine(sys.argv[1]), lease_seconds=2)
+    Worker(store, WITHIN_SECONDS, name="doomed", poll_seconds=0.1,
+           heartbeat_seconds=0.5, services=services).work()
+    """)
+
+
+def test_a_job_survives_the_worker_being_killed_outright(tmp_path):
+    url = f"sqlite:///{tmp_path}/jobs.db"
+    store = SQLJobStore(sa.create_engine(url), create_schema=True, lease_seconds=2)
+    job_id = store.enqueue(
+        JobRequest(
+            lane=WITHIN_SECONDS,
+            kind="test.long",
+            tenant="acme",
+            max_attempts=3,
+            deadline_seconds=600,
+        )
+    )
+
+    script = tmp_path / "worker.py"
+    script.write_text(WORKER)
+    root = Path(__file__).resolve().parents[3]
+    # A fresh interpreter takes its first import path from the script, which is
+    # in a temporary directory, so it is told where the package is.
+    said = tmp_path / "worker.err"
+    doomed = subprocess.Popen(
+        [sys.executable, str(script), url],
+        cwd=str(root),
+        env={**os.environ, "PYTHONPATH": str(root)},
+        stderr=said.open("w"),
+    )
+    try:
+        _until(
+            lambda: store.read(job_id).state == "running",
+            "the job to start",
+            said=said,
+        )
+        assert store.read(job_id).leased_by == "doomed"
+
+        # Not a signal the worker can catch, tidy up after, or write anything
+        # in response to. Exactly what an out-of-memory kill looks like.
+        doomed.send_signal(signal.SIGKILL)
+        doomed.wait(timeout=10)
+
+        _until(
+            lambda: store.claim(WITHIN_SECONDS, "worker-2", 1) != [],
+            "the lapsed claim to be offered again",
+            wait=6,
+        )
+    finally:
+        if doomed.poll() is None:
+            doomed.kill()
+
+    taken = store.read(job_id)
+    assert taken.state == "running"
+    assert taken.leased_by == "worker-2"
+    assert taken.attempt == 2
+
+
+def _until(ready, what: str, wait: float = 10.0, said: Path = None) -> None:
+    until = time.monotonic() + wait
+    while time.monotonic() < until:
+        if ready():
+            return
+        time.sleep(0.1)
+    complaint = said.read_text().strip() if said and said.exists() else ""
+    raise AssertionError(
+        f"Waited {wait}s for {what} and it did not happen. {complaint}".strip()
+    )

--- a/src/tests/unit/test_core_jobs_store.py
+++ b/src/tests/unit/test_core_jobs_store.py
@@ -207,3 +207,30 @@ def test_a_delayed_job_is_not_offered_before_it_is_due(store, clock):
     assert store.claim(WITHIN_SECONDS, "worker-1", 5) == []
     clock.ahead(31)
     assert len(store.claim(WITHIN_SECONDS, "worker-1", 5)) == 1
+
+
+def test_finished_work_is_cleared_away_but_work_still_waiting_is_not(store, clock):
+    """Nothing clears this table on its own, so without pruning it grows for
+    as long as the deployment runs."""
+    done = store.enqueue(_asked())
+    (lease,) = store.claim(WITHIN_SECONDS, "worker-1", 5)
+    store.finish(lease, JobOutcome.ok())
+    waiting = store.enqueue(_asked(dedupe_slot="still-wanted"))
+
+    clock.ahead(15 * 24 * 60 * 60)
+    cleared = store.prune(keep_finished_for_days=14)
+
+    assert cleared == 1
+    assert store.read(done) is None
+    assert store.read(waiting).state == QUEUED
+
+
+def test_keeping_them_for_ever_is_a_choice_that_is_honoured(store, clock):
+    store.enqueue(_asked())
+    (lease,) = store.claim(WITHIN_SECONDS, "worker-1", 5)
+    store.finish(lease, JobOutcome.ok())
+
+    clock.ahead(400 * 24 * 60 * 60)
+
+    assert store.prune(keep_finished_for_days=0) == 0
+    assert store.read(lease.job.id) is not None

--- a/src/tests/unit/test_core_jobs_store.py
+++ b/src/tests/unit/test_core_jobs_store.py
@@ -234,3 +234,17 @@ def test_keeping_them_for_ever_is_a_choice_that_is_honoured(store, clock):
 
     assert store.prune(keep_finished_for_days=0) == 0
     assert store.read(lease.job.id) is not None
+
+
+def test_cancelling_gives_the_key_back_and_can_be_cleared_away(store, clock):
+    """Cancelled is an ending. Held open, the key blocks the same work from ever
+    being asked for again, and nothing tidying up would ever reach the row."""
+    first = store.enqueue(_asked(dedupe_slot="refresh:9"))
+
+    assert store.cancel(first) is True
+
+    second = store.enqueue(_asked(dedupe_slot="refresh:9"))
+    assert second != first
+
+    clock.ahead(15 * 24 * 60 * 60)
+    assert store.prune(keep_finished_for_days=14) == 1

--- a/src/tests/unit/test_core_jobs_store.py
+++ b/src/tests/unit/test_core_jobs_store.py
@@ -1,0 +1,209 @@
+"""How the queue behaves, whatever is keeping it.
+
+Every case here is written against the interface rather than against a store,
+so the database-backed one can be held to exactly the same behaviour. Where the
+two would differ, one of them is wrong.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import os
+
+import sqlalchemy as sa
+
+from src.core.jobs.memory import InMemoryJobStore
+from src.core.jobs.models import WITHIN_SECONDS, DEAD, QUEUED, JobOutcome, JobRequest
+from src.core.jobs.sql import SQLJobStore, metadata
+
+
+class Clock:
+    """A clock the test moves, so waiting is asserted rather than slept through."""
+
+    def __init__(self) -> None:
+        self.now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def ahead(self, seconds: int) -> None:
+        self.now += timedelta(seconds=seconds)
+
+
+@pytest.fixture
+def clock() -> Clock:
+    return Clock()
+
+
+# A real server is used where one is offered, because SQLite never reaches the
+# paths that matter most: `FOR UPDATE SKIP LOCKED`, and a failed insert rolled
+# back to a savepoint rather than taking the transaction with it.
+SERVERS = {
+    "mysql": os.environ.get("JOBS_TEST_MYSQL_URL", ""),
+    "postgres": os.environ.get("JOBS_TEST_POSTGRES_URL", ""),
+}
+STORES = ["memory", "sqlite"] + [name for name, url in SERVERS.items() if url]
+
+
+@pytest.fixture(params=STORES)
+def store(request, clock, tmp_path):
+    """Every store, held to the same behaviour.
+
+    The database-backed one is what production uses and the in-process one is
+    what tests and a stateless deployment use, so a difference between them is
+    a bug rather than a detail of storage.
+    """
+    if request.param == "memory":
+        return InMemoryJobStore(lease_seconds=60, cap=3, now=clock)
+    if request.param == "sqlite":
+        engine = sa.create_engine(f"sqlite:///{tmp_path}/jobs.db")
+    else:
+        engine = sa.create_engine(SERVERS[request.param])
+        metadata.drop_all(engine)
+    return SQLJobStore(engine, create_schema=True, lease_seconds=60, cap=3, now=clock)
+
+
+def _asked(**over) -> JobRequest:
+    asked = {"lane": WITHIN_SECONDS, "kind": "test.work", "tenant": "acme"}
+    asked.update(over)
+    return JobRequest(**asked)
+
+
+def test_a_job_is_claimed_run_and_finished(store):
+    store.enqueue(_asked())
+
+    (lease,) = store.claim(WITHIN_SECONDS, "worker-1", 5)
+    store.finish(lease, JobOutcome.ok())
+
+    assert store.read(lease.job.id).state == "succeeded"
+
+
+def test_work_from_a_killed_worker_is_offered_again_once_its_lease_lapses(store, clock):
+    """This is the whole point. A worker that is killed writes nothing, so
+    nothing running inside it can be what recovers the job."""
+    job_id = store.enqueue(_asked())
+    (first,) = store.claim(WITHIN_SECONDS, "worker-1", 5)
+    assert first.job.id == job_id
+
+    assert store.claim(WITHIN_SECONDS, "worker-2", 5) == []
+
+    clock.ahead(61)
+    (second,) = store.claim(WITHIN_SECONDS, "worker-2", 5)
+
+    assert second.job.id == job_id
+    assert second.job.attempt == 2
+
+
+def test_a_worker_whose_lease_was_taken_away_is_told_so(store, clock):
+    """It must stop rather than finish into a row somebody else now owns."""
+    store.enqueue(_asked())
+    (first,) = store.claim(WITHIN_SECONDS, "worker-1", 5)
+    assert store.heartbeat(first) is True
+
+    clock.ahead(61)
+    store.claim(WITHIN_SECONDS, "worker-2", 5)
+
+    assert store.heartbeat(first) is False
+
+
+def test_asking_twice_for_the_same_work_queues_it_once(store):
+    """A page that refreshes advisories on every view would otherwise pile up
+    thousands of identical durable jobs."""
+    first = store.enqueue(_asked(dedupe_slot="refresh:7"))
+    second = store.enqueue(_asked(dedupe_slot="refresh:7"))
+
+    assert first == second
+    assert len(store.pending(WITHIN_SECONDS)) == 1
+
+
+def test_the_same_work_can_be_asked_for_again_once_it_has_finished(store):
+    """Otherwise "not twice at once" quietly becomes "never again"."""
+    first = store.enqueue(_asked(dedupe_slot="refresh:7"))
+    (lease,) = store.claim(WITHIN_SECONDS, "worker-1", 5)
+    store.finish(lease, JobOutcome.ok())
+
+    second = store.enqueue(_asked(dedupe_slot="refresh:7"))
+
+    assert second != first
+
+
+def test_two_jobs_needing_the_same_files_do_not_run_at_once(store):
+    """Two initializations of one repository delete each other's checkout."""
+    store.enqueue(_asked(exclusive_key="working-area:5"))
+    store.enqueue(_asked(exclusive_key="working-area:5"))
+
+    claimed = store.claim(WITHIN_SECONDS, "worker-1", 5)
+
+    assert len(claimed) == 1
+
+
+def test_a_lock_held_by_a_worker_that_died_does_not_block_for_ever(store, clock):
+    """A mutex without an expiry replaces one outage with a longer one."""
+    store.enqueue(_asked(exclusive_key="working-area:5"))
+    store.enqueue(_asked(exclusive_key="working-area:5"))
+    store.claim(WITHIN_SECONDS, "worker-1", 1)
+
+    clock.ahead(61)
+    claimed = store.claim(WITHIN_SECONDS, "worker-2", 5)
+
+    assert len(claimed) == 1
+
+
+def test_work_that_must_not_run_twice_is_not_retried(store):
+    """Initialization writes proposals as it goes, so a second attempt at a
+    half-finished run proposes the same things again."""
+    store.enqueue(_asked(max_attempts=1))
+    (lease,) = store.claim(WITHIN_SECONDS, "worker-1", 5)
+
+    store.finish(lease, JobOutcome.failed("no", retry=True))
+
+    assert store.read(lease.job.id).state == DEAD
+
+
+def test_a_provider_asking_us_to_wait_is_waited_for(store, clock):
+    """A 429 carries how long to wait. Guessing instead is how a rate limit
+    becomes a failure."""
+    store.enqueue(_asked(max_attempts=3))
+    (lease,) = store.claim(WITHIN_SECONDS, "worker-1", 5)
+
+    store.finish(lease, JobOutcome.failed("429", retry=True, retry_in=120))
+
+    assert store.read(lease.job.id).state == QUEUED
+    assert store.claim(WITHIN_SECONDS, "worker-1", 5) == []
+    clock.ahead(121)
+    assert len(store.claim(WITHIN_SECONDS, "worker-1", 5)) == 1
+
+
+def test_handing_a_claim_back_does_not_count_as_an_attempt(store):
+    """A job taken but never started has not been tried."""
+    store.enqueue(_asked(max_attempts=1))
+    (lease,) = store.claim(WITHIN_SECONDS, "worker-1", 5)
+
+    store.release(lease)
+
+    assert store.read(lease.job.id).attempt == 0
+    assert store.read(lease.job.id).state == QUEUED
+
+
+def test_a_batch_counts_down_as_its_jobs_finish(store):
+    """Seven repositories at once should read as progress, not as six rows
+    where nothing appears to be happening."""
+    batch = store.open("initialize", total=2, tenant="acme")
+    store.enqueue(_asked(batch_id=batch.id))
+    store.enqueue(_asked(batch_id=batch.id))
+
+    for lease in store.claim(WITHIN_SECONDS, "worker-1", 5):
+        store.finish(lease, JobOutcome.ok())
+
+    done = store.read_batch(batch.id)
+    assert done.pending == 0
+    assert done.finished_at is not None
+
+
+def test_a_delayed_job_is_not_offered_before_it_is_due(store, clock):
+    store.enqueue(_asked(delay_seconds=30))
+
+    assert store.claim(WITHIN_SECONDS, "worker-1", 5) == []
+    clock.ahead(31)
+    assert len(store.claim(WITHIN_SECONDS, "worker-1", 5)) == 1

--- a/src/tests/unit/test_core_jobs_sweep.py
+++ b/src/tests/unit/test_core_jobs_sweep.py
@@ -43,3 +43,17 @@ def test_a_sweep_that_cannot_tidy_says_so_and_is_tried_again():
 
     assert outcome.succeeded is False
     assert outcome.retry is True
+
+
+def test_a_tidy_that_cannot_ask_for_the_next_one_is_tried_again():
+    """Each tidy asks for the next, so one that fails silently is the end of all
+    tidying, and the table grows from then on with nothing saying why."""
+
+    class Deaf(InMemoryJobStore):
+        def enqueue(self, request, *, session=None):
+            raise RuntimeError("no")
+
+    outcome = Sweeper(Deaf()).run()
+
+    assert outcome.succeeded is False
+    assert outcome.retry is True

--- a/src/tests/unit/test_core_jobs_sweep.py
+++ b/src/tests/unit/test_core_jobs_sweep.py
@@ -1,0 +1,45 @@
+"""The tidying, which asks for its own next run so nothing has to schedule it."""
+
+from src.core.jobs.memory import InMemoryJobStore
+from src.core.jobs.models import WITHIN_MINUTES
+from src.core.jobs.sweep import SWEEP_KIND, SWEEP_SLOT, Sweeper
+
+
+def test_a_sweep_asks_for_the_next_one_so_nothing_has_to_schedule_it():
+    """There is no scheduler anywhere in this estate, so a tidy that had to be
+    scheduled would simply never run."""
+    store = InMemoryJobStore()
+    sweeper = Sweeper(store, every_seconds=3600)
+
+    assert sweeper.run().succeeded is True
+
+    waiting = store.pending(WITHIN_MINUTES)
+    assert [job.kind for job in waiting] == [SWEEP_KIND]
+    assert waiting[0].dedupe_slot == SWEEP_SLOT
+
+
+def test_two_sweeps_cannot_be_queued_at_once():
+    """It runs every hour for the life of the deployment, so a duplicate would
+    not stay a duplicate for long."""
+    store = InMemoryJobStore()
+    sweeper = Sweeper(store)
+
+    first = sweeper.arrange()
+    second = sweeper.arrange()
+
+    assert first == second
+    assert len(store.pending(WITHIN_MINUTES)) == 1
+
+
+def test_a_sweep_that_cannot_tidy_says_so_and_is_tried_again():
+    """Tidying is not urgent, but a sweep that failed silently would be the end
+    of all tidying, because each one asks for the next."""
+
+    class Broken(InMemoryJobStore):
+        def prune(self, keep_finished_for_days: int = 14) -> int:
+            raise RuntimeError("no")
+
+    outcome = Sweeper(Broken()).run()
+
+    assert outcome.succeeded is False
+    assert outcome.retry is True

--- a/src/tests/unit/test_core_jobs_worker.py
+++ b/src/tests/unit/test_core_jobs_worker.py
@@ -127,3 +127,23 @@ def test_a_worker_asked_to_stop_does_not_take_more_work(store, services):
 
     assert worker.work() == 0
     assert handler.ran == []
+
+
+def test_a_handler_that_answers_with_something_else_is_a_failure(store, services):
+    """A handler is somebody else's code. One that returns nothing, or the wrong
+    thing, must not take the worker down on the way to recording it."""
+
+    class Confused:
+        kind = "test.work"
+
+        def run(self, job):
+            return "done!"
+
+    services.contribute(JobHandler, Confused(), "test")
+    job_id = store.enqueue(_asked())
+
+    _worker(store, services).work(max_jobs=1)
+
+    kept = store.read(job_id)
+    assert kept.state == "dead"
+    assert "did not say how it went" in kept.error

--- a/src/tests/unit/test_core_jobs_worker.py
+++ b/src/tests/unit/test_core_jobs_worker.py
@@ -1,0 +1,129 @@
+"""What a worker does with a job, including when the job misbehaves."""
+
+import pytest
+
+from src.core.jobs.interfaces import JobHandler, JobMiddleware
+from src.core.jobs.memory import InMemoryJobStore
+from src.core.jobs.models import WITHIN_SECONDS, JobOutcome, JobRequest
+from src.core.jobs.worker import DEADLINE_EXIT, Worker
+from src.core.services import ServiceRegistry
+
+
+class Handler:
+    def __init__(self, kind="test.work", answer=None, raises=None, blocks=None):
+        self.kind = kind
+        self._answer = answer or JobOutcome.ok()
+        self._raises = raises
+        self._blocks = blocks
+        self.ran = []
+
+    def run(self, job):
+        self.ran.append(job.id)
+        if self._raises:
+            raise self._raises
+        if self._blocks is not None:
+            self._blocks.wait()
+        return self._answer
+
+
+@pytest.fixture
+def services():
+    return ServiceRegistry()
+
+
+@pytest.fixture
+def store():
+    return InMemoryJobStore(lease_seconds=60, cap=3)
+
+
+def _worker(store, services, **over):
+    return Worker(store, WITHIN_SECONDS, name="worker-1", services=services, **over)
+
+
+def _asked(**over):
+    asked = {"lane": WITHIN_SECONDS, "kind": "test.work", "tenant": "acme"}
+    asked.update(over)
+    return JobRequest(**asked)
+
+
+def test_a_job_reaches_the_handler_that_claims_its_kind(store, services):
+    handler = Handler()
+    services.contribute(JobHandler, handler, "test")
+    job_id = store.enqueue(_asked())
+
+    _worker(store, services).work(max_jobs=1)
+
+    assert handler.ran == [job_id]
+    assert store.read(job_id).state == "succeeded"
+
+
+def test_a_handler_that_raises_is_recorded_rather_than_lost(store, services):
+    """A job that vanishes is worse than one that failed, because nothing says
+    it needs looking at."""
+    services.contribute(JobHandler, Handler(raises=ValueError("nope")), "test")
+    job_id = store.enqueue(_asked())
+
+    _worker(store, services).work(max_jobs=1)
+
+    kept = store.read(job_id)
+    assert kept.state == "dead"
+    assert "nope" in kept.error
+
+
+def test_work_nothing_here_handles_says_so(store, services):
+    """A plugin may be installed on one deployment and not another, so this is
+    a fact about this machine rather than about the job."""
+    job_id = store.enqueue(_asked(kind="somebody.elses.work"))
+
+    _worker(store, services).work(max_jobs=1)
+
+    assert "no handler" in store.read(job_id).error
+
+
+def test_middleware_can_hold_a_job_back_before_it_runs(store, services):
+    """This is how a provider that has just refused us stops being asked."""
+
+    class Holding:
+        def before(self, job):
+            return JobOutcome.failed("not now", retry=True, retry_in=30)
+
+        def after(self, job, outcome):
+            return outcome
+
+    handler = Handler()
+    services.contribute(JobHandler, handler, "test")
+    services.contribute(JobMiddleware, Holding(), "test")
+    job_id = store.enqueue(_asked(max_attempts=3))
+
+    _worker(store, services).work(max_jobs=1)
+
+    assert handler.ran == []
+    assert store.read(job_id).state == "queued"
+
+
+def test_a_job_that_outruns_its_deadline_takes_the_worker_down_with_it(store, services):
+    """The work cannot be stopped from inside this process, so recording it as
+    finished while it carried on writing would be a lie. The process goes."""
+    import threading
+
+    never = threading.Event()
+    services.contribute(JobHandler, Handler(blocks=never), "test")
+    job_id = store.enqueue(_asked(deadline_seconds=1))
+    halted = []
+
+    _worker(store, services, halt=halted.append).work(max_jobs=1)
+    never.set()
+
+    assert halted == [DEADLINE_EXIT]
+    assert "went past" in store.read(job_id).error
+
+
+def test_a_worker_asked_to_stop_does_not_take_more_work(store, services):
+    handler = Handler()
+    services.contribute(JobHandler, handler, "test")
+    store.enqueue(_asked())
+    worker = _worker(store, services)
+    worker.stop()
+
+    assert worker.work() == 0
+    assert handler.ran == []

--- a/src/tests/unit/test_core_sqlite_jobs.py
+++ b/src/tests/unit/test_core_sqlite_jobs.py
@@ -1,0 +1,57 @@
+"""The queue has to build on every database a deployment might use.
+
+MySQL counts four bytes a character in an index and refuses a key over 3072 of
+them, which is what has already caught this estate once. A test is cheaper than
+finding out when somebody's migration fails.
+"""
+
+from sqlalchemy.dialects import mysql, postgresql
+from sqlalchemy.schema import CreateIndex, CreateTable
+
+from src.core.jobs.sql import job_batch_table, job_lock_table, job_table
+
+TABLES = (job_table, job_lock_table, job_batch_table)
+
+
+def _mysql_bytes(columns) -> int:
+    """What MySQL counts these columns as, reserving four bytes a character."""
+    total = 0
+    for column in columns:
+        kind = column.type.dialect_impl(mysql.dialect())
+        total += (kind.length * 4) if getattr(kind, "length", None) else 8
+    return total
+
+
+def test_every_key_fits_inside_what_mysql_allows():
+    for table in TABLES:
+        assert _mysql_bytes(table.primary_key) <= 3072, table.name
+        for index in table.indexes:
+            assert _mysql_bytes(index.columns) <= 3072, f"{table.name}.{index.name}"
+
+
+def test_the_tables_build_on_mysql_and_postgres():
+    for table in TABLES:
+        for dialect in (mysql.dialect(), postgresql.dialect()):
+            ddl = str(CreateTable(table).compile(dialect=dialect))
+            assert table.name in ddl
+
+
+def test_at_most_one_queued_job_holds_a_dedupe_key():
+    """A plain unique index rather than a partial one, because MySQL has no
+    partial indexes. A finished job gives its key up so the same work can be
+    asked for again."""
+    unique = [index for index in job_table.indexes if index.unique]
+
+    assert [index.name for index in unique] == ["ux_jobs_dedupe"]
+    for dialect in (mysql.dialect(), postgresql.dialect()):
+        ddl = str(CreateIndex(unique[0]).compile(dialect=dialect))
+        assert "UNIQUE" in ddl and "dedupe_slot" in ddl
+
+
+def test_no_column_type_is_available_on_only_one_database():
+    """Nothing here may use a type that would tie the core to Postgres. The
+    estate has just paid to keep MySQL working."""
+    for table in TABLES:
+        for dialect in (mysql.dialect(), postgresql.dialect()):
+            for column in table.columns:
+                assert column.type.dialect_impl(dialect) is not None

--- a/src/tests/unit/test_dispatcher.py
+++ b/src/tests/unit/test_dispatcher.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import MagicMock, patch
 from fastapi import BackgroundTasks
-from src.events.dispatcher import EventDispatcher, bg_tasks_cv
+from src.events.dispatcher import DELIVERY_TIMEOUT, EventDispatcher, bg_tasks_cv
 from src.events.repository_event import RepositoryEvent
 
 
@@ -37,7 +37,9 @@ class TestDispatcher:
             dispatcher.dispatch(dummy_event)
 
             mock_q.enqueue.assert_called_once_with(
-                dispatcher._process_event_sync, dummy_event
+                dispatcher._process_event_sync,
+                dummy_event,
+                job_timeout=DELIVERY_TIMEOUT,
             )
 
     def test_dispatch_uses_redislite_when_mode_is_redislite(self, monkeypatch):
@@ -50,5 +52,13 @@ class TestDispatcher:
             dispatcher.dispatch(dummy_event)
 
             mock_q.enqueue.assert_called_once_with(
-                dispatcher._process_event_sync, dummy_event
+                dispatcher._process_event_sync,
+                dummy_event,
+                job_timeout=DELIVERY_TIMEOUT,
             )
+
+
+def test_a_delivery_is_given_longer_than_the_queue_would_allow_by_default():
+    """The queue stops a job at 180 seconds unless told otherwise, and a review
+    of a large change asks a model several times and takes longer than that."""
+    assert DELIVERY_TIMEOUT > 180

--- a/src/tests/unit/test_model_catalogue_api.py
+++ b/src/tests/unit/test_model_catalogue_api.py
@@ -150,16 +150,16 @@ def test_a_provider_that_stops_answering_does_not_hold_the_request(client):
 def test_a_mistyped_timeout_does_not_stop_the_process_starting(monkeypatch):
     """It is read at import, so anything that raises takes the deployment down
     before it serves a request."""
-    from src.core.model.catalogue import _seconds
+    from src.config.settings import whole_number
 
     monkeypatch.setenv("A_TIMEOUT", "half a minute")
-    assert _seconds("A_TIMEOUT", 15) == 15
+    assert whole_number("A_TIMEOUT", 15) == 15
 
     monkeypatch.setenv("A_TIMEOUT", "0")
-    assert _seconds("A_TIMEOUT", 15) == 15
+    assert whole_number("A_TIMEOUT", 15) == 15
 
     monkeypatch.setenv("A_TIMEOUT", "45")
-    assert _seconds("A_TIMEOUT", 15) == 45
+    assert whole_number("A_TIMEOUT", 15) == 45
 
 
 def test_the_key_is_never_read_back(client):


### PR DESCRIPTION
Adds a job subsystem in the core. Work is kept in the database, split into lanes named by the latency they promise, and shared equally between tenants up to a fixed cap per workspace.

Nothing uses it yet. Background work still runs through the existing queue, so the only behaviour that changes is that a webhook delivery is no longer stopped after 180 seconds.

### Why a table and not a queue library

The core has to run on SQLite, MySQL and Postgres.

| Library | Where the queue lives |
|---|---|
| Celery, Dramatiq, RQ, Taskiq | Redis or RabbitMQ |
| Huey | Redis, SQLite, files |
| SAQ | Redis, Postgres |
| procrastinate, pgqueuer | Postgres |
| Temporal | a server of its own |

None covers those three engines. Keeping the queue in the same database also lets an enqueue join the caller's transaction, so a row and the job about it cannot disagree.

`FOR UPDATE SKIP LOCKED` comes from one SQLAlchemy expression on Postgres and MySQL, and SQLite drops it. Correctness rests on a compare and swap. Skipping locked rows is only an optimisation.

### A lease is not a deadline

A claim lapses when a worker stops renewing it, and the next worker to look is offered the job again. That is how work survives a worker being killed, and it happens as jobs are claimed, so nothing has to be scheduled.

A job that outruns its deadline cannot be stopped from inside the process, so the process stops and takes the work with it.

Delivery is at least once. Work that must not repeat says so with `max_attempts=1`.

### Fairness

Tenants take turns, least recently served first, up to `jobs.per_workspace` at once. A tenant with one job waiting is served on the first rotation rather than behind another tenant's backlog.
