### PR TITLE
fix(release): Build images for release tags

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   release:
-    types: [published]
+    types: [published, edited]
   workflow_dispatch:
 
 permissions:
@@ -28,6 +28,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Check GitHub's latest release
+        id: release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              const { data } = await github.rest.repos.getLatestRelease(context.repo);
+              core.setOutput('latest', context.ref === `refs/tags/${data.tag_name}`);
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              core.setOutput('latest', false);
+            }
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -38,7 +52,7 @@ jobs:
             type=sha
             type=ref,event=branch
             type=ref,event=tag
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ steps.release.outputs.latest == 'true' }}
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -33,6 +33,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/sourceant/sourceant
+          flavor: latest=false
           tags: |
             type=sha
             type=ref,event=branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   create-release:
@@ -43,3 +44,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: v${{ steps.version.outputs.version }}
           files: dist/*.whl
+
+      - name: Build the release image
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: v${{ steps.version.outputs.version }}
+        run: gh workflow run build-image.yml --ref "$RELEASE_TAG"


### PR DESCRIPTION
Build versioned images explicitly because releases created with the workflow token cannot trigger the image workflow. Set the container’s latest tag only for the release GitHub selects as latest.