### PR TITLE
fix(jobs): Stop the queue repeating work it was told to do once

### DIFF
--- a/src/cli/work_command.py
+++ b/src/cli/work_command.py
@@ -8,8 +8,10 @@ cannot be stopped. Running several is a matter for whatever starts them.
 import click
 
 from src.config.db import get_engine
-from src.core.jobs import WITHIN_SECONDS, LANES, job_store
+from src.core.jobs import LANES, WITHIN_MINUTES, WITHIN_SECONDS, JobHandler, job_store
+from src.core.jobs.sweep import Sweeper
 from src.core.jobs.worker import Worker
+from src.core.services import service_registry
 from src.utils.logger import logger
 
 
@@ -43,7 +45,13 @@ def work_command(lane, name, poll, max_jobs, max_time):
             "Background work runs in the request that asked for it instead."
         )
 
-    worker = Worker(job_store(), lane, name=name, poll_seconds=poll)
+    store = job_store()
+    sweeper = Sweeper(store)
+    service_registry.contribute(JobHandler, sweeper, "sourceant_core")
+    if lane == WITHIN_MINUTES:
+        sweeper.arrange(store)
+
+    worker = Worker(store, lane, name=name, poll_seconds=poll)
     worker.attend()
     logger.info(f"{worker.name} is working the {lane} lane")
     done = worker.work(max_jobs=max_jobs, max_time=max_time)

--- a/src/core/jobs/sql.py
+++ b/src/core/jobs/sql.py
@@ -145,6 +145,23 @@ def _naive(moment: datetime) -> datetime:
     return moment.astimezone(timezone.utc).replace(tzinfo=None)
 
 
+def _offerable(now: datetime):
+    """Work a claim may take: never started, or abandoned with a try to spare.
+
+    A claim that has lapsed is only offered again while the job has an attempt
+    left. Without that, work asked for once runs twice whenever the worker
+    holding it is killed, which is the one thing `max_attempts=1` is for.
+    """
+    return or_(
+        and_(job_table.c.state == QUEUED, job_table.c.available_at <= now),
+        and_(
+            job_table.c.state == RUNNING,
+            job_table.c.lease_until <= now,
+            job_table.c.attempt < job_table.c.max_attempts,
+        ),
+    )
+
+
 class SQLJobStore:
     """Jobs kept in a database, claimed by compare and swap."""
 
@@ -233,11 +250,27 @@ class SQLJobStore:
                 ).inserted_primary_key[0]
         except IntegrityError:
             existing = connection.execute(
-                select(job_table.c.id).where(job_table.c.dedupe_slot == slot)
-            ).scalar()
+                select(job_table.c.id, job_table.c.state).where(
+                    job_table.c.dedupe_slot == slot
+                )
+            ).one_or_none()
             if existing is None:
                 raise
