### PR TITLE
feat(jobs): Let a workspace read the work it asked for

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -68,6 +68,7 @@ app = FastAPI(
 )
 
 from src.api.routes import code as code_endpoints
+from src.api.routes import jobs as job_endpoints
 from src.api.routes import knowledge as knowledge_endpoints
 from src.api.routes import local_reviews as local_review_endpoints
 from src.api.routes import local_settings as local_settings_endpoints
@@ -94,6 +95,7 @@ app.include_router(
     local_settings_endpoints.router, prefix="/api/local/settings", tags=["settings"]
 )
 app.include_router(skill_endpoints.router, prefix="/api/skills", tags=["skills"])
+app.include_router(job_endpoints.router, prefix="/api/jobs", tags=["jobs"])
 app.include_router(
     local_review_endpoints.router, prefix="/api/local/reviews", tags=["reviews"]
 )

--- a/src/api/routes/jobs.py
+++ b/src/api/routes/jobs.py
@@ -1,0 +1,80 @@
+"""What background work has been asked for, and what became of it.
+
+A job is answered only to the workspace it belongs to. Jobs are numbered in one
+sequence across every customer on an instance, so an id alone must not be
+enough to read one.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from src.auth import get_current_user
+from src.core.jobs import LANES, Batch, Job, job_store
+from src.core.responses import success_response
+from src.core.workspace import workspace_of
+
+router = APIRouter()
+
+
+def _as_dict(job: Job) -> dict:
+    return {
+        "id": job.id,
+        "lane": job.lane,
+        "kind": job.kind,
+        "state": job.state,
+        "tenant": job.tenant,
+        "attempt": job.attempt,
+        "max_attempts": job.max_attempts,
+        "batch_id": job.batch_id,
+        "error": job.error,
+    }
+
+
+def _theirs(owner: str, tenant: str) -> bool:
+    """Whether work attributed to `tenant` belongs to whoever is asking.
+
+    Work nobody could attribute belongs to nobody, rather than to everybody.
+    """
+    return tenant == owner
+
+
+@router.get("")
+async def list_jobs(
+    lane: Optional[str] = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    user: dict = Depends(get_current_user),
+):
+    if lane and lane not in LANES:
+        raise HTTPException(status_code=400, detail=f"No lane called {lane!r}")
+    owner = workspace_of(user)
+    waiting = job_store().pending(lane=lane or "", limit=limit)
+    return success_response(
+        [_as_dict(job) for job in waiting if _theirs(owner, job.tenant)]
+    )
+
+
+@router.get("/{job_id}")
+async def read_job(job_id: int, user: dict = Depends(get_current_user)):
+    job = job_store().read(job_id)
+    if job is None or not _theirs(workspace_of(user), job.tenant):
+        raise HTTPException(status_code=404, detail="No such job")
+    return success_response(_as_dict(job))
+
+
+@router.get("/batches/{batch_id}")
+async def read_batch(batch_id: int, user: dict = Depends(get_current_user)):
+    batch: Optional[Batch] = job_store().read_batch(batch_id)
+    if batch is None or not _theirs(workspace_of(user), batch.tenant):
+        raise HTTPException(status_code=404, detail="No such batch")
+    return success_response(
+        {
+            "id": batch.id,
+            "name": batch.name,
+            "total": batch.total,
+            "done": batch.done,
+            "pending": batch.pending,
+            "failed": batch.failed,
+            "finished": batch.finished,
+        }
+    )

--- a/src/tests/test_jobs_api.py
+++ b/src/tests/test_jobs_api.py
@@ -1,0 +1,119 @@
+"""Reading background work, and only your own."""
+
+import os
+import time
+
+import jwt
+
+from src.core.jobs import BATCH, INTERACTIVE, JobOutcome, JobRequest, job_store
+from src.tests.base_test import BaseTestCase
+
+OURS = "workspace-ours"
+THEIRS = "workspace-theirs"
+# Its own, so that a cap on how much one workspace runs at once cannot have
+# this batch waiting behind work another test left queued.
+COUNTING = "workspace-counting"
+
+
+def _as(workspace: str) -> dict:
+    token = jwt.encode(
+        {
+            "sub": "1",
+            "username": "octocat",
+            "scope": {"workspace_id": workspace},
+            "exp": int(time.time()) + 300,
+        },
+        os.environ["JWT_SECRET"],
+        algorithm="HS256",
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestReadingWork(BaseTestCase):
+
+    def test_a_job_says_what_became_of_it(self, monkeypatch):
+        monkeypatch.setenv("JWT_SECRET", "jobs-api-secret")
+        job_id = job_store().enqueue(
+            JobRequest(lane=INTERACTIVE, kind="test.work").for_(OURS)
+        )
+
+        read = self.client.get(f"/api/jobs/{job_id}", headers=_as(OURS))
+
+        assert read.status_code == 200
+        assert read.json()["data"]["kind"] == "test.work"
+        assert read.json()["data"]["state"] == "queued"
+
+    def test_work_belonging_to_somebody_else_is_not_there(self, monkeypatch):
+        monkeypatch.setenv("JWT_SECRET", "jobs-api-secret")
+        job_id = job_store().enqueue(
+            JobRequest(lane=INTERACTIVE, kind="test.private").for_(THEIRS)
+        )
+
+        read = self.client.get(f"/api/jobs/{job_id}", headers=_as(OURS))
+
+        assert read.status_code == 404
+
+    def test_the_listing_holds_only_your_own(self, monkeypatch):
+        monkeypatch.setenv("JWT_SECRET", "jobs-api-secret")
+        job_store().enqueue(JobRequest(lane=BATCH, kind="test.mine").for_(OURS))
+        job_store().enqueue(JobRequest(lane=BATCH, kind="test.not-mine").for_(THEIRS))
+
+        listed = self.client.get("/api/jobs?lane=batch", headers=_as(OURS))
+
+        kinds = {job["kind"] for job in listed.json()["data"]}
+        assert "test.mine" in kinds
+        assert "test.not-mine" not in kinds
+
+    def test_a_lane_nobody_has_is_refused(self, monkeypatch):
+        monkeypatch.setenv("JWT_SECRET", "jobs-api-secret")
+
+        listed = self.client.get("/api/jobs?lane=whenever", headers=_as(OURS))
+
+        assert listed.status_code == 400
+
+
+class TestReadingABatch(BaseTestCase):
+
+    def test_a_batch_counts_down_as_its_work_finishes(self, monkeypatch):
+        monkeypatch.setenv("JWT_SECRET", "jobs-api-secret")
+        store = job_store()
+        batch = store.open("reading three repositories", 3, tenant=COUNTING)
+        for _ in range(3):
+            store.enqueue(
+                JobRequest(lane=INTERACTIVE, kind="test.part", batch_id=batch.id).for_(
+                    COUNTING
+                )
+            )
+
+        read = self.client.get(f"/api/jobs/batches/{batch.id}", headers=_as(COUNTING))
+        assert read.json()["data"]["total"] == 3
+        assert read.json()["data"]["done"] == 0
+        assert read.json()["data"]["finished"] is False
+
+        for _ in range(20):
+            leases = store.claim(INTERACTIVE, "worker", 3)
+            if not leases:
+                break
+            for lease in leases:
+                store.finish(lease, JobOutcome.ok())
+            if store.read_batch(batch.id).finished:
+                break
+
+        read = self.client.get(f"/api/jobs/batches/{batch.id}", headers=_as(COUNTING))
+        assert read.json()["data"]["done"] == 3
+        assert read.json()["data"]["finished"] is True
+
+    def test_somebody_elses_batch_is_not_there(self, monkeypatch):
+        monkeypatch.setenv("JWT_SECRET", "jobs-api-secret")
+        batch = job_store().open("theirs", 1, tenant=THEIRS)
+
+        read = self.client.get(f"/api/jobs/batches/{batch.id}", headers=_as(OURS))
+
+        assert read.status_code == 404
+
+    def test_a_batch_nobody_opened_is_not_there(self, monkeypatch):
+        monkeypatch.setenv("JWT_SECRET", "jobs-api-secret")
+
+        read = self.client.get("/api/jobs/batches/999999", headers=_as(OURS))
+
+        assert read.status_code == 404


### PR DESCRIPTION
Nothing could see what background work existed or what became of it. A workspace can now list its own queued work, read one piece of it, and read how far a batch of it has got.

Work is answered only to the workspace it belongs to. Jobs are numbered in one sequence across every customer on an instance, so an id alone is not enough to read one.
