### PR TITLE
refactor(model): Centralize configuration source

### DIFF
--- a/src/api/routes/local_settings.py
+++ b/src/api/routes/local_settings.py
@@ -20,6 +20,7 @@ from src.api.routes.code import require_local
 from src.api.routes.settings import _described
 from src.core.environment import LOCAL, environment
 from src.core.model import SettingsLLMSource
+from src.core.settings.configuration import Configuration
 from src.core.responses import success_response
 from src.core.settings.definitions import USER
 from src.core.settings.resolver import clear_value, resolve_all, set_value
@@ -36,7 +37,7 @@ def local_provider():
     deployment = environment()
     if deployment is not None:
         return deployment.provider_for(deployment.workspace_for())
-    return SettingsLLMSource(fallback_model="").provider_for(user=LOCAL)
+    return SettingsLLMSource(fallback_model="").provider_for(Configuration(user=LOCAL))
 
 
 @router.get("", dependencies=[Depends(require_local)])

--- a/src/core/change_context/models.py
+++ b/src/core/change_context/models.py
@@ -8,6 +8,7 @@ from src.core.knowledge import KnowledgeObject
 from src.core.requirements import Requirement
 from src.core.impact import ChangedCodeReference, ChangeImpact
 from src.core.scope import Scope
+from src.core.settings.configuration import Configuration
 
 
 @dataclass(frozen=True)
@@ -37,6 +38,10 @@ class ChangeSet:
     #: repository, because asked of the repository alone the walk cannot leave
     #: it.
     impact_scope: Scope | None = None
+    #: Where every setting this review reads is resolved from. Separate from
+    #: `scope`, which also files code in the index and so carries nothing
+    #: wider than the repository.
+    configuration: Configuration = field(default_factory=Configuration)
 
     def __post_init__(self) -> None:
         if not self.files:
@@ -48,6 +53,10 @@ class ChangeSet:
             raise ValueError("depth must be between 1 and 3")
         if not 1 <= self.limit <= 100:
             raise ValueError("limit must be between 1 and 100")
+        if self.configuration == Configuration():
+            object.__setattr__(
+                self, "configuration", Configuration.from_scope(self.scope)
+            )
 
     @property
     def paths(self) -> tuple[str, ...]:

--- a/src/core/model/__init__.py
+++ b/src/core/model/__init__.py
@@ -1,9 +1,7 @@
-"""Which model gets asked. Answered from settings unless a plugin registers its own."""
-
-from typing import Optional
+"""Which model is used. Answered from settings unless a plugin registers its own."""
 
 from src.core.services import ServiceRegistry, service_registry
-from src.core.workspace import workspace_holding
+from src.core.settings.configuration import Configuration
 from src.llms.llm_interface import LLMInterface
 
 from .interfaces import LLMSource
@@ -21,39 +19,20 @@ def llm_source(services: ServiceRegistry = service_registry) -> LLMSource:
 
 
 def config_for(
-    *,
-    repository: Optional[str] = None,
-    organization: Optional[str] = None,
-    user: Optional[str] = None,
-    workspace: Optional[str] = None,
+    configuration: Configuration,
     services: ServiceRegistry = service_registry,
 ) -> LLMConfig | None:
     """What to call and on whose account, for callers that do the call
     themselves. The provider is synchronous; an async caller needs the parts."""
-    holder = workspace or (workspace_holding(repository) if repository else None)
-    return llm_source(services).config_for(
-        repository=repository,
-        organization=organization,
-        user=user,
-        workspace=holder,
-    )
+    return llm_source(services).config_for(configuration)
 
 
 def provider_for(
-    *,
-    repository: Optional[str] = None,
-    organization: Optional[str] = None,
-    user: Optional[str] = None,
-    workspace: Optional[str] = None,
+    configuration: Configuration,
     services: ServiceRegistry = service_registry,
 ) -> LLMInterface | None:
