### PR TITLE
fix(review): Drop suggestions that quote the diff back

### DIFF
--- a/src/tests/unit/test_line_mapper.py
+++ b/src/tests/unit/test_line_mapper.py
@@ -361,3 +361,29 @@ class TestLineMapper:
         )
 
         assert not mapper.suggestion_replays_diff(suggestion)
+
+    def test_keeps_a_suggestion_spanning_a_gap_between_two_additions(self):
+        """Separate additions are separate: a span across them is not applied."""
+        diff = """\
+--- a/app.py
++++ b/app.py
+@@ -1,3 +1,5 @@
+ first
++alpha = 1
+ middle
++beta = 2
+ last
+"""
+        mapper = LineMapper(parse_diff(diff))
+        suggestion = CodeSuggestion(
+            file_name="app.py",
+            start_line=2,
+            end_line=4,
+            side=Side.RIGHT,
+            comment="Declare these together.",
+            category=SuggestionCategory.REFACTOR,
+            existing_code="alpha = 1",
+            suggested_code="alpha = 1\nbeta = 2",
+        )
+
+        assert not mapper.suggestion_replays_diff(suggestion)

--- a/src/tests/unit/test_line_mapper.py
+++ b/src/tests/unit/test_line_mapper.py
@@ -288,3 +288,76 @@ class TestLineMapper:
         assert mapping["line"] == expected_line
         assert mapping["side"] == "RIGHT"
         assert "position" in mapping
+
+    def test_rejects_a_comment_that_quotes_the_added_lines_back(self):
+        """A pure addition has nothing removed, so a replacement never matches."""
+        diff = """\
+--- a/src/memory/initializer.py
++++ b/src/memory/initializer.py
+@@ -138,2 +138,3 @@
+                 repository,
+             )
++        self._indexed()
+"""
+        mapper = LineMapper(parse_diff(diff))
+        suggestion = CodeSuggestion(
+            file_name="src/memory/initializer.py",
+            start_line=141,
+            end_line=141,
+            side=Side.RIGHT,
+            comment=(
+                "The initializer now calls self._indexed() to trigger the "
+                "on_indexed callback, drafting the system after indexing."
+            ),
+            category=SuggestionCategory.REFACTOR,
+            existing_code="            )",
+            suggested_code="        self._indexed()",
+        )
+
+        assert mapper.suggestion_replays_diff(suggestion)
+
+    def test_rejects_a_restatement_even_with_no_existing_code(self):
+        diff = """\
+--- a/src/memory/initializer.py
++++ b/src/memory/initializer.py
+@@ -138,2 +138,3 @@
+                 repository,
+             )
++        self._indexed()
+"""
+        mapper = LineMapper(parse_diff(diff))
+        suggestion = CodeSuggestion(
+            file_name="src/memory/initializer.py",
+            start_line=141,
+            end_line=141,
+            side=Side.RIGHT,
+            comment="Calls the indexed hook.",
+            category=SuggestionCategory.REFACTOR,
+            existing_code="",
+            suggested_code="        self._indexed()",
+        )
+
+        assert mapper.suggestion_replays_diff(suggestion)
+
+    def test_keeps_a_suggestion_the_diff_does_not_already_add(self):
+        diff = """\
+--- a/src/memory/initializer.py
++++ b/src/memory/initializer.py
+@@ -138,2 +138,3 @@
+                 repository,
+             )
++        self._indexed()
+"""
+        mapper = LineMapper(parse_diff(diff))
+        suggestion = CodeSuggestion(
+            file_name="src/memory/initializer.py",
+            start_line=141,
+            end_line=141,
+            side=Side.RIGHT,
+            comment="Draw the system before the knowledge pass can fail.",
+            category=SuggestionCategory.BUG,
+            existing_code="        self._indexed()",
+            suggested_code="        self._indexed(force=True)",
+        )
+
+        assert not mapper.suggestion_replays_diff(suggestion)

