### PR TITLE
feat(reviews): Resolve a review's model as the workspace owner

### DIFF
--- a/src/api/routes/pr.py
+++ b/src/api/routes/pr.py
@@ -99,6 +99,7 @@ def process_github_webhook(
     enhanced_payload = payload.model_dump()
     enhanced_payload["sourceant_auth_type"] = auth_type
     enhanced_payload["sourceant_workspace_id"] = (scope or {}).get("workspace_id")
+    enhanced_payload["sourceant_owner_id"] = (scope or {}).get("owner_id")
 
     return RepositoryEventController.create(
         action=payload.action,

--- a/src/plugins/builtin/code_reviewer/plugin.py
+++ b/src/plugins/builtin/code_reviewer/plugin.py
@@ -247,6 +247,9 @@ class CodeReviewerPlugin(BasePlugin):
                 pr_metadata=pr_metadata,
                 event_type=event_type,
                 repository_full_name=repository_context.get("full_name"),
+                # A delivery has no acting user, so the owner is the user its
+                # settings resolve from.
+                user=payload.get("sourceant_owner_id"),
             )
 
             # Broadcast review completion event
@@ -324,6 +327,7 @@ class CodeReviewerPlugin(BasePlugin):
         repository_full_name: Optional[str] = None,
         post: bool = True,
         workspace: str | None = None,
+        user: str | None = None,
     ) -> Dict[str, Any]:
         """
         Generate code review and post it to GitHub.
@@ -390,7 +394,9 @@ class CodeReviewerPlugin(BasePlugin):
             from src.core.workspace import workspace_holding
 
             workspace = workspace or workspace_holding(repo_full_name)
-            llm_instance = provider_for(repository=repo_full_name, workspace=workspace)
+            llm_instance = provider_for(
+                repository=repo_full_name, workspace=workspace, user=user
+            )
             if llm_instance is None:
                 return {
                     "status": "error",

--- a/src/tests/unit/test_code_reviewer_plugin.py
+++ b/src/tests/unit/test_code_reviewer_plugin.py
@@ -1254,3 +1254,71 @@ class TestWhetherASkillWasHonoured:
 
         assert result["status"] == "success"
         assert "did not finish" in self.honoured(result)[0]["reason"]
+
+
+class TestWhoseModelReviews:
+    """A delivery has no acting user, so the user its settings resolve from has
+    to be carried from the gateway or the user scope is skipped."""
+
+    @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
+    @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
+    @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
+    @patch("src.plugins.builtin.code_reviewer.plugin.provider_for")
+    def test_a_model_is_asked_for_on_behalf_of_the_owner(
+        self,
+        mock_llm,
+        mock_github_cls,
+        mock_get_sha,
+        mock_save_record,
+        plugin,
+        repository,
+        pull_request,
+    ):
+        import asyncio
+
+        mock_get_sha.return_value = None
+        mock_llm.return_value = None
+
+        asyncio.run(
+            plugin.generate_review(
+                repository,
+                pull_request,
+                repository_full_name="acme/web",
+                post=False,
+                workspace="2",
+                user="42",
+            )
+        )
+
+        assert mock_llm.call_args.kwargs["user"] == "42"
+
+    @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
+    @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
+    @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
+    @patch("src.plugins.builtin.code_reviewer.plugin.provider_for")
+    def test_no_owner_asks_for_no_one(
+        self,
+        mock_llm,
+        mock_github_cls,
+        mock_get_sha,
+        mock_save_record,
+        plugin,
+        repository,
+        pull_request,
+    ):
+        import asyncio
+
+        mock_get_sha.return_value = None
+        mock_llm.return_value = None
+
+        asyncio.run(
+            plugin.generate_review(
+                repository,
+                pull_request,
+                repository_full_name="acme/web",
+                post=False,
+                workspace="2",
+            )
+        )
+
+        assert mock_llm.call_args.kwargs["user"] is None


### PR DESCRIPTION
Pass the workspace owner as the user when resolving a model for a review. A delivery has no acting user, so resolution skipped the user scope and a model set there was never used.

The owner arrives on the token the gateway calls with.
