### PR TITLE
feat(topology): Add system queries

### DIFF
--- a/src/api/routes/topology.py
+++ b/src/api/routes/topology.py
@@ -13,6 +13,7 @@ from src.core.topology.inference import infer_dependencies
 from src.core.topology.manifests import read_manifests
 from src.utils.logger import logger
 from src.core.topology import (
+    contents,
     InMemoryTopologyRepository,
     SQLTopologyRepository,
     TopologyEntity,
@@ -367,6 +368,28 @@ async def traverse(
         logger.exception("Topology store unreachable during traversal")
         raise HTTPException(status_code=503, detail=STORE_UNAVAILABLE)
     return success_response(asdict(result))
+
+
+@router.get("/systems/{system_id}/contents")
+async def system_contents(
+    system_id: str,
+    scope: Scope = Depends(get_scope),
+    repository: TopologyRepository = Depends(get_topology_repository),
+):
+    """Everything one system holds, however deep it is nested.
+
+    Asked here rather than worked out by the caller, which otherwise reads the
+    whole graph to answer a question about two identities and decides
+    membership from data instead of from the thing that owns it.
+    """
+    try:
+        held = contents(repository, scope, system_id)
+    except ValueError as error:
+        raise HTTPException(status_code=422, detail=str(error))
+    except Exception:
+        logger.exception("Topology store unreachable while reading a system")
+        raise HTTPException(status_code=503, detail=STORE_UNAVAILABLE)
+    return success_response(asdict(held))
 
 
 class BatchInput(BaseModel):

--- a/src/core/topology/__init__.py
+++ b/src/core/topology/__init__.py
@@ -1,3 +1,4 @@
+from .containment import CONTAINS, SYSTEM, SystemContents, contents
 from .interfaces import (
     TopologyReader,
     TopologyRepository,
@@ -18,6 +19,10 @@ from .snapshots import JSONTopologySnapshotCodec, TopologySnapshot
 from .sql import SQLTopologyRepository
 
 __all__ = [
+    "CONTAINS",
+    "SYSTEM",
+    "SystemContents",
+    "contents",
     "InMemoryTopologyRepository",
     "JSONTopologySnapshotCodec",
     "SQLTopologyRepository",

--- a/src/core/topology/containment.py
+++ b/src/core/topology/containment.py
@@ -1,0 +1,105 @@
+"""What a system holds, however deep it is nested.
+
+A system holds parts, and some of those parts are systems holding parts of
+their own. Answering "is this inside that" is a walk, and it was being done by
+whoever asked: read the whole graph, follow the containment edges, decide. A
+caller doing that has the whole graph in its hands to answer a question about
+two identities, and it decides membership from data rather than asking the
+thing that owns it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .interfaces import TopologyReader
+from .models import TopologyTraversal
+from ..scope import Scope
+
+#: What a system is, and how it holds anything.
+SYSTEM = "system"
+CONTAINS = "contains"
+
+#: How many seeds one walk of the graph accepts, and how much it answers with.
+STEP = 50
+
+#: How deep the nesting may go before this stops descending. A hierarchy has
+#: no cycles and one parent per entity, so this is depth and not a guard
+#: against looping.
+MAX_DEPTH = 20
+
+
+@dataclass(frozen=True)
+class SystemContents:
+    """Everything one system holds, transitively."""
+
+    #: Systems nested inside it, at any depth.
+    systems: tuple[str, ...] = ()
+    #: Everything held that is not itself a system, by it or by those.
+    assets: tuple[str, ...] = ()
+    #: Whether the walk stopped before it ran out of graph. A caller deciding
+    #: membership from a truncated answer would refuse things that are in
+    #: fact inside, so it has to know.
+    truncated: bool = False
+
+
+def contents(
+    reader: TopologyReader,
+    scope: Scope,
+    system_id: str,
+    *,
+    depth: int = MAX_DEPTH,
+) -> SystemContents:
+    """Walk the containment edges down from one system.
+
+    One step at a time rather than in one traversal, because a traversal is
+    bounded to three hops and a hierarchy is not.
+    """
+    systems: list[str] = []
+    assets: list[str] = []
+    seen = {system_id}
+    frontier = [system_id]
+    truncated = False
+
+    for _ in range(max(1, depth)):
+        if not frontier:
+            break
+        next_frontier: list[str] = []
+        for start in range(0, len(frontier), STEP):
+            batch = tuple(frontier[start : start + STEP])
+            walked = reader.traverse(
+                TopologyTraversal(
+                    scope,
+                    batch,
+                    depth=1,
+                    relationship_types=frozenset({CONTAINS}),
+                    direction="outbound",
+                    entity_limit=STEP,
+                    relationship_limit=STEP * 10,
+                )
+            )
+            truncated = truncated or walked.truncated
+            kinds = {entity.id: entity.kind for entity in walked.entities}
+            held = tuple(
+                edge.target_id
+                for edge in walked.relationships
+                if edge.type == CONTAINS and edge.source_id in batch
+            )
+            for child in held:
+                if child in seen:
+                    continue
+                seen.add(child)
+                if kinds.get(child) == SYSTEM:
+                    systems.append(child)
+                    next_frontier.append(child)
+                else:
+                    assets.append(child)
+        frontier = next_frontier
+    else:
+        truncated = truncated or bool(frontier)
+
+    return SystemContents(
+        systems=tuple(sorted(systems)),
+        assets=tuple(sorted(assets)),
+        truncated=truncated,
+    )

--- a/src/tests/test_topology_api.py
+++ b/src/tests/test_topology_api.py
@@ -299,6 +299,63 @@ class TestTopologyApi(BaseTestCase):
 
         assert response.status_code in (401, 422)
 
+    def hold(self, parent, child):
+        return self.client.put(
+            "/api/topology/relationships",
+            json={
+                "id": f"{parent}->{child}",
+                "source_id": parent,
+                "target_id": child,
+                "type": "contains",
+                "status": "approved",
+            },
+            headers=self.headers,
+        )
+
+    def test_a_system_says_what_it_holds_so_the_caller_need_not_walk_it(self):
+        for identifier in ("stack", "billing"):
+            self.put_entity(identifier, kind="system")
+        for identifier in ("api", "ledger"):
+            self.put_entity(identifier)
+        self.hold("stack", "api")
+        self.hold("stack", "billing")
+        self.hold("billing", "ledger")
+
+        answer = self.client.get(
+            "/api/topology/systems/stack/contents", headers=self.headers
+        )
+
+        assert answer.status_code == 200
+        held = answer.json()["data"]
+        assert held["systems"] == ["billing"]
+        assert held["assets"] == ["api", "ledger"]
+        assert held["truncated"] is False
+
+    def test_what_another_workspace_holds_is_not_answered(self):
+        self.put_entity("stack", kind="system")
+        self.put_entity("api")
+        self.hold("stack", "api")
+
+        answer = self.client.get(
+            "/api/topology/systems/stack/contents",
+            headers={"Authorization": f"Bearer {_token(uuid.uuid4().hex)}"},
+        )
+
+        assert answer.status_code == 200
+        assert answer.json()["data"]["assets"] == []
+
+    def test_a_system_nobody_recorded_holds_nothing(self):
+        answer = self.client.get(
+            "/api/topology/systems/absent/contents", headers=self.headers
+        )
+
+        assert answer.status_code == 200
+        assert answer.json()["data"] == {
+            "systems": [],
+            "assets": [],
+            "truncated": False,
+        }
+
     def test_removing_an_entity_takes_its_relationships_with_it(self):
         for identifier in ("checkout", "ledger", "search"):
             self.put_entity(identifier)

--- a/src/tests/unit/test_system_containment.py
+++ b/src/tests/unit/test_system_containment.py
@@ -1,0 +1,115 @@
+"""What a system holds, asked of the thing that owns the answer.
+
+Deciding whether an asset is inside a system meant reading the whole graph and
+following the containment edges by hand. A caller doing that holds the whole
+graph to answer a question about two identities.
+"""
+
+from src.core.scope import Scope
+from src.core.topology import (
+    InMemoryTopologyRepository,
+    SystemContents,
+    TopologyEntity,
+    TopologyRelationship,
+    contents,
+)
+
+WHERE = Scope.from_mapping({"workspace": "1"})
+
+
+def graph(*edges, systems=(), assets=()):
+    repository = InMemoryTopologyRepository()
+    for name in systems:
+        repository.put_entity(WHERE, TopologyEntity(name, "system", "approved"))
+    for name in assets:
+        repository.put_entity(WHERE, TopologyEntity(name, "service", "approved"))
+    for parent, child in edges:
+        repository.put_relationship(
+            WHERE,
+            TopologyRelationship(
+                f"{parent}->{child}", parent, child, "contains", "approved"
+            ),
+        )
+    return repository
+
+
+class TestWhatASystemHolds:
+    def test_its_own_parts(self):
+        held = contents(
+            graph(
+                ("stack", "api"),
+                ("stack", "web"),
+                systems=("stack",),
+                assets=("api", "web"),
+            ),
+            WHERE,
+            "stack",
+        )
+
+        assert held.assets == ("api", "web")
+        assert held.systems == ()
+
+    def test_the_parts_of_the_systems_it_holds(self):
+        repository = graph(
+            ("stack", "billing"),
+            ("billing", "ledger"),
+            systems=("stack", "billing"),
+            assets=("ledger",),
+        )
+
+        held = contents(repository, WHERE, "stack")
+
+        assert held.systems == ("billing",)
+        assert held.assets == ("ledger",)
+
+    def test_deeper_than_a_traversal_reaches(self):
+        """A traversal stops at three hops and a hierarchy does not."""
+        edges = [(f"s{n}", f"s{n + 1}") for n in range(6)]
+        repository = graph(
+            *edges,
+            ("s6", "leaf"),
+            systems=tuple(f"s{n}" for n in range(7)),
+            assets=("leaf",),
+        )
+
+        held = contents(repository, WHERE, "s0")
+
+        assert "s6" in held.systems
+        assert held.assets == ("leaf",)
+        assert not held.truncated
+
+    def test_a_system_holding_nothing(self):
+        assert contents(graph(systems=("stack",)), WHERE, "stack") == SystemContents()
+
+    def test_nothing_above_it_is_counted(self):
+        """Containment runs one way. A parent is not inside its child."""
+        repository = graph(("stack", "billing"), systems=("stack", "billing"))
+
+        assert contents(repository, WHERE, "billing").systems == ()
+
+    def test_a_sibling_is_not_inside(self):
+        repository = graph(
+            ("stack", "billing"),
+            ("stack", "web"),
+            systems=("stack", "billing", "web"),
+        )
+
+        assert contents(repository, WHERE, "billing").systems == ()
+
+
+class TestSayingWhenItStoppedEarly:
+    def test_a_hierarchy_deeper_than_it_will_walk(self):
+        """Deciding membership from a truncated answer refuses things that
+        are in fact inside, so the caller is told."""
+        edges = [(f"s{n}", f"s{n + 1}") for n in range(5)]
+        repository = graph(*edges, systems=tuple(f"s{n}" for n in range(6)))
+
+        held = contents(repository, WHERE, "s0", depth=2)
+
+        assert held.truncated
+        assert "s5" not in held.systems
+
+    def test_a_walk_that_finished_says_so(self):
+        repository = graph(("stack", "api"), systems=("stack",), assets=("api",))
+
+        assert not contents(repository, WHERE, "stack").truncated


### PR DESCRIPTION
Add a containment query, so a caller does not read the whole graph to find what a system holds.

A traversal stops at three hops and a hierarchy does not, so this walks one step at a time.
