### PR TITLE
feat(admission): Ask whether a delivery is acted on before acting on it

### DIFF
--- a/src/core/admission/__init__.py
+++ b/src/core/admission/__init__.py
@@ -1,0 +1,52 @@
+"""Whether this deployment acts on a delivery.
+
+Nothing here decides anything. A deployment that contributes no gate acts on
+everything, which is what an instance serving one team wants. A deployment
+serving many contributes a gate that knows whose repositories are whose.
+"""
+
+from __future__ import annotations
+
+from src.core.services import ServiceRegistry, service_registry
+from src.utils.logger import logger
+
+from .interfaces import DeliveryGate
+from .models import Admission, Delivery
+
+
+def gates(services: ServiceRegistry = service_registry) -> tuple[DeliveryGate, ...]:
+    """Everything contributed that has a say."""
+    return services.contributions(DeliveryGate)
+
+
+def admits(
+    delivery: Delivery, services: ServiceRegistry = service_registry
+) -> Admission:
+    """Whether to act on this delivery, and what to say when not.
+
+    The first refusal is the answer. A gate that raises is not a refusal: it
+    could not decide, and refusing on its behalf would stop work nobody meant
+    to stop.
+    """
+    for gate in gates(services):
+        try:
+            answered = gate.admits(delivery)
+        except Exception:
+            logger.warning(
+                f"{type(gate).__name__} could not say whether to act on "
+                f"{delivery.repository}",
+                exc_info=True,
+            )
+            continue
+        if not answered.accepted:
+            return answered
+    return Admission.accept()
+
+
+__all__ = [
+    "Admission",
+    "Delivery",
+    "DeliveryGate",
+    "admits",
+    "gates",
+]

--- a/src/core/admission/interfaces.py
+++ b/src/core/admission/interfaces.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from .models import Admission, Delivery
+
+
+@runtime_checkable
+class DeliveryGate(Protocol):
+    """Something that decides whether a delivery is acted on.
+
+    Asked before anything is fetched or generated, so a delivery nobody wants
+    costs a decision rather than a diff and a model call.
+    """
+
+    def admits(self, delivery: Delivery) -> Admission: ...