-    """The model to ask for this repository, workspace, organisation or user."""
-    return llm_source(services).provider_for(
-        repository=repository,
-        organization=organization,
-        user=user,
-        workspace=workspace,
-    )
+    """The model for this configuration, or None where no scope in it names one."""
+    return llm_source(services).provider_for(configuration)
 
 
 __all__ = [

--- a/src/core/model/interfaces.py
+++ b/src/core/model/interfaces.py
@@ -1,33 +1,19 @@
 from __future__ import annotations
 
-from typing import Any, Optional, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
-from src.core.settings.resolver import UNSTATED
+from src.core.settings.configuration import Configuration
 from src.llms.llm_interface import LLMInterface
 
 
 @runtime_checkable
 class LLMSource(Protocol):
-    """Which model to ask, at the scope asking.
+    """Which model to use, for the configuration being done.
 
     None means no model is named at any scope reaching this caller. Nothing
     that proposes or judges runs until one is.
     """
 
-    def provider_for(
-        self,
-        *,
-        repository: Optional[str] = None,
-        organization: Optional[str] = None,
-        user: Optional[str] = None,
-        workspace: Optional[str] = None,
-    ) -> LLMInterface | None: ...
+    def provider_for(self, configuration: Configuration) -> LLMInterface | None: ...
 
-    def config_for(
-        self,
-        *,
-        repository: Optional[str] = None,
-        organization: Optional[str] = None,
-        user: Optional[str] = None,
-        workspace: Any = UNSTATED,
-    ) -> Any: ...
+    def config_for(self, configuration: Configuration) -> Any: ...

--- a/src/core/model/settings.py
+++ b/src/core/model/settings.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional
 
 from src.config.settings import DEFAULT_TOKEN_LIMIT, LLM_MODEL, LLM_TOKEN_LIMIT
-from src.core.settings.resolver import UNSTATED, value_of
+from src.core.settings.configuration import Configuration
 from src.core.workspace import workspace_holding
 from src.llms.litellm_provider import LiteLLMProvider
 from src.llms.llm_interface import LLMInterface
@@ -46,60 +45,31 @@ class SettingsLLMSource:
     fallback_model: str = LLM_MODEL
     fallback_token_limit: int = LLM_TOKEN_LIMIT
 
-    def provider_for(
-        self,
-        *,
-        repository: Optional[str] = None,
-        organization: Optional[str] = None,
-        user: Optional[str] = None,
-        workspace: Optional[str] = None,
-    ) -> LLMInterface | None:
+    def provider_for(self, configuration: Configuration) -> LLMInterface | None:
         # Worked out once here rather than left to each setting: the lookup goes
         # to the database, and a config is four settings deep.
-        holder = workspace or (workspace_holding(repository) if repository else None)
-        config = self.config_for(
-            repository=repository,
-            organization=organization,
-            user=user,
-            workspace=holder,
+        configuration = configuration.with_workspace_holding(
+            workspace_holding(configuration.repository)
+            if configuration.repository
+            else None
         )
+        config = self.config_for(configuration)
         if config is None:
             return None
-        logger.info(f"Asking {config.name}")
+        logger.info(f"Reading with {config.name}")
         return LiteLLMProvider(
             model=config.name,
             token_limit=config.token_limit,
             api_key=config.api_key,
             api_base=config.base_url,
-            attribution={
-                "repository": repository,
-                "organization": organization,
-                "user": user,
-                "workspace": holder,
-            },
+            attribution=configuration.attribution(),
         )
 
-    def config_for(
-        self,
-        *,
-        repository: Optional[str] = None,
-        organization: Optional[str] = None,
-        user: Optional[str] = None,
-        workspace: Any = UNSTATED,
-    ) -> LLMConfig | None:
+    def config_for(self, configuration: Configuration) -> LLMConfig | None:
         """What was chosen, before a provider is built from it."""
 
         def named(key: str) -> str:
-            return str(
-                value_of(
-                    key,
-                    repository=repository,
-                    organization=organization,
-                    user=user,
-                    workspace=workspace,
-                )
-                or ""
-            )
+            return str(configuration.value(key) or "")
 
         name = named("model.name")
         if name:
@@ -107,7 +77,7 @@ class SettingsLLMSource:
                 name=name,
                 api_key=named("model.api_key"),
                 base_url=named("model.base_url"),
-                token_limit=self._limit(repository, organization, user, workspace),
+                token_limit=self._limit(configuration),
             )
         if self.fallback_model:
             return LLMConfig(
@@ -115,14 +85,8 @@ class SettingsLLMSource:
             )
         return None
 
-    def _limit(self, repository, organization, user, workspace) -> int:
-        stated = value_of(
-            "model.token_limit",
-            repository=repository,
-            organization=organization,
-            user=user,
-            workspace=workspace,
-        )
+    def _limit(self, configuration: Configuration) -> int:
+        stated = configuration.value("model.token_limit")
         try:
             return int(stated) if stated else DEFAULT_TOKEN_LIMIT
         except (TypeError, ValueError):

--- a/src/core/model/settings.py
+++ b/src/core/model/settings.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 
 from src.config.settings import DEFAULT_TOKEN_LIMIT, LLM_MODEL, LLM_TOKEN_LIMIT
 from src.core.settings.configuration import Configuration
-from src.core.workspace import workspace_holding
 from src.llms.litellm_provider import LiteLLMProvider
 from src.llms.llm_interface import LLMInterface
 from src.utils.logger import logger
@@ -46,13 +45,7 @@ class SettingsLLMSource:
     fallback_token_limit: int = LLM_TOKEN_LIMIT
 
     def provider_for(self, configuration: Configuration) -> LLMInterface | None:
-        # Worked out once here rather than left to each setting: the lookup goes
-        # to the database, and a config is four settings deep.
-        configuration = configuration.with_workspace_holding(
-            workspace_holding(configuration.repository)
-            if configuration.repository
-            else None
-        )
+        configuration = configuration.with_workspace()
         config = self.config_for(configuration)
         if config is None:
             return None

--- a/src/core/settings/configuration.py
+++ b/src/core/settings/configuration.py
@@ -1,0 +1,67 @@
+"""Reading settings for one piece of work, from one place."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, Optional
+
+from src.core.scope import Scope
+from src.core.settings.definitions import Resolved
+from src.core.settings.resolver import UNSTATED, resolve
+
+
+@dataclass(frozen=True)
+class Configuration:
+    """Every setting, read at the scopes one piece of work belongs to.
+
+    Named once here rather than at each read: a read that leaves a scope out
+    resolves as though that scope named nothing.
+    """
+
+    repository: Optional[str] = None
+    organization: Optional[str] = None
+    user: Optional[str] = None
+    workspace: Optional[str] = None
+
+    @classmethod
+    def from_scope(cls, scope: Optional[Scope]) -> "Configuration":
+        """The scopes a change carries."""
+        if scope is None:
+            return cls()
+        return cls(
+            repository=scope.get("repository"),
+            organization=scope.get("organization"),
+            user=scope.get("user"),
+            workspace=scope.get("workspace"),
+        )
+
+    def with_workspace_holding(self, holder: Optional[str]) -> "Configuration":
+        """The workspace a repository belongs to, worked out once by the caller
+        rather than per setting, because that lookup goes to the database."""
+        if self.workspace:
+            return self
+        return replace(self, workspace=holder)
+
+    def with_user(self, user: str) -> "Configuration":
+        return self if self.user else replace(self, user=user)
+
+    def resolved(self, key: str) -> Resolved:
+        return resolve(
+            key,
+            repository=self.repository,
+            organization=self.organization,
+            user=self.user,
+            workspace=UNSTATED if self.workspace is None else self.workspace,
+        )
+
+    def value(self, key: str) -> Any:
+        return self.resolved(key).value
+
+    def attribution(self) -> dict[str, Optional[str]]:
+        """What a call made under this is recorded against."""
+        return {
+            "repository": self.repository,
+            "organization": self.organization,
+            "user": self.user,
+            "workspace": self.workspace,
+        }

--- a/src/core/settings/configuration.py
+++ b/src/core/settings/configuration.py
@@ -21,6 +21,8 @@ class Configuration:
     repository: Optional[str] = None
     organization: Optional[str] = None
     user: Optional[str] = None
+    #: Left unnamed, the workspace holding the repository is looked up on every
+    #: read. `with_workspace` settles it once for a caller doing several.
     workspace: Optional[str] = None
 
     @classmethod
@@ -35,12 +37,14 @@ class Configuration:
             workspace=scope.get("workspace"),
         )
 
