### PR TITLE
feat(review): Say what a change makes worse, and stop assuming improvement

### DIFF
--- a/src/integrations/github/github.py
+++ b/src/integrations/github/github.py
@@ -509,6 +509,12 @@ class GitHub(ProviderAdapter):
                 parts.append(f"- {item}\n")
             parts.append("\n")
 
+        if summary.regressions:
+            parts.append("### 📉 Regressions\n")
+            for item in summary.regressions:
+                parts.append(f"- {item}\n")
+            parts.append("\n")
+
         if summary.minor_suggestions:
             parts.append("### 💡 Minor Suggestions\n")
             for item in summary.minor_suggestions:

--- a/src/models/code_review.py
+++ b/src/models/code_review.py
@@ -130,8 +130,18 @@ class CodeReviewOverview(BaseModel):
         description="A high-level overview of the code changes and the review.",
     )
     key_improvements: List[str] = Field(
-        ...,
-        description="A list of key improvements, which may contain references to paths.",
+        default_factory=list,
+        description=(
+            "A list of key improvements, which may contain references to "
+            "paths. Leave empty if none."
+        ),
+    )
+    regressions: List[str] = Field(
+        default_factory=list,
+        description=(
+            "A list of regressions, which may contain references to paths. "
+            "Leave empty if none."
+        ),
     )
 
 
@@ -215,6 +225,7 @@ def summary_from(
     return CodeReviewSummary(
         overview=(written.overview if written and written.overview else counted),
         key_improvements=list(written.key_improvements) if written else [],
+        regressions=list(written.regressions) if written else [],
         minor_suggestions=minor,
         critical_issues=critical,
     )

--- a/src/prompts/prompts.py
+++ b/src/prompts/prompts.py
@@ -154,11 +154,20 @@ The diff below uses a decoupled format where removed and added code are shown in
         "overview": "✨ <A high-level overview of the code changes and the review.>",
         "key_improvements": [
             "<An improvement, can reference a file path.>"
+        ],
+        "regressions": [
+            "<A regression, can reference a file path.>"
         ]
     }}
     ```
 
-    The content within the `overview` and `key_improvements` fields should be formatted using **GitHub-flavored Markdown**.
+    Leave a list empty when you judge nothing belongs in it. Naming an
+    improvement to fill the list is worse than leaving it empty. Where the
+    change makes something worse, say so plainly in `regressions`: slower,
+    harder to change, weaker in a case that used to work, or a capability that
+    is gone.
+
+    The content within these fields should be formatted using **GitHub-flavored Markdown**.
 
     The current change context below is authoritative. It contains either the full
     diff, a part of that diff, or summaries of parts of the same pull request.


### PR DESCRIPTION
A summary had one list, it was called improvements, and it was required, so every review produced some. A change that makes nothing better now says nothing, and one that makes something worse says that instead: slower, harder to change, weaker in a case that used to work, or a capability that is gone.

Neither list has to be filled. Until now the only way a reader learned a change had cost them something was a finding anchored to a line, so harm with no single line to point at reached nobody.