-            return existing
+            if existing.state == QUEUED:
+                return existing.id
+            # The key says at most one job waits under it, and this one is no
+            # longer waiting. A job asking for its own successor holds its key
+            # until it finishes, so leaving it would mean the successor is
+            # never asked for at all.
+            connection.execute(
+                update(job_table)
+                .where(job_table.c.id == existing.id)
+                .values(dedupe_slot=f"job:{uuid.uuid4()}")
+            )
+            with connection.begin_nested():
+                return connection.execute(
+                    job_table.insert().values(**values)
+                ).inserted_primary_key[0]
 
     def claim(self, lane: str, worker: str, budget: int) -> Sequence[Lease]:
         """Take up to `budget` jobs for this worker, fairly.
@@ -256,7 +289,8 @@ class SQLJobStore:
                 delete(job_lock_table).where(job_lock_table.c.expires_at <= now)
             )
             held |= self._locked(connection, now)
-            candidates = self._candidates(connection, lane, now)
+            spent = [who for who, count in busy.items() if count >= self._cap]
+            candidates = self._candidates(connection, lane, now, spent)
 
         chosen = share(
             candidates,
@@ -290,11 +324,7 @@ class SQLJobStore:
             .group_by(job_table.c.tenant)
         ).all()
         busy = {tenant: count for tenant, count, _ in rows}
-        last_served = {
-            tenant: _naive(claimed).timestamp()
-            for tenant, _, claimed in rows
-            if claimed is not None
-        }
+        last_served = self._turns(connection, lane, now)
         running_keys = connection.execute(
             select(job_table.c.exclusive_key).where(
                 and_(
@@ -306,6 +336,31 @@ class SQLJobStore:
         ).scalars()
         return busy, set(running_keys), last_served
 
+    def _turns(self, connection, lane: str, now: datetime) -> dict:
+        """When each tenant last had a turn, whether or not it still holds one.
+
+        Reading this from what is running would forget a tenant the moment its
+        job ended, and a tenant that has just been served would then sort as
+        one that never has.
+        """
+        recent = now - timedelta(days=1)
+        rows = connection.execute(
+            select(job_table.c.tenant, func.max(job_table.c.claimed_at))
+            .where(
+                and_(
+                    job_table.c.lane == lane,
+                    job_table.c.claimed_at.is_not(None),
+                    job_table.c.claimed_at > recent,
+                )
+            )
+            .group_by(job_table.c.tenant)
+        ).all()
+        return {
+            tenant: _naive(claimed).timestamp()
+            for tenant, claimed in rows
+            if claimed is not None
+        }
+
     def _locked(self, connection, now: datetime) -> set:
         return set(
             connection.execute(
@@ -313,28 +368,28 @@ class SQLJobStore:
             ).scalars()
         )
 
-    def _candidates(self, connection, lane: str, now: datetime) -> list:
-        """Queued and due, or running on a claim that has lapsed."""
+    def _candidates(
+        self, connection, lane: str, now: datetime, spent: Sequence[str] = ()
+    ) -> list:
+        """Queued and due, or running on a claim that has lapsed.
+
+        A tenant already at its cap is left out rather than filtered later. A
+        window filled with work nobody may start yet hides everybody else's,
+        and the worker takes nothing while another tenant waits.
+        """
         query = (
             select(job_table.c.id, job_table.c.tenant, job_table.c.exclusive_key)
             .where(
                 and_(
                     job_table.c.lane == lane,
-                    or_(
-                        and_(
-                            job_table.c.state == QUEUED,
-                            job_table.c.available_at <= now,
-                        ),
-                        and_(
-                            job_table.c.state == RUNNING,
-                            job_table.c.lease_until <= now,
-                        ),
-                    ),
+                    _offerable(now),
                 )
             )
             .order_by(job_table.c.priority.desc(), job_table.c.id)
             .limit(self._window)
         )
+        if spent:
+            query = query.where(job_table.c.tenant.notin_(list(spent)))
         if self._engine.dialect.name in SKIPS_LOCKED:
             query = query.with_for_update(skip_locked=True)
         return [
@@ -363,21 +418,7 @@ class SQLJobStore:
 
             claimed = connection.execute(
                 update(job_table)
-                .where(
-                    and_(
-                        job_table.c.id == job_id,
-                        or_(
-                            and_(
-                                job_table.c.state == QUEUED,
-                                job_table.c.available_at <= now,
-                            ),
-                            and_(
-                                job_table.c.state == RUNNING,
-                                job_table.c.lease_until <= now,
-                            ),
-                        ),
-                    )
-                )
+                .where(and_(job_table.c.id == job_id, _offerable(now)))
                 .values(
                     state=RUNNING,
                     leased_by=worker,
@@ -630,12 +671,44 @@ class SQLJobStore:
                         )
                     )
                 ).rowcount
+            self._bury(connection, now)
             # A lock outliving its job would hold work back for ever, and the
             # claim only passes over ones that have not expired yet.
             connection.execute(
                 delete(job_lock_table).where(job_lock_table.c.expires_at <= now)
             )
             return cleared or 0
+
+    def _bury(self, connection, now: datetime) -> None:
+        """Settle work whose worker went away with no attempt left.
+
+        The claim will not offer it again, so without this it stays running for
+        ever and its dedupe key stays taken.
+        """
+        abandoned = connection.execute(
+            select(job_table).where(
+                and_(
+                    job_table.c.state == RUNNING,
+                    job_table.c.lease_until <= now,
+                    job_table.c.attempt >= job_table.c.max_attempts,
+                )
+            )
+        ).all()
+        for row in abandoned:
+            self._unlock(connection, row)
+            connection.execute(
+                update(job_table)
+                .where(job_table.c.id == row.id)
+                .values(
+                    state=DEAD,
+                    error="the worker holding this went away",
+                    finished_at=now,
+                    lease_until=None,
+                    leased_by=None,
+                    dedupe_slot=f"job:{uuid.uuid4()}",
+                )
+            )
+            self._settle(connection, row, now, failed=True)
 
     def cancel(self, job_id: int) -> bool:
         with self._engine.begin() as connection:

--- a/src/core/jobs/sql.py
+++ b/src/core/jobs/sql.py
@@ -262,12 +262,12 @@ class SQLJobStore:
             # longer waiting. A job asking for its own successor holds its key
             # until it finishes, so leaving it would mean the successor is
             # never asked for at all.
-            connection.execute(
-                update(job_table)
-                .where(job_table.c.id == existing.id)
-                .values(dedupe_slot=f"job:{uuid.uuid4()}")
-            )
             with connection.begin_nested():
+                connection.execute(
+                    update(job_table)
+                    .where(job_table.c.id == existing.id)
+                    .values(dedupe_slot=f"job:{uuid.uuid4()}")
+                )
                 return connection.execute(
                     job_table.insert().values(**values)
                 ).inserted_primary_key[0]

--- a/src/core/jobs/worker.py
+++ b/src/core/jobs/worker.py
@@ -33,6 +33,13 @@ from .models import Job, JobOutcome, Lease
 #: understood as intended rather than as a crash.
 DEADLINE_EXIT = 75
 
+#: Told to the supervisor when the claim on the job in hand was taken by
+#: somebody else, which means two copies of it are running.
+LOST_EXIT = 76
+
+#: How often the wait on a job looks up to see whether the claim is still ours.
+WATCH_SECONDS = 1.0
+
 
 class Worker:
     """Claims work for one lane and does it."""
@@ -161,7 +168,13 @@ class Worker:
 
         doing = threading.Thread(target=perform, name=f"job-{job.id}", daemon=True)
         doing.start()
-        doing.join(timeout=job.deadline_seconds)
+
+        left = float(job.deadline_seconds)
+        while left > 0 and doing.is_alive():
+            doing.join(timeout=min(WATCH_SECONDS, left))
+            left -= WATCH_SECONDS
+            if beating.lost and doing.is_alive():
+                return self._taken(job, beating)
 
         if doing.is_alive():
             return self._overran(job, lease, beating)
@@ -195,6 +208,21 @@ class Worker:
             logger.warning("Could not record the job that overran", exc_info=True)
         self._halt(DEADLINE_EXIT)
         return JobOutcome.failed(f"went past {job.deadline_seconds}s")
+
+    def _taken(self, job: Job, beating: "_Heartbeat") -> JobOutcome:
+        """Stop once the claim has gone to somebody else.
+
+        Another worker is running this job now. The copy here cannot be halted
+        from this thread, so the process goes and takes it with it, which is
+        the only way two of them do not write over each other.
+        """
+        logger.error(
+            f"The claim on job {job.id} ({job.kind}) went to another worker; "
+            f"{self._name} is stopping so this copy cannot carry on"
+        )
+        beating.stop()
+        self._halt(LOST_EXIT)
+        return JobOutcome.failed("the claim on this job was taken")
 
     def _handler(self, kind: str) -> Optional[JobHandler]:
         for handler in self._services.contributions(JobHandler):

--- a/src/tests/unit/test_core_jobs_claims.py
+++ b/src/tests/unit/test_core_jobs_claims.py
@@ -1,0 +1,170 @@
+"""What a claim may take, and what happens when one is lost.
+
+Every case here was a way the queue did the same work twice, or stopped doing
+it at all. They are checked against the store rather than argued about.
+"""
+
+import threading
+import time
+
+import sqlalchemy as sa
+
+from src.core.jobs.interfaces import JobHandler
+from src.core.jobs.models import (
+    DEAD,
+    RUNNING,
+    WITHIN_MINUTES,
+    WITHIN_SECONDS,
+    JobOutcome,
+    JobRequest,
+)
+from src.core.jobs.sql import SQLJobStore, job_table
+from src.core.jobs.sweep import SWEEP_SLOT, Sweeper
+from src.core.jobs.worker import LOST_EXIT, Worker
+from src.core.services import ServiceRegistry
+
+
+def store_at(tmp_path, **kwargs) -> SQLJobStore:
+    engine = sa.create_engine(f"sqlite:///{tmp_path}/jobs.db")
+    return SQLJobStore(engine, create_schema=True, **kwargs)
+
+
+def abandon(store: SQLJobStore, job_id: int) -> None:
+    """Leave a job claimed by a worker that is never coming back."""
+    with store._engine.begin() as connection:
+        connection.execute(
+            sa.update(job_table)
+            .where(job_table.c.id == job_id)
+            .values(lease_until=sa.text("'1970-01-01 00:00:00'"))
+        )
+
+
+def test_work_asked_for_once_is_not_offered_again_after_a_worker_dies(tmp_path):
+    store = store_at(tmp_path)
+    job_id = store.enqueue(
+        JobRequest(lane=WITHIN_SECONDS, kind="test.once", max_attempts=1)
+    )
+
+    assert [lease.job.id for lease in store.claim(WITHIN_SECONDS, "first", 1)] == [
+        job_id
+    ]
+    abandon(store, job_id)
+
+    assert store.claim(WITHIN_SECONDS, "second", 1) == []
+    assert store.read(job_id).attempt == 1
+
+
+def test_work_asked_for_twice_is_offered_again_after_a_worker_dies(tmp_path):
+    store = store_at(tmp_path)
+    job_id = store.enqueue(
+        JobRequest(lane=WITHIN_SECONDS, kind="test.twice", max_attempts=2)
+    )
+
+    store.claim(WITHIN_SECONDS, "first", 1)
+    abandon(store, job_id)
+
+    assert [lease.job.id for lease in store.claim(WITHIN_SECONDS, "second", 1)] == [
+        job_id
+    ]
+    assert store.read(job_id).attempt == 2
+
+
+def test_work_nobody_may_take_again_stops_saying_it_is_running(tmp_path):
+    store = store_at(tmp_path)
+    job_id = store.enqueue(
+        JobRequest(lane=WITHIN_SECONDS, kind="test.once", max_attempts=1)
+    )
+    store.claim(WITHIN_SECONDS, "first", 1)
+    abandon(store, job_id)
+
+    store.prune(0)
+
+    assert store.read(job_id).state == DEAD
+
+
+def test_a_backlog_for_one_tenant_does_not_hide_another_tenants_work(tmp_path):
+    store = store_at(tmp_path, cap=1, worker_window=5)
+    for _ in range(6):
+        store.enqueue(
+            JobRequest(lane=WITHIN_SECONDS, kind="test.many").for_("busy-tenant")
+        )
+    waiting = store.enqueue(
+        JobRequest(lane=WITHIN_SECONDS, kind="test.one").for_("quiet-tenant")
+    )
+
+    store.claim(WITHIN_SECONDS, "first", 1)
+
+    taken = [lease.job.id for lease in store.claim(WITHIN_SECONDS, "second", 1)]
+    assert taken == [waiting]
+
+
+def test_two_tenants_take_turns_rather_than_one_going_twice(tmp_path):
+    store = store_at(tmp_path, cap=1)
+    for tenant in ("a", "b"):
+        for _ in range(2):
+            store.enqueue(
+                JobRequest(lane=WITHIN_SECONDS, kind="test.turns").for_(tenant)
+            )
+
+    served = []
+    for _ in range(3):
+        for lease in store.claim(WITHIN_SECONDS, "worker", 1):
+            served.append(lease.job.tenant)
+            store.finish(lease, JobOutcome.ok())
+
+    assert served == ["a", "b", "a"]
+
+
+def test_a_tidy_asks_for_the_next_one_while_it_is_still_running(tmp_path):
+    store = store_at(tmp_path)
+    sweeper = Sweeper(store, every_seconds=0)
+    first = sweeper.arrange(store)
+    lease = store.claim(WITHIN_MINUTES, "worker", 1)[0]
+    assert lease.job.id == first
+
+    outcome = sweeper.run(lease.job)
+    store.finish(lease, outcome)
+
+    assert outcome.succeeded
+    queued = [job for job in store.pending(lane=WITHIN_MINUTES) if job.id != first]
+    assert len(queued) == 1
+    assert queued[0].dedupe_slot == SWEEP_SLOT
+
+
+def test_a_worker_whose_claim_is_taken_stops_rather_than_carrying_on(tmp_path):
+    store = store_at(tmp_path, lease_seconds=1)
+    store.enqueue(JobRequest(lane=WITHIN_SECONDS, kind="test.slow", max_attempts=2))
+
+    running = threading.Event()
+
+    class Slow:
+        kind = "test.slow"
+
+        def run(self, job):
+            running.set()
+            time.sleep(10)
+            return JobOutcome.ok()
+
+    services = ServiceRegistry()
+    services.contribute(JobHandler, Slow(), "test")
+
+    halted = []
+    worker = Worker(
+        store,
+        WITHIN_SECONDS,
+        name="first",
+        poll_seconds=0.05,
+        heartbeat_seconds=0.2,
+        services=services,
+        halt=halted.append,
+    )
+    lease = store.claim(WITHIN_SECONDS, "first", 1)[0]
+    doing = threading.Thread(target=worker.perform, args=(lease,), daemon=True)
+    doing.start()
+    assert running.wait(5)
+
+    abandon(store, lease.job.id)
+    store.claim(WITHIN_SECONDS, "second", 1)
+
+    doing.join(timeout=15)
+    assert halted == [LOST_EXIT]

--- a/src/tests/unit/test_core_jobs_store.py
+++ b/src/tests/unit/test_core_jobs_store.py
@@ -82,7 +82,7 @@ def test_a_job_is_claimed_run_and_finished(store):
 def test_work_from_a_killed_worker_is_offered_again_once_its_lease_lapses(store, clock):
     """This is the whole point. A worker that is killed writes nothing, so
     nothing running inside it can be what recovers the job."""
-    job_id = store.enqueue(_asked())
+    job_id = store.enqueue(_asked(max_attempts=2))
     (first,) = store.claim(WITHIN_SECONDS, "worker-1", 5)
     assert first.job.id == job_id
 


### PR DESCRIPTION
Reclaiming a lapsed claim now asks whether the job has an attempt left. Without that, `max_attempts=1` did nothing in the one case it exists for, a worker killed mid-job, and work asked for once ran twice. Work with no attempt left is settled as dead rather than offered again or left saying it is running for ever.

The rest, in the same subsystem, found while reviewing the change that puts webhook deliveries on it:

- A worker stops when its claim is taken, instead of carrying on while another worker runs the same job. A copy already running cannot be halted any other way, so it stops the way it does when work outruns its deadline.
- Turns between tenants come from when each was last served, not from what it holds now. A tenant whose job had just finished read as one never served and went again immediately.
- A tenant with no room left is dropped from the window a worker looks at, so its backlog stops hiding everybody else's work behind jobs nobody was allowed to start.
- Tidying frees its own key before asking for the next one, and a worker now starts the first. It was getting itself back instead, and nothing queued another.

One existing test asserted the first fault as correct behaviour. It now asks for a job with a retry to spare.
