### PR TITLE
fix(jobs): Bring the plugins up before a worker claims anything

### DIFF
--- a/src/cli/work_command.py
+++ b/src/cli/work_command.py
@@ -16,6 +16,28 @@ from src.events.delivery import Deliveries
 from src.utils.logger import logger
 
 
+def _plugins_are_up() -> None:
+    """Bring the plugins up before any work is claimed.
+
+    Left until the first job needed one, a plugin that decides whether work is
+    done at all is absent for that job and present for every one after it.
+    """
+    import asyncio
+    from pathlib import Path
+
+    from src.core.plugins import plugin_manager
+
+    import src as core
+
+    async def load() -> None:
+        plugin_manager.add_plugin_directory(Path(core.__file__).parent / "plugins")
+        await plugin_manager.load_all_plugins()
+        await plugin_manager.initialize_plugins()
+        await plugin_manager.start_plugins()
+
+    asyncio.run(load())
+
+
 @click.command(name="work")
 @click.option(
     "--lane",
@@ -45,6 +67,8 @@ def work_command(lane, name, poll, max_jobs, max_time):
             "There is no database here, so there is no queue to work. "
             "Background work runs in the request that asked for it instead."
         )
+
+    _plugins_are_up()
 
     store = job_store()
     sweeper = Sweeper(store)

--- a/src/plugins/builtin/code_reviewer/reviewing.py
+++ b/src/plugins/builtin/code_reviewer/reviewing.py
@@ -282,7 +282,9 @@ class CodeReviewer:
         if full_review:
             return CodeReview(
                 summary=(
-                    summary_from(suggestions) if rejections else full_review.summary
+                    summary_from(suggestions, full_review.summary)
+                    if rejections
+                    else full_review.summary
                 ),
                 verdict=verdict,
                 code_suggestions=suggestions,
@@ -355,12 +357,8 @@ class CodeReviewer:
                 )
 
         return CodeReview(
-            summary=(
-                summary_from(suggestions)
-                if rejections
-                else provider.generate_summary(
-                    suggestions, previous_summary=previous_summary
-                )
+            summary=provider.generate_summary(
+                suggestions, previous_summary=previous_summary
             ),
             verdict=verdict_from(suggestions),
             code_suggestions=suggestions,
@@ -418,7 +416,16 @@ class CodeReviewer:
         return result
 
 
-def summary_from(suggestions: List) -> CodeReviewSummary:
+def summary_from(
+    suggestions: List, written: CodeReviewSummary | None = None
+) -> CodeReviewSummary:
+    """The findings that survived, under whatever was written about the change.
+
+    What was written about the change is not a claim about a defect, so a
+    finding that failed its evidence check is no reason to lose it. Dropped
+    with the findings, a review of a change nobody could fault reads exactly
+    like a review that found nothing to say.
+    """
     critical_categories = {SuggestionCategory.BUG, SuggestionCategory.SECURITY}
     critical = [
         suggestion.comment
@@ -430,14 +437,14 @@ def summary_from(suggestions: List) -> CodeReviewSummary:
         for suggestion in suggestions
         if suggestion.category not in critical_categories
     ]
-    overview = (
+    counted = (
         f"Review found {len(suggestions)} actionable issue(s)."
         if suggestions
         else "No actionable issues were found."
     )
     return CodeReviewSummary(
-        overview=overview,
-        key_improvements=[],
+        overview=(written.overview if written and written.overview else counted),
+        key_improvements=list(written.key_improvements) if written else [],
         minor_suggestions=minor,
         critical_issues=critical,
     )

--- a/src/tests/unit/test_reviewing_summary.py
+++ b/src/tests/unit/test_reviewing_summary.py
@@ -1,0 +1,43 @@
+"""What a review says about a change, when its findings do not survive."""
+
+from src.models.code_review import CodeReviewSummary, SuggestionCategory
+from src.plugins.builtin.code_reviewer.reviewing import summary_from
+
+
+class Suggestion:
+    def __init__(self, comment: str, category: SuggestionCategory) -> None:
+        self.comment = comment
+        self.category = category
+
+
+WRITTEN = CodeReviewSummary(
+    overview="Moves the plugins up so a worker has them before it claims work.",
+    key_improvements=["The first job a worker takes is now gated like the rest"],
+    minor_suggestions=["a suggestion that did not survive"],
+    critical_issues=["a finding that did not survive"],
+)
+
+
+def test_what_was_written_about_the_change_survives_its_findings():
+    kept = summary_from([], WRITTEN)
+
+    assert kept.overview == WRITTEN.overview
+    assert kept.key_improvements == WRITTEN.key_improvements
+
+
+def test_only_the_findings_that_survived_are_carried():
+    surviving = [
+        Suggestion("a real bug", SuggestionCategory.BUG),
+        Suggestion("a nicety", SuggestionCategory.STYLE),
+    ]
+
+    kept = summary_from(surviving, WRITTEN)
+
+    assert kept.critical_issues == ["a real bug"]
+    assert kept.minor_suggestions == ["a nicety"]
+
+
+def test_with_nothing_written_it_still_says_what_it_found():
+    kept = summary_from([Suggestion("a real bug", SuggestionCategory.BUG)])
+
+    assert kept.overview == "Review found 1 actionable issue(s)."


### PR DESCRIPTION
A worker loaded its plugins the first time a job needed one. A plugin that decides whether work is done at all was therefore absent for that job and present for every one after it, so the first delivery a freshly started worker took was never refused.

A review also kept what it said about the change. A finding that failed its evidence check was taking the whole written summary with it, so a review of a change nobody could fault read exactly like a review that found nothing to say: three words and no description. Only the findings are replaced now, with the ones that survived.