--- a/src/utils/diff_parser.py
+++ b/src/utils/diff_parser.py
@@ -144,6 +144,26 @@ class ParsedDiff:
 
         return False
 
+    def contains_suggested_lines(self, suggested_code: str) -> bool:
+        """Whether this diff already adds exactly what is being suggested.
+
+        A suggestion is a replacement, so one whose every line is already among
+        the lines the diff adds proposes the code that is there. That holds
+        whatever it claims the existing code is, which is why this asks the
+        diff rather than comparing the two halves of the suggestion against
+        each other.
+        """
+        suggested_lines = self._normalize_snippet(suggested_code)
+        if not suggested_lines:
+            return False
+        return any(
+            self._contains_lines(
+                [line.value.strip() for line in hunk if line.is_added],
+                suggested_lines,
+            )
+            for hunk in self._patched_file
+        )
+
     @staticmethod
     def _normalize_snippet(code: str) -> List[str]:
         lines = []

--- a/src/utils/diff_parser.py
+++ b/src/utils/diff_parser.py
@@ -135,11 +135,13 @@ class ParsedDiff:
             return False
 
         for hunk in self._patched_file:
-            removed_lines = [line.value.strip() for line in hunk if line.is_removed]
-            added_lines = [line.value.strip() for line in hunk if line.is_added]
-            if self._contains_lines(
-                removed_lines, existing_lines
-            ) and self._contains_lines(added_lines, suggested_lines):
+            if any(
+                self._contains_lines(run, existing_lines)
+                for run in self._changed_runs(hunk, added=False)
+            ) and any(
+                self._contains_lines(run, suggested_lines)
+                for run in self._changed_runs(hunk, added=True)
+            ):
                 return True
 
         return False
@@ -157,12 +159,31 @@ class ParsedDiff:
         if not suggested_lines:
             return False
         return any(
-            self._contains_lines(
-                [line.value.strip() for line in hunk if line.is_added],
-                suggested_lines,
-            )
+            self._contains_lines(run, suggested_lines)
             for hunk in self._patched_file
+            for run in self._changed_runs(hunk, added=True)
         )
+
+    @classmethod
+    def _changed_runs(cls, hunk, added: bool) -> List[List[str]]:
+        """Each block of changed lines the hunk holds, kept apart.
+
+        Read as one list, two additions with an unchanged line between them are
+        adjacent, and a suggestion spanning that gap looks like code the patch
+        already applied. Normalized the same way a suggestion is, so the two
+        sides can be compared line for line.
+        """
+        runs: List[List[str]] = []
+        current: List[str] = []
+        for line in hunk:
+            if line.is_added if added else line.is_removed:
+                current.append(line.value)
+            elif current:
+                runs.append(current)
+                current = []
+        if current:
+            runs.append(current)
+        return [cls._normalize_snippet("\n".join(run)) for run in runs]
 
     @staticmethod
     def _normalize_snippet(code: str) -> List[str]:

--- a/src/utils/line_mapper.py
+++ b/src/utils/line_mapper.py
@@ -41,11 +41,13 @@ class LineMapper:
             normalized_file_name = normalized_file_name[2:]
 
         parsed_file = self.file_map.get(normalized_file_name)
-        if (
-            not parsed_file
-            or not suggestion.existing_code
-            or not suggestion.suggested_code
-        ):
+        if not parsed_file or not suggestion.suggested_code:
+            return False
+
+        if parsed_file.contains_suggested_lines(suggestion.suggested_code):
+            return True
+
+        if not suggestion.existing_code:
             return False
 
         return parsed_file.contains_applied_replacement(


### PR DESCRIPTION
A suggestion whose lines the diff already adds is dropped, whatever it says the existing code is.

Restatement was only caught as a replacement: the diff had to remove the existing code and add the suggested code. A comment on a pure addition removes nothing, so it reached the pull request describing what the author had just written.