-    def with_workspace_holding(self, holder: Optional[str]) -> "Configuration":
-        """The workspace a repository belongs to, worked out once by the caller
-        rather than per setting, because that lookup goes to the database."""
-        if self.workspace:
+    def with_workspace(self) -> "Configuration":
+        """The workspace holding the repository, settled here rather than on
+        every read, because that lookup goes to the database."""
+        if self.workspace or not self.repository:
             return self
-        return replace(self, workspace=holder)
+        from src.core.workspace import workspace_holding
+
+        return replace(self, workspace=workspace_holding(self.repository))
 
     def with_user(self, user: str) -> "Configuration":
         return self if self.user else replace(self, user=user)
@@ -51,7 +55,7 @@ class Configuration:
             repository=self.repository,
             organization=self.organization,
             user=self.user,
-            workspace=UNSTATED if self.workspace is None else self.workspace,
+            workspace=self.workspace if self.workspace else UNSTATED,
         )
 
     def value(self, key: str) -> Any:

--- a/src/integrations/github/github.py
+++ b/src/integrations/github/github.py
@@ -342,8 +342,9 @@ class GitHub(ProviderAdapter):
         review, or an instance answers to two providers at once.
         """
         from src.core.model import provider_for
+        from src.core.settings.configuration import Configuration
 
-        return provider_for(repository=repository) or llm()
+        return provider_for(Configuration(repository=repository)) or llm()
 
     def post_notice(self, owner: str, repo: str, pr_number: int, message: str) -> bool:
         """Say something once on a pull request, whatever else happens on it.

--- a/src/plugins/builtin/code_reviewer/overview.py
+++ b/src/plugins/builtin/code_reviewer/overview.py
@@ -1,6 +1,7 @@
 import json
 from concurrent.futures import ThreadPoolExecutor
 
