### PR TITLE
fix(settings): Read a personal setting last, not first

### DIFF
--- a/src/core/settings/resolver.py
+++ b/src/core/settings/resolver.py
@@ -1,9 +1,13 @@
-"""Resolve a setting through user, repository, workspace, and organization scopes.
+"""Resolve a setting through repository, workspace, organization and user scopes.
 
-A user value wins when supplied. A repository otherwise inherits from the
-workspace holding it, a workspace from the organization, and an organization
-from the shipped default. The answer carries its source so a screen can show
-whether it is set here or inherited.
+A repository inherits from the workspace holding it, a workspace from the
+organization, and an organization from whatever the person set for themselves.
+A personal value is a fallback rather than an override: somebody joining a
+workspace gets what that workspace chose, and their own answer applies only
+where nothing else has one. The shipped default is below all of it.
+
+The answer carries its source so a screen can show whether it is set here or
+inherited.
 """
 
 from __future__ import annotations
@@ -69,13 +73,8 @@ def resolve(
     user: Optional[str] = None,
     workspace: Any = UNSTATED,
 ) -> Resolved:
-    """Resolve one setting, narrowest scope first."""
+    """Resolve one setting: the work's own scopes first, then the person's."""
     setting = get(key)
-
-    if user:
-        value = _stored(setting, USER, user)
-        if value is not None:
-            return Resolved(key, value, USER, user, setting)
 
     if repository:
         value = _stored(setting, REPOSITORY, repository)
@@ -97,6 +96,11 @@ def resolve(
         value = _stored(setting, ORGANIZATION, owner)
         if value is not None:
             return Resolved(key, value, ORGANIZATION, owner, setting)
+
+    if user:
+        value = _stored(setting, USER, user)
+        if value is not None:
+            return Resolved(key, value, USER, user, setting)
 
     return Resolved(key, setting.default, "default", None, setting)
 

--- a/src/tests/unit/test_core_settings.py
+++ b/src/tests/unit/test_core_settings.py
@@ -55,7 +55,10 @@ def reuse_days(monkeypatch):
 
 
 class TestResolution:
-    def test_a_user_value_wins_for_that_user(self, store, reuse_days):
+    def test_the_work_is_answered_for_before_the_person(self, store, reuse_days):
+        """A personal value follows a person between repositories and
+        organisations, so letting it win would mean somebody carrying their own
+        answer into work that had already chosen one."""
         from src.core.settings.resolver import resolve, set_value
 
         set_value(ORGANIZATION, "acme", "review.reuse_days", 14)
@@ -67,6 +70,27 @@ class TestResolution:
             user="42",
             repository="acme/web",
         )
+
+        assert answer.value == 2
+        assert answer.source == REPOSITORY
+
+    def test_an_organisation_is_answered_for_before_the_person(self, store, reuse_days):
+        from src.core.settings.resolver import resolve, set_value
+
+        set_value(ORGANIZATION, "acme", "review.reuse_days", 14)
+        set_value(USER, "42", "review.reuse_days", 1)
+
+        answer = resolve("review.reuse_days", user="42", repository="acme/web")
+
+        assert answer.value == 14
+        assert answer.source == ORGANIZATION
+
+    def test_the_person_answers_where_nothing_else_does(self, store, reuse_days):
+        from src.core.settings.resolver import resolve, set_value
+
+        set_value(USER, "42", "review.reuse_days", 1)
+
+        answer = resolve("review.reuse_days", user="42", repository="acme/web")
 
         assert answer.value == 1
         assert answer.source == USER


### PR DESCRIPTION
Read a personal setting last rather than first. What a repository, workspace or organisation chose now wins over it.