--- a/src/core/admission/models.py
+++ b/src/core/admission/models.py
@@ -1,0 +1,33 @@
+"""What a delivery is, and whether this deployment should act on it."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Delivery:
+    """The little of an event that deciding whether to act on it needs."""
+
+    repository: str
+    event: str
+
+
+@dataclass(frozen=True)
+class Admission:
+    """Whether to act, and what to say when not.
+
+    The reason is written by whoever refused and is repeated verbatim, so what
+    a deployment tells somebody is that deployment's to write.
+    """
+
+    accepted: bool
+    reason: str = ""
+
+    @staticmethod
+    def accept() -> "Admission":
+        return Admission(accepted=True)
+
+    @staticmethod
+    def reject(reason: str = "") -> "Admission":
+        return Admission(accepted=False, reason=reason)

--- a/src/events/delivery.py
+++ b/src/events/delivery.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from typing import Any, Mapping, Optional
 
 from src.config.settings import whole_number
+from src.core.admission import Delivery, admits
+from src.core.services import ServiceRegistry, service_registry
 from src.core.jobs.models import (
     BY_REPOSITORY,
     BY_WORKSPACE,
@@ -69,10 +71,23 @@ class Deliveries:
 
     kind = KIND
 
+    def __init__(self, services: ServiceRegistry = service_registry) -> None:
+        self._services = services
+
     def run(self, job: Job) -> JobOutcome:
         event = self._event(job)
         if event is None:
             return JobOutcome.failed("this job names no delivery that still exists")
+
+        # Asked before any subscriber is told, so a delivery this deployment
+        # does not act on costs a decision rather than a diff and a review.
+        verdict = admits(
+            Delivery(repository=event.repository_full_name, event=_named(event)),
+            self._services,
+        )
+        if not verdict.accepted:
+            _say(event, verdict.reason)
+            return JobOutcome.failed(verdict.reason or "not acted on here")
 
         from src.events.dispatcher import EventDispatcher
         from src.events.repository_event import RepositoryEvent
@@ -105,3 +120,23 @@ def _refusals(said: Mapping[str, Any]) -> list[str]:
         for who, answer in (said or {}).items()
         if isinstance(answer, Mapping) and answer.get("error")
     ]
+
+
+def _named(event: RepositoryEventModel) -> str:
+    """The event as subscribers know it, action included where there is one."""
+    return f"{event.type}.{event.action}" if event.action else event.type
+
+
+def _say(event: RepositoryEventModel, reason: str) -> None:
+    """Repeat a refusal where whoever sent the delivery will see it."""
+    if not reason or not event.number:
+        return
+    owner, _, repo = event.repository_full_name.partition("/")
+    if not repo:
+        return
+    try:
+        from src.integrations.github.github import GitHub
+
+        GitHub().post_notice(owner, repo, event.number, reason)
+    except Exception:
+        logger.warning(f"Could not say why {event.repository_full_name} was refused")

--- a/src/integrations/github/github.py
+++ b/src/integrations/github/github.py
@@ -18,6 +18,7 @@ from src.llms.llm_factory import llm
 
 COMMENT_MARKER = "<!-- SOURCEANT_REVIEW_SUMMARY -->"
 FALLBACK_COMMENT_MARKER = "<!-- SOURCEANT_FALLBACK_REVIEW -->"
+NOTICE_MARKER = "<!-- SOURCEANT_NOTICE -->"
 
 
 class GitHub(ProviderAdapter):
@@ -343,6 +344,68 @@ class GitHub(ProviderAdapter):
         from src.core.model import provider_for
 
         return provider_for(repository=repository) or llm()
+
+    def post_notice(self, owner: str, repo: str, pr_number: int, message: str) -> bool:
+        """Say something once on a pull request, whatever else happens on it.
+
+        Said again on every push, a notice about the pull request itself would
+        bury the conversation it is interrupting.
+        """
+        try:
+            headers = {
+                "Authorization": f"Bearer {self.get_installation_access_token(owner, repo)}",
+                "Accept": "application/vnd.github.v3+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            }
+        except Exception as e:
+            logger.error(f"Could not reach {owner}/{repo} to say anything: {e}")
+            return False
+        if self._find_marked_comment(owner, repo, pr_number, headers, NOTICE_MARKER):
+            logger.info(f"{owner}/{repo}#{pr_number} has already been told this")
+            return False
+        try:
+            response = requests.post(
+                f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/comments",
+                headers=headers,
+                json={"body": f"{message}\n\n{NOTICE_MARKER}"},
+                timeout=30,
+            )
+            response.raise_for_status()
+            return True
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Could not post a notice on {owner}/{repo}: {e}")
+            return False
+
+    def _find_marked_comment(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        headers: Dict[str, str],
+        marker: str,
+    ) -> Optional[Dict[str, Any]]:
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/comments"
+        try:
+            for page in range(1, 11):
+                response = requests.get(
+                    url,
+                    headers=headers,
+                    params={"per_page": 100, "page": page},
+                    timeout=30,
+                )
+                response.raise_for_status()
+                comments = response.json()
+                for comment in comments:
+                    if marker in comment.get("body", ""):
+                        return comment
+                # A marker on a page nobody read is a marker not found, and
+                # whatever it marks gets said again.
+                if len(comments) < 100:
+                    break
+            return None
+        except (requests.exceptions.RequestException, ValueError) as e:
+            logger.warning(f"Could not read the comments on {owner}/{repo}: {e}")
+            return None
 
     def _find_overview_comment(
         self, owner: str, repo: str, pr_number: int, headers: Dict[str, str]

--- a/src/tests/test_delivery_queue.py
+++ b/src/tests/test_delivery_queue.py
@@ -118,6 +118,39 @@ class TestDeliveriesOnTheJobsTable(BaseTestCase):
 
         assert _failed_with(job_store(), "the signing key is a directory")
 
+    def test_a_delivery_a_gate_refuses_reaches_no_subscriber(self):
+        from unittest.mock import patch
+
+        from src.core.admission import Admission, DeliveryGate
+        from src.core.plugins import event_hooks
+
+        seen = []
+        event_hooks.subscribe_to_events(
+            "test_subscriber",
+            lambda event_type, data: seen.append(event_type),
+            ["pull_request.opened"],
+        )
+
+        class Refuses:
+            def admits(self, delivery):
+                return Admission.reject("this repository is not onboarded")
+
+        services = ServiceRegistry()
+        services.contribute(DeliveryGate, Refuses(), "test")
+        services.contribute(JobHandler, Deliveries(services), "sourceant_core")
+
+        try:
+            self._deliver()
+            with patch("src.events.delivery._say") as said:
+                worker = Worker(job_store(), INTERACTIVE, services=services)
+                worker.work(max_jobs=len(job_store().pending(lane=INTERACTIVE)))
+        finally:
+            event_hooks._event_subscribers.pop("pull_request.opened", None)
+
+        assert seen == []
+        assert said.called
+        assert _failed_with(job_store(), "this repository is not onboarded")
+
     def test_a_worker_tells_the_subscribers_what_arrived(self):
         from src.core.plugins import event_hooks
 

--- a/src/tests/unit/test_core_admission.py
+++ b/src/tests/unit/test_core_admission.py
@@ -1,0 +1,58 @@
+"""Whether a deployment acts on a delivery at all."""
+
+from src.core.admission import Admission, Delivery, DeliveryGate, admits
+from src.core.services import ServiceRegistry
+
+A_DELIVERY = Delivery(repository="someone/somewhere", event="pull_request.opened")
+
+
+class Refuses:
+    def __init__(self, reason: str = "") -> None:
+        self._reason = reason
+
+    def admits(self, delivery: Delivery) -> Admission:
+        return Admission.reject(self._reason)
+
+
+class Accepts:
+    def admits(self, delivery: Delivery) -> Admission:
+        return Admission.accept()
+
+
+class Breaks:
+    def admits(self, delivery: Delivery) -> Admission:
+        raise RuntimeError("this gate cannot tell")
+
+
+def test_a_deployment_with_no_gate_acts_on_everything():
+    """Which is what an instance serving one team wants, and it is the only
+    thing the core ships."""
+    assert admits(A_DELIVERY, ServiceRegistry()).accepted
+
+
+def test_a_refusal_carries_what_to_say():
+    services = ServiceRegistry()
+    services.contribute(
+        DeliveryGate, Refuses("nothing here says whose this is"), "test"
+    )
+
+    answered = admits(A_DELIVERY, services)
+
+    assert not answered.accepted
+    assert answered.reason == "nothing here says whose this is"
+
+
+def test_one_refusal_is_enough():
+    services = ServiceRegistry()
+    services.contribute(DeliveryGate, Accepts(), "test")
+    services.contribute(DeliveryGate, Refuses("no"), "test")
+
+    assert not admits(A_DELIVERY, services).accepted
+
+
+def test_a_gate_that_cannot_tell_does_not_refuse():
+    """Refusing on its behalf would stop work nobody meant to stop."""
+    services = ServiceRegistry()
+    services.contribute(DeliveryGate, Breaks(), "test")
+
+    assert admits(A_DELIVERY, services).accepted


### PR DESCRIPTION
A deployment serving many customers has deliveries it should not act on, and nothing let it say so. It could only refuse after a diff had been fetched and a review generated and paid for, and the fallback model meant a repository nobody configured was reviewed on the operator's key.

A gate is asked before anything is fetched. What it says when it refuses is repeated verbatim on the pull request, once, so a deployment writes its own words and the core never carries them.

The core contributes no gate. An instance serving one team acts on everything and uses the model it was started with, exactly as before.

```python
@runtime_checkable
class DeliveryGate(Protocol):
    def admits(self, delivery: Delivery) -> Admission: ...
```

A gate that raises is not a refusal. It could not decide, and refusing on its behalf would stop work nobody meant to stop.