+from src.core.settings.configuration import Configuration
 from src.plugins.builtin.code_reviewer.reviewing import (
     CodeReviewer,
     MAX_AT_ONCE,
@@ -10,9 +11,11 @@ from src.utils.diff_parser import parse_diff
 from src.models.code_review import CodeReviewSummary, summary_from
 
 
-def summarize_changes(diff, provider, repository, metadata=None, suggestions=()):
+def summarize_changes(
+    diff, provider, configuration: Configuration, metadata=None, suggestions=()
+):
     batches = _batched(
-        parse_diff(diff), CodeReviewer._budget(repository), provider.count_tokens
+        parse_diff(diff), CodeReviewer._budget(configuration), provider.count_tokens
     )
     if not batches:
         raise ValueError("The full pull request diff is unavailable")

--- a/src/plugins/builtin/code_reviewer/plugin.py
+++ b/src/plugins/builtin/code_reviewer/plugin.py
@@ -15,6 +15,7 @@ from src.core.plugins import event_hooks
 
 from src.core.change_context import ChangeSet
 from src.core.model import provider_for
+from src.core.settings.configuration import Configuration
 from src.core.mcp import contribute_tools
 from src.core.review import Reviewer, WorkingTreeReviewer
 from src.core.review_coverage import (
@@ -394,9 +395,10 @@ class CodeReviewerPlugin(BasePlugin):
             from src.core.workspace import workspace_holding
 
             workspace = workspace or workspace_holding(repo_full_name)
-            llm_instance = provider_for(
+            configuration = Configuration(
                 repository=repo_full_name, workspace=workspace, user=user
             )
+            llm_instance = provider_for(configuration)
             if llm_instance is None:
                 return {
                     "status": "error",
@@ -468,6 +470,7 @@ class CodeReviewerPlugin(BasePlugin):
             final_review = CodeReviewer(services=self.services).review(
                 ChangeSet(
                     scope=Scope.from_mapping({"repository": repo_full_name}),
+                    configuration=configuration,
                     requirement_scopes=(
                         (
                             Scope.from_mapping(
@@ -521,7 +524,7 @@ class CodeReviewerPlugin(BasePlugin):
             final_review.summary = summarize_changes(
                 full_diff,
                 llm_instance,
-                repo_full_name,
+                configuration,
                 pr_metadata,
                 final_review.code_suggestions or (),
             )

--- a/src/plugins/builtin/code_reviewer/reviewing.py
+++ b/src/plugins/builtin/code_reviewer/reviewing.py
@@ -46,7 +46,7 @@ from src.core.skills import (
 from src.core.review.fingerprint import of_code, of_words
 from src.core.review.models import Sections, Told
 from src.core.services import ServiceRegistry, service_registry
-from src.core.settings.resolver import value_of
+from src.core.settings.configuration import Configuration
 from src.models.code_review import (
     CodeReview,
     summary_from,
@@ -131,9 +131,9 @@ class CodeReviewer:
             if not parsed_file.is_binary_file and parsed_file.file_path
         ]
 
-        repository = str(changes.scope.get("repository") or "")
+        configuration = changes.configuration
         file_limit = (
-            value_of("review.structural_context_file_limit", repository=repository)
+            configuration.value("review.structural_context_file_limit")
             or DEFAULT_FILE_LIMIT
         )
 
@@ -164,7 +164,7 @@ class CodeReviewer:
         metadata = metadata or self._metadata(changes)
 
         readers = (durable_code, local_code)
-        budget = self._budget(repository)
+        budget = self._budget(configuration)
         total = sum(provider.count_tokens(one.diff_text) for one in parsed_files)
 
         available = {skill.id: skill for skill in skills}
@@ -281,7 +281,9 @@ class CodeReviewer:
                 )
                 continue
             combined.extend(checked.code_suggestions or ())
-        self._check_they_were_applied(provider, changes, repository, guidance, coverage)
+        self._check_they_were_applied(
+            provider, changes, configuration, guidance, coverage
+        )
 
         unique, seen = [], set()
         for suggestion in combined:
@@ -302,7 +304,7 @@ class CodeReviewer:
         )
 
     @staticmethod
-    def _check_they_were_applied(provider, changes, repository, guidance, coverage):
+    def _check_they_were_applied(provider, changes, configuration, guidance, coverage):
         """Ask whether the review actually judged the change against each skill.
 
         A skill attached to a prompt and a skill a review took notice of look
@@ -313,9 +315,7 @@ class CodeReviewer:
         A model call per skill on every pull request, so it waits to be asked
         for.
         """
-        if not guidance or not value_of(
-            "review.check_skills_were_applied", repository=repository
-        ):
+        if not guidance or not configuration.value("review.check_skills_were_applied"):
             for skill in guidance:
                 coverage.record(
                     SKILLS,
@@ -372,9 +372,9 @@ class CodeReviewer:
             )
 
     @staticmethod
-    def _budget(repository: str) -> int:
+    def _budget(configuration: Configuration) -> int:
         """Where a review stops finding things, which is far below the window."""
-        stated = value_of("review.reading_budget", repository=repository)
+        stated = configuration.value("review.reading_budget")
         try:
             return int(stated) if stated else DEFAULT_READING_BUDGET
         except (TypeError, ValueError):

--- a/src/plugins/builtin/code_reviewer/working_tree.py
+++ b/src/plugins/builtin/code_reviewer/working_tree.py
@@ -25,6 +25,7 @@ from src.core.change_context import (
 )
 from src.core.knowledge import KnowledgeQuery
 from src.core.model import provider_for
+from src.core.settings.configuration import Configuration
 from src.core.review import Told, reviewer
 from src.core.review_coverage import Coverage, read_and_unread
 from src.core.scope import Scope
@@ -115,16 +116,15 @@ def told(recorded, skills) -> tuple[Told, ...]:
     return tuple(sections)
 
 
-def remember(review, scope, services, repository: str = "") -> None:
+def remember(review, scope, services, configuration: Configuration) -> None:
     """Keep what a review said, so the next one knows it has said it before.
 
     Off unless asked for: a reviewer that rewords itself raises the odd
     duplicate under any fingerprint. Nothing here fails a review.
     """
     from src.core.review import OPEN, ReviewFinding, finding_store, prints_for
-    from src.core.settings.resolver import value_of
 
-    if not value_of("review.remember_findings", repository=repository):
+    if not configuration.value("review.remember_findings"):
         return
 
     kept = finding_store(services)
@@ -284,6 +284,7 @@ class WorkingTreeReviews:
         """What changed, what applies to it, and what the reviewer made of it."""
         entry = self._folders().named(LOCAL, repository)
         root = Path(entry.path)
+        configuration = Configuration(repository=repository, user=LOCAL)
 
         try:
             changes = read_change(
@@ -372,7 +373,7 @@ class WorkingTreeReviews:
             )
             return answer
 
-        provider = provider_for(user=LOCAL)
+        provider = provider_for(configuration)
         if provider is None:
             raise ReviewRefused(
                 400,
@@ -393,7 +394,11 @@ class WorkingTreeReviews:
         coverage = Coverage()
         try:
             review = judge.review(
-                replace(changes, title=changes.title or f"Work on {where['branch']}"),
+                replace(
+                    changes,
+                    title=changes.title or f"Work on {where['branch']}",
+                    configuration=configuration,
+                ),
                 provider=provider,
                 read_content=on_disk(root),
                 coverage=coverage,
@@ -412,7 +417,7 @@ class WorkingTreeReviews:
                 review.summary = summarize_changes(
                     changes.diff,
                     provider,
-                    repository,
+                    configuration,
                     {"title": changes.title, "description": changes.description},
                     review.code_suggestions or (),
                 )
@@ -429,7 +434,7 @@ class WorkingTreeReviews:
         if review.summary is not None:
             review.summary.coverage = read_and_unread(coverage)
         answer["review"] = reviewed(review)
-        remember(review, entry.scope, self.services, repository)
+        remember(review, entry.scope, self.services, configuration)
 
         subject = Change(
             title=changes.title,

--- a/src/plugins/builtin/local/environment.py
+++ b/src/plugins/builtin/local/environment.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Optional
 
 from src.core.environment import LOCAL
+from src.core.settings.configuration import Configuration
 from src.llms.llm_interface import LLMInterface
 
 from .llm import ChosenLLM
@@ -29,4 +30,4 @@ class LocalEnvironment:
         return LOCAL
 
     def provider_for(self, workspace: str) -> Optional[LLMInterface]:
-        return self._model.provider_for(user=workspace or LOCAL)
+        return self._model.provider_for(Configuration(user=workspace or LOCAL))

--- a/src/plugins/builtin/local/llm.py
+++ b/src/plugins/builtin/local/llm.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
-
 from src.core.model import SettingsLLMSource
-from src.core.settings.resolver import UNSTATED
+from src.core.settings.configuration import Configuration
 from src.llms.llm_interface import LLMInterface
 
 from src.core.environment import LOCAL
@@ -21,32 +19,13 @@ class ChosenLLM(SettingsLLMSource):
     def __init__(self) -> None:
         super().__init__(fallback_model="")
 
-    def provider_for(
-        self,
-        *,
-        repository: Optional[str] = None,
-        organization: Optional[str] = None,
-        user: Optional[str] = None,
-        workspace: Optional[str] = None,
-    ) -> LLMInterface | None:
-        return super().provider_for(
-            repository=repository,
-            organization=organization,
-            user=user or LOCAL,
-            workspace=workspace,
-        )
+    def provider_for(self, configuration: Configuration) -> LLMInterface | None:
+        return super().provider_for(self._local(configuration))
 
-    def config_for(
-        self,
-        *,
-        repository: Optional[str] = None,
-        organization: Optional[str] = None,
-        user: Optional[str] = None,
-        workspace: Any = UNSTATED,
-    ):
-        return super().config_for(
-            repository=repository,
-            organization=organization,
-            user=user or LOCAL,
-            workspace=workspace,
-        )
+    def config_for(self, configuration: Configuration):
+        return super().config_for(self._local(configuration))
+
+    @staticmethod
+    def _local(configuration: Configuration) -> Configuration:
+        """One machine, one person, so an unnamed user is this one."""
+        return configuration.with_user(LOCAL)

--- a/src/tests/test_local_review_api.py
+++ b/src/tests/test_local_review_api.py
@@ -264,7 +264,7 @@ class TestLocalReview(BaseTestCase):
         )
         monkeypatch.setattr(
             "src.plugins.builtin.code_reviewer.working_tree.provider_for",
-            lambda **_: model,
+            lambda *_, **__: model,
         )
         self.register()
         self.edit_the_migration()
@@ -287,7 +287,7 @@ class TestLocalReview(BaseTestCase):
         )
         monkeypatch.setattr(
             "src.plugins.builtin.code_reviewer.working_tree.provider_for",
-            lambda **_: model,
+            lambda *_, **__: model,
         )
         self.register()
         self.edit_the_migration()
@@ -302,7 +302,7 @@ class TestLocalReview(BaseTestCase):
     def test_judging_without_a_model_is_refused_rather_than_guessed(self, monkeypatch):
         monkeypatch.setattr(
             "src.plugins.builtin.code_reviewer.working_tree.provider_for",
-            lambda **_: None,
+            lambda *_, **__: None,
         )
         self.register()
         self.edit_the_migration()
@@ -335,7 +335,7 @@ class TestLocalReview(BaseTestCase):
         )
         monkeypatch.setattr(
             "src.plugins.builtin.code_reviewer.working_tree.provider_for",
-            lambda **_: model,
+            lambda *_, **__: model,
         )
         self.register()
         self.edit_the_migration()
@@ -354,7 +354,7 @@ class TestLocalReview(BaseTestCase):
         model = FakeModel({"passed": True})
         monkeypatch.setattr(
             "src.plugins.builtin.code_reviewer.working_tree.provider_for",
-            lambda **_: model,
+            lambda *_, **__: model,
         )
         self.register()
         self.edit_the_migration()

--- a/src/tests/test_pull_request_overview.py
+++ b/src/tests/test_pull_request_overview.py
@@ -8,6 +8,7 @@ import pytest
 
 from src.api.routes import reviews
 from src.core.plugins.plugin_registry import plugin_registry
+from src.core.settings.configuration import Configuration
 from src.models.code_review import (
     CodeReview,
     CodeReviewSummary,
@@ -100,10 +101,12 @@ def test_http_preview_overview_reads_all_pr_changes(
         minor_suggestions=[],
         critical_issues=[],
     )
-    monkeypatch.setattr(reviewer_plugin, "provider_for", lambda **kwargs: provider)
+    monkeypatch.setattr(
+        reviewer_plugin, "provider_for", lambda *args, **kwargs: provider
+    )
     monkeypatch.setattr(
         "src.plugins.builtin.code_reviewer.reviewing.CodeReviewer._budget",
-        staticmethod(lambda repository: budget),
+        staticmethod(lambda configuration: budget),
     )
     credentials = headers()
     claims = jwt.decode(
@@ -170,5 +173,7 @@ def test_empty_overview_cannot_replace_the_standing_overview():
     )
     with pytest.raises(ValueError, match="did not produce"):
         summarize_changes(
-            (FIXTURES / "full.diff").read_text(), provider, "sourceant/sourceant"
+            (FIXTURES / "full.diff").read_text(),
+            provider,
+            Configuration(repository="sourceant/sourceant"),
         )

--- a/src/tests/unit/test_code_reviewer_plugin.py
+++ b/src/tests/unit/test_code_reviewer_plugin.py
@@ -558,9 +558,7 @@ class TestPreviewResponseIsSerializable:
 
     @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
     @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
-    @patch(
-        "src.plugins.builtin.code_reviewer.reviewing.value_of", side_effect=_one_file
-    )
+    @patch("src.core.settings.configuration.Configuration.value", side_effect=_one_file)
     @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
     @patch("src.plugins.builtin.code_reviewer.plugin.provider_for")
     def test_preview_drops_a_missing_import_claim_disproved_by_post_change_file(
@@ -646,17 +644,14 @@ class TestPreviewResponseIsSerializable:
         assert '"name":"load"' in code_context
         # That this setting is read, not that it is the only one: a review also
         # asks how much it is worth reading at once.
-        mock_value_of.assert_any_call(
-            "review.structural_context_file_limit",
-            repository="test_owner/test_repo",
-        )
+        mock_value_of.assert_any_call("review.structural_context_file_limit")
         mock_github.get_file_content.assert_called_once_with(
             "test_owner", "test_repo", "test.py", "head_sha_def"
         )
 
     @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
     @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
-    @patch("src.plugins.builtin.code_reviewer.reviewing.value_of", side_effect=_setting)
+    @patch("src.core.settings.configuration.Configuration.value", side_effect=_setting)
     @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
     @patch("src.plugins.builtin.code_reviewer.plugin.provider_for")
     def test_review_receives_referenced_definition_source_from_durable_graph(
@@ -1096,7 +1091,7 @@ class TestWhetherASkillWasHonoured:
                 "src.plugins.builtin.code_reviewer.reviewing.LLMSkillChecker", _Checker
             ),
             patch(
-                "src.plugins.builtin.code_reviewer.reviewing.value_of",
+                "src.core.settings.configuration.Configuration.value",
                 side_effect=lambda key, **_: (
                     checking if key == "review.check_skills_were_applied" else None
                 ),
@@ -1214,7 +1209,7 @@ class TestWhetherASkillWasHonoured:
                 "src.plugins.builtin.code_reviewer.reviewing.LLMSkillChecker", _Raises
             ),
             patch(
-                "src.plugins.builtin.code_reviewer.reviewing.value_of",
+                "src.core.settings.configuration.Configuration.value",
                 side_effect=lambda key, **_: (
                     True if key == "review.check_skills_were_applied" else None
                 ),

--- a/src/tests/unit/test_code_reviewer_plugin.py
+++ b/src/tests/unit/test_code_reviewer_plugin.py
@@ -1290,7 +1290,7 @@ class TestWhoseModelReviews:
             )
         )
 
-        assert mock_llm.call_args.kwargs["user"] == "42"
+        assert mock_llm.call_args.args[0].user == "42"
 
     @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
     @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
@@ -1321,4 +1321,4 @@ class TestWhoseModelReviews:
             )
         )
 
-        assert mock_llm.call_args.kwargs["user"] is None
+        assert mock_llm.call_args.args[0].user is None

--- a/src/tests/unit/test_llm_source_registry.py
+++ b/src/tests/unit/test_llm_source_registry.py
@@ -2,6 +2,7 @@
 
 import src.core.settings.resolver as resolver
 from src.core.model import LLMSource, config_for, provider_for
+from src.core.settings.configuration import Configuration
 from src.core.services import ServiceRegistry
 from src.plugins.builtin.local.llm import ChosenLLM
 
@@ -11,8 +12,8 @@ def test_a_registered_source_decides_the_config_as_well_as_the_provider(monkeypa
     registry = ServiceRegistry()
     registry.register(LLMSource, ChosenLLM(), "local")
 
-    assert provider_for(user="local", services=registry) is None
-    assert config_for(user="local", services=registry) is None
+    assert provider_for(Configuration(user="local"), services=registry) is None
+    assert config_for(Configuration(user="local"), services=registry) is None
 
 
 def test_without_one_the_deployment_answers(monkeypatch):
@@ -20,7 +21,7 @@ def test_without_one_the_deployment_answers(monkeypatch):
     monkeypatch.setenv("LLM_MODEL", "gemini/gemini-2.5-flash")
     registry = ServiceRegistry()
 
-    named = config_for(user="local", services=registry)
+    named = config_for(Configuration(user="local"), services=registry)
 
     assert named is not None
     assert named.name

--- a/src/tests/unit/test_review_change_context.py
+++ b/src/tests/unit/test_review_change_context.py
@@ -138,7 +138,7 @@ def _run(plugin, repository, pull_request, mock_github_cls, mock_llm, mock_get_s
 
 @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
 @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
-@patch("src.plugins.builtin.code_reviewer.reviewing.value_of", side_effect=_setting)
+@patch("src.core.settings.configuration.Configuration.value", side_effect=_setting)
 @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
 @patch("src.plugins.builtin.code_reviewer.plugin.provider_for")
 def test_a_requirement_on_a_changed_file_reaches_the_review(
@@ -168,7 +168,7 @@ def test_a_requirement_on_a_changed_file_reaches_the_review(
 
 @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
 @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
-@patch("src.plugins.builtin.code_reviewer.reviewing.value_of", side_effect=_setting)
+@patch("src.core.settings.configuration.Configuration.value", side_effect=_setting)
 @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
 @patch("src.plugins.builtin.code_reviewer.plugin.provider_for")
 def test_a_requirement_on_an_untouched_file_stays_out_of_the_review(
@@ -198,7 +198,7 @@ def test_a_requirement_on_an_untouched_file_stays_out_of_the_review(
 
 @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
 @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
-@patch("src.plugins.builtin.code_reviewer.reviewing.value_of", side_effect=_setting)
+@patch("src.core.settings.configuration.Configuration.value", side_effect=_setting)
 @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
 @patch("src.plugins.builtin.code_reviewer.plugin.provider_for")
 def test_a_review_still_runs_when_the_requirement_tables_are_missing(
@@ -245,7 +245,7 @@ class _IntentSelector:
 
 @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
 @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
-@patch("src.plugins.builtin.code_reviewer.reviewing.value_of", side_effect=_setting)
+@patch("src.core.settings.configuration.Configuration.value", side_effect=_setting)
 @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
 @patch("src.plugins.builtin.code_reviewer.plugin.provider_for")
 def test_a_registered_selector_decides_instead_of_the_links(
@@ -277,7 +277,7 @@ def test_a_registered_selector_decides_instead_of_the_links(
 
 @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
 @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
-@patch("src.plugins.builtin.code_reviewer.reviewing.value_of", side_effect=_setting)
+@patch("src.core.settings.configuration.Configuration.value", side_effect=_setting)
 @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
 @patch("src.plugins.builtin.code_reviewer.plugin.provider_for")
 def test_a_selector_is_told_what_the_change_is(
@@ -326,7 +326,7 @@ def _knowledge(tmp_path, *, linked_path="test.py"):
 
 @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
 @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
-@patch("src.plugins.builtin.code_reviewer.reviewing.value_of", side_effect=_setting)
+@patch("src.core.settings.configuration.Configuration.value", side_effect=_setting)
 @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
 @patch("src.plugins.builtin.code_reviewer.plugin.provider_for")
 def test_a_decision_governing_a_changed_file_reaches_the_review(
@@ -356,7 +356,7 @@ def test_a_decision_governing_a_changed_file_reaches_the_review(
 
 @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
 @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
-@patch("src.plugins.builtin.code_reviewer.reviewing.value_of", side_effect=_setting)
+@patch("src.core.settings.configuration.Configuration.value", side_effect=_setting)
 @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
 @patch("src.plugins.builtin.code_reviewer.plugin.provider_for")
 def test_a_decision_on_an_untouched_file_stays_out_of_the_review(
@@ -386,7 +386,7 @@ def test_a_decision_on_an_untouched_file_stays_out_of_the_review(
 
 @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
 @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
-@patch("src.plugins.builtin.code_reviewer.reviewing.value_of", side_effect=_setting)
+@patch("src.core.settings.configuration.Configuration.value", side_effect=_setting)
 @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
 @patch("src.plugins.builtin.code_reviewer.plugin.provider_for")
 def test_a_store_that_holds_no_links_reviews_without_knowledge(
@@ -416,7 +416,7 @@ def test_a_store_that_holds_no_links_reviews_without_knowledge(
 
 @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
 @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
-@patch("src.plugins.builtin.code_reviewer.reviewing.value_of", side_effect=_setting)
+@patch("src.core.settings.configuration.Configuration.value", side_effect=_setting)
 @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
 @patch("src.plugins.builtin.code_reviewer.plugin.provider_for")
 def test_a_registered_knowledge_selector_decides_instead_of_the_links(
@@ -464,7 +464,7 @@ Binary files a/logo.png and b/logo.png differ
 
 @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
 @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
-@patch("src.plugins.builtin.code_reviewer.reviewing.value_of", side_effect=_setting)
+@patch("src.core.settings.configuration.Configuration.value", side_effect=_setting)
 @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
 @patch("src.plugins.builtin.code_reviewer.plugin.provider_for")
 def test_a_change_with_nothing_readable_still_reviews(
@@ -518,7 +518,7 @@ def test_a_change_with_nothing_readable_still_reviews(
 
 @patch("src.plugins.builtin.code_reviewer.plugin.save_review_record")
 @patch("src.plugins.builtin.code_reviewer.plugin.get_last_reviewed_sha")
-@patch("src.plugins.builtin.code_reviewer.reviewing.value_of", side_effect=_setting)
+@patch("src.core.settings.configuration.Configuration.value", side_effect=_setting)
 @patch("src.plugins.builtin.code_reviewer.plugin.GitHub")
 @patch("src.plugins.builtin.code_reviewer.plugin.provider_for")
 def test_what_a_change_reaches_is_carried_into_the_review(

--- a/src/tests/unit/test_token_usage.py
+++ b/src/tests/unit/test_token_usage.py
@@ -1,5 +1,7 @@
 """What a model call consumed is recorded against whoever it was made for."""
 
+from src.core.settings.configuration import Configuration
+
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -81,8 +83,12 @@ def test_two_repositories_are_not_billed_to_one(tmp_path):
     ):
         with patch("src.core.usage.sql.get_engine", return_value=engine):
             with patch("litellm.completion", return_value=answered):
-                source.provider_for(repository="one/a").generate_text("x")
-                source.provider_for(repository="two/b").generate_text("x")
+                source.provider_for(Configuration(repository="one/a")).generate_text(
+                    "x"
+                )
+                source.provider_for(Configuration(repository="two/b")).generate_text(
+                    "x"
+                )
 
     with Session(engine) as session:
         kept = session.exec(select(TokenUsageRecord)).all()

--- a/src/tests/unit/test_workspace_scoped_model.py
+++ b/src/tests/unit/test_workspace_scoped_model.py
@@ -16,6 +16,7 @@ import src.core.workspace as workspace_module
 from src.api.main import app
 from src.config.db import get_session
 from src.core.model import SettingsLLMSource
+from src.core.settings.configuration import Configuration
 
 TEST_JWT_SECRET = "workspace-scoped-model-secret"
 
@@ -99,7 +100,9 @@ def test_a_workspace_key_is_the_key_its_repository_is_reviewed_with(client):
     assert _choose(client, "ws-a", "model.name", "moonshot/kimi-k2").status_code == 200
     assert _choose(client, "ws-a", "model.api_key", "ws-a-key").status_code == 200
 
-    provider = SettingsLLMSource(fallback_model="").provider_for(repository="acme/web")
+    provider = SettingsLLMSource(fallback_model="").provider_for(
+        Configuration(repository="acme/web")
+    )
     asked = _asked(provider)
 
     assert asked["model"] == "moonshot/kimi-k2"
@@ -110,7 +113,9 @@ def test_usage_for_that_call_is_owed_by_the_workspace(client):
     _connect(client, "ws-a", "acme/web")
     _choose(client, "ws-a", "model.name", "moonshot/kimi-k2")
 
-    provider = SettingsLLMSource(fallback_model="").provider_for(repository="acme/web")
+    provider = SettingsLLMSource(fallback_model="").provider_for(
+        Configuration(repository="acme/web")
+    )
     with patch("src.core.usage.record_completion") as recorded:
         _asked(provider)
 
@@ -123,7 +128,9 @@ def test_a_repository_two_workspaces_hold_resolves_to_neither_of_their_keys(clie
     _choose(client, "ws-a", "model.name", "moonshot/kimi-k2")
     _choose(client, "ws-a", "model.api_key", "ws-a-key")
 
-    provider = SettingsLLMSource(fallback_model="").provider_for(repository="acme/web")
+    provider = SettingsLLMSource(fallback_model="").provider_for(
+        Configuration(repository="acme/web")
+    )
 
     assert provider is None
 


### PR DESCRIPTION
Every setting a review reads now resolves from one value carrying the repository, workspace, organisation and person. It is built once, where the review starts.

The reviewer's settings named only the repository, so a reading budget, a file limit or a skill check set on a workspace or a person never reached a review.

The settings ride beside the change rather than in the scope it already carries: that scope also files code in the index, and a workspace in it would move where code is stored.
