### PR TITLE
refactor(config): Read a setting that must be one of a few in one place

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -14,14 +14,27 @@ REQUIRE_GATEWAY = os.getenv("REQUIRE_GATEWAY", "false").lower() == "true"
 # 'sourceant serve' turns it on, being the local command. Deployments run
 # uvicorn directly and leave it off unless an operator means otherwise.
 LOCAL_MODE = os.getenv("SOURCEANT_LOCAL", "false").lower() == "true"
-VALID_QUEUE_MODES = ["database", "redis", "request", "redislite"]
+
+
+def choice(name: str, among: tuple[str, ...], fallback: str) -> str:
+    """One of a few known values from the environment, or the fallback.
+
+    Read as the process starts, so a value nothing here handles stops a
+    deployment rather than turning up later as work that quietly never happens.
+    """
+    given = os.getenv(name, "").strip().lower() or fallback
+    if given in among:
+        return given
+    raise ValueError(f"{name} must be one of {', '.join(among)}, not {given!r}")
+
+
 # A deployment that keeps nothing has nowhere to put background work, so it
 # does the work in the request that asked for it.
-QUEUE_MODE = os.getenv("QUEUE_MODE", "request" if STATELESS_MODE else "database")
-if QUEUE_MODE not in VALID_QUEUE_MODES:
-    raise ValueError(
-        f"Invalid QUEUE_MODE: {QUEUE_MODE}. Must be one of {VALID_QUEUE_MODES}"
-    )
+QUEUE_MODE = choice(
+    "QUEUE_MODE",
+    ("database", "redis", "redislite", "request"),
+    "request" if STATELESS_MODE else "database",
+)
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 if not STATELESS_MODE and DATABASE_URL is None:

--- a/src/events/dispatcher.py
+++ b/src/events/dispatcher.py
@@ -9,7 +9,6 @@ from rq import Queue
 
 from src.config.settings import (
     QUEUE_MODE,
-    VALID_QUEUE_MODES,
     REDIS_HOST,
     REDIS_PORT,
 )
@@ -79,10 +78,7 @@ class EventDispatcher:
                 )
             background_tasks.add_task(self._process_event_sync, event)
         else:
-            raise ValueError(
-                f"Unknown QUEUE_MODE: '{QUEUE_MODE}'. Must be one of "
-                f"{', '.join(VALID_QUEUE_MODES)}."
-            )
+            raise ValueError(f"Nothing here dispatches with QUEUE_MODE {QUEUE_MODE!r}")
 
     def deliver(self, event: Event) -> Dict[str, Any]:
         """Do what a delivery asks for, here, in the caller's process.

--- a/src/tests/unit/test_core_settings.py
+++ b/src/tests/unit/test_core_settings.py
@@ -161,3 +161,29 @@ class TestOrganizationOf:
 
     def test_has_no_organisation_without_one(self):
         assert organization_of("dashboard") is None
+
+
+class TestASettingThatMustBeOneOfAFew:
+    def test_the_fallback_is_taken_when_nothing_is_set(self, monkeypatch):
+        from src.config.settings import choice
+
+        monkeypatch.delenv("A_MODE", raising=False)
+
+        assert choice("A_MODE", ("one", "two"), "two") == "two"
+
+    def test_a_value_nothing_handles_stops_the_process(self, monkeypatch):
+        """Left to run, it would turn up later as work that quietly never
+        happens rather than as anything anyone could see."""
+        from src.config.settings import choice
+
+        monkeypatch.setenv("A_MODE", "three")
+
+        with pytest.raises(ValueError, match="one, two"):
+            choice("A_MODE", ("one", "two"), "one")
+
+    def test_it_is_read_however_it_was_typed(self, monkeypatch):
+        from src.config.settings import choice
+
+        monkeypatch.setenv("A_MODE", "  ONE ")
+
+        assert choice("A_MODE", ("one", "two"), "two") == "one"

--- a/src/utils/review_cache.py
+++ b/src/utils/review_cache.py
@@ -12,7 +12,6 @@ get the saving.
 """
 
 import json
-import os
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
@@ -20,19 +19,14 @@ import sqlalchemy as sa
 from sqlalchemy.exc import IntegrityError
 
 from src.config.db import get_engine
-from src.config.settings import REDIS_HOST, REDIS_PORT
+from src.config.settings import REDIS_HOST, REDIS_PORT, choice
 from src.core.settings import value_of
 from src.models.cached_review import CachedReview
 from src.utils.logger import logger
 
 SECONDS_PER_DAY = 24 * 60 * 60
 
-VALID_REVIEW_CACHES = ["database", "redis"]
-REVIEW_CACHE = os.getenv("REVIEW_CACHE", "database").lower()
-if REVIEW_CACHE not in VALID_REVIEW_CACHES:
-    raise ValueError(
-        f"Invalid REVIEW_CACHE: {REVIEW_CACHE}. Must be one of {VALID_REVIEW_CACHES}"
-    )
+REVIEW_CACHE = choice("REVIEW_CACHE", ("database", "redis"), "database")
 
 _client = None
 _unavailable = False


### PR DESCRIPTION
A setting that must be one of a few known values is now read by one helper, beside the one already reading whole numbers from the environment the same way.

Each such setting used to carry a list of its own permitted values. The list was named for the check rather than for the thing, nothing else ever read it, and its Python repr went into the message an operator sees. The values now sit at the point of use and only `QUEUE_MODE` and `REVIEW_CACHE` have names.

A value is read however it was typed. `QUEUE_MODE=Database` used to fail while `REVIEW_CACHE=Database` did not